### PR TITLE
requiring muon used in the discriminator to be in the boosted tau area

### DIFF
--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
@@ -19,6 +19,8 @@ def addBoostedTaus(process):
     process.combinatoricRecoTausBoosted.modifiers.remove(process.combinatoricRecoTausBoosted.modifiers[3])
     #process.combinatoricRecoTausBoosted.builders[0].pfCandSrc = cms.InputTag('pfNoPileUpForBoostedTaus')
     process.combinatoricRecoTausBoosted.builders[0].pfCandSrc = cms.InputTag('particleFlow')
+    process.hpsPFTauDiscriminationByLooseMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
+    process.hpsPFTauDiscriminationByTightMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
     massSearchReplaceAnyInputTag(process.PATTauSequenceBoosted,cms.InputTag("ak4PFJets"),cms.InputTag("boostedTauSeeds"))  
     process.slimmedTausBoosted = process.slimmedTaus.clone(src = cms.InputTag("selectedPatTausBoosted"))
     


### PR DESCRIPTION
Dear Roger, All,
I added this requirement to be sure that the muon considered by the against muon discriminator is reconstructed in the tau area and not in a cone of dR 0.3, since this requirement is to strict for boosted taus.  It would be nice to have this change also in the code used in the production of rereco MC and data. 
Is it possible to port it to 80X? What version of 80X could I use ?
