### PR TITLE
added dump boosted taus

### DIFF
--- a/RecoTauTag/Configuration/python/dumpBoostedTauVariables_cfi.py
+++ b/RecoTauTag/Configuration/python/dumpBoostedTauVariables_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+dumpBoostedTauVariables = cms.EDProducer(
+    "CandViewNtpProducer",
+    ## can be selectedTausCandidates or slimmedTaus from miniAOD
+    src = cms.InputTag("slimmedTausBoosted"),
+    ## prefix for variables for the dump
+    prefix     = cms.untracked.string(""),
+    ## allow access to function calls from derived classes
+    lazyParser = cms.untracked.bool(True),
+    ## add run, event number and lumi section
+    eventInfo  = cms.untracked.bool(True),
+    ## define variables to be dumped
+    variables  = cms.VPSet()
+    )

--- a/RecoTauTag/Configuration/test/dumpBoostedTauVariables_cfg.py
+++ b/RecoTauTag/Configuration/test/dumpBoostedTauVariables_cfg.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DUMP")
+
+## MessageLogger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+## Options and output report
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+## switch to uncheduled mode
+process.options.allowUnscheduled = cms.untracked.bool(True)
+
+
+## Source (expect a locally produced patTuple.root or miniAODTuple.root, produced via standard sequesnted in PatAlgos)
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:patMiniAOD_standard.root")
+)
+## Maximal number of events
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+## Load dump of tau variables
+process.load("RecoTauTag.Configuration.dumpBoostedTauVariables_cfi")
+## Define variables to be dumped to out
+from RecoTauTag.Configuration.tauVariables_cff import slimmedVariables
+process.dumpBoostedTauVariables.variables = slimmedVariables
+
+## OutputModule configuration (expects a path 'p')
+process.out = cms.OutputModule("PoolOutputModule",
+                               fileName = cms.untracked.string('dumpTauVariables_slimmed_v0.root'),
+                               outputCommands = cms.untracked.vstring('drop *', 'keep *_*_*_DUMP' )
+                               )
+process.outpath = cms.EndPath(process.out)


### PR DESCRIPTION
Hello,
I think that I tried something like that:
cmsRun RecoTauTag/Configuration/test/edmTauVariables_slimmed_cfg.py inputFiles_load=RecoTauTag/Configuration/test/ZTT-validation.txt maxEvents=100

<-----This reruns the boosted taus automatically 

mv patMiniAOD_standard_maxEvents100.root patMiniAOD_standard.root

cmsRun RecoTauTag/Configuration/test/dumpBoostedTauVariables_cfg.py

<--- it should just dumpe the variables for the input object   "slimmedTausBoosted" instead of  "slimmedTaus", but it doesn't seem to take it because the output then is empty.

mv dumpTauVariables_slimmed.root dumpTauVariables_test.root

Thanks,
Camilla
