### PR TITLE
Customize function to re-run tau tagging in miniAOD production

### DIFF
--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -108,3 +108,8 @@ PFTau = cms.Sequence(
     recoTauClassicHPSSequence
 )
 
+
+def runPFTauFromAOD(process):
+    process.load('RecoTauTag.Configuration.RecoPFTauTag_cff')
+    return process
+


### PR DESCRIPTION
run cmsDriver with `--customise_unsch RecoTauTag/Configuration/RecoPFTauTag_cff.runPFTauFromAOD` to enable it.
Note that instead using just the plain `--customise` won't work, as the file has to be loaded after switching to unscheduled and cleaning up the process
@slava77 @veelken 
