### PR TITLE
Run mva isolation on mini aod 80 x

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -528,6 +528,7 @@
 
   <class name="std::pair<pat::TauRef, float>"/>
   <class name="std::vector<std::pair<pat::TauRef, float> >" />
+  <class name="edm::RefProd<std::vector<pat::Tau> >"/>
 
   </selection>
  <exclusion>

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -191,6 +191,7 @@ namespace DataFormats_PatCandidates {
    
   std::pair<pat::TauRef, float>                              pattdiscr_p;
   std::vector<std::pair<pat::TauRef, float> >                pattdiscr_v;    
+  edm::RefProd<std::vector<pat::Tau> >                       patt_rp;
   };
 
 }

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -15,7 +15,6 @@
 //           - TauPFEssential
 //           - PFRecoTauDiscriminationByMVAIsolationRun2
 //           - Training of BDT
-// todo 2: do we need/want to add PATTauIDEmbedder?
 
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 

--- a/RecoTauTag/RecoTau/plugins/PATTauIDEmbedder.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauIDEmbedder.cc
@@ -1,0 +1,97 @@
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/PatCandidates/interface/PATTauDiscriminator.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "FWCore/Utilities/interface/transform.h"
+
+class PATTauIDEmbedder : public edm::EDProducer
+{
+public:
+
+	explicit PATTauIDEmbedder(const edm::ParameterSet&);
+	~PATTauIDEmbedder(){};
+
+	void produce(edm::Event&, const edm::EventSetup&);
+
+private:
+
+//--- configuration parameters
+	edm::EDGetTokenT<pat::TauCollection> src_;
+	typedef std::pair<std::string, edm::InputTag> NameTag;
+	std::vector<NameTag> tauIDSrcs_;
+	std::vector<edm::EDGetTokenT<pat::PATTauDiscriminator> > patTauIDTokens_;
+};
+
+PATTauIDEmbedder::PATTauIDEmbedder(const edm::ParameterSet& cfg)
+{
+	src_ = consumes<pat::TauCollection>(cfg.getParameter<edm::InputTag>("src"));
+	// it might be a single tau ID
+	if (cfg.existsAs<edm::InputTag>("tauIDSource")) {
+		tauIDSrcs_.push_back(NameTag("", cfg.getParameter<edm::InputTag>("tauIDSource")));
+	}
+	// or there might be many of them
+	if (cfg.existsAs<edm::ParameterSet>("tauIDSources")) {
+		// please don't configure me twice
+		if (!tauIDSrcs_.empty()){
+			throw cms::Exception("Configuration") << "PATTauProducer: you can't specify both 'tauIDSource' and 'tauIDSources'\n";
+		}
+		// read the different tau ID names
+		edm::ParameterSet idps = cfg.getParameter<edm::ParameterSet>("tauIDSources");
+		std::vector<std::string> names = idps.getParameterNamesForType<edm::InputTag>();
+		for (std::vector<std::string>::const_iterator it = names.begin(), ed = names.end(); it != ed; ++it) {
+			tauIDSrcs_.push_back(NameTag(*it, idps.getParameter<edm::InputTag>(*it)));
+		}
+	}
+	// but in any case at least once
+	if (tauIDSrcs_.empty()) throw cms::Exception("Configuration") <<
+		"PATTauProducer: id addTauID is true, you must specify either:\n" <<
+		"\tInputTag tauIDSource = <someTag>\n" << "or\n" <<
+		"\tPSet tauIDSources = { \n" <<
+		"\t\tInputTag <someName> = <someTag>   // as many as you want \n " <<
+		"\t}\n";
+	patTauIDTokens_ = edm::vector_transform(tauIDSrcs_, [this](NameTag const & tag){return mayConsume<pat::PATTauDiscriminator>(tag.second);});
+
+	produces<pat::TauCollection>();
+}
+
+void PATTauIDEmbedder::produce(edm::Event& evt, const edm::EventSetup& es)
+{
+	edm::Handle<pat::TauCollection> inputTaus;
+	evt.getByToken(src_, inputTaus);
+
+	std::auto_ptr<pat::TauCollection> outputTaus(new pat::TauCollection());
+	outputTaus->reserve(inputTaus->size());
+
+	int tau_idx = 0;
+	for(pat::TauCollection::const_iterator inputTau = inputTaus->begin(); inputTau != inputTaus->end(); ++inputTau, tau_idx++){
+		pat::Tau outputTau(*inputTau);
+		pat::TauRef inputTauRef(inputTaus, tau_idx);
+		size_t nTauIds = inputTau->tauIDs().size();
+		std::vector<pat::Tau::IdPair> tauIds(nTauIds+tauIDSrcs_.size());
+
+		for(size_t i = 0; i < nTauIds; ++i){
+			tauIds[i] = inputTau->tauIDs().at(i);
+		}
+
+		for(size_t i = 0; i < tauIDSrcs_.size(); ++i){
+			edm::Handle<pat::PATTauDiscriminator> tauDiscr;
+			evt.getByToken(patTauIDTokens_[i], tauDiscr);
+
+			tauIds[nTauIds+i].first = tauIDSrcs_[i].first;
+			tauIds[nTauIds+i].second = (*tauDiscr)[inputTauRef];
+		}
+
+		outputTau.setTauIDs(tauIds);
+		outputTaus->push_back(outputTau);
+	}
+
+	evt.put(outputTaus);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(PATTauIDEmbedder);
+

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.cc
@@ -75,14 +75,6 @@ class rerunMVAIsolationOnMiniAOD : public edm::one::EDAnalyzer<edm::one::SharedR
       TauIdMVAAuxiliaries clusterVariables_;
 
       edm::EDGetTokenT<pat::TauCollection> tauToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationVLooseToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationLooseToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationMediumToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationTightToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationVTightToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaIsolationVVTightToken_;
-      edm::EDGetTokenT<pat::PATTauDiscriminator> mvaEleRawToken_;
       edm::EDGetTokenT<reco::PFTauCollection> pfTauToken_;
       edm::EDGetTokenT<reco::PFTauDiscriminator> dmfNewToken_;
       edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSumToken_;
@@ -161,15 +153,7 @@ rerunMVAIsolationOnMiniAOD::rerunMVAIsolationOnMiniAOD(const edm::ParameterSet& 
 
    outfile = new TFile("outfile_rerunMVAIsolationOnMiniAOD.root","RECREATE");
 
-   tauToken_ = consumes<pat::TauCollection>(edm::InputTag("slimmedTaus","","PAT"));
-   mvaIsolationToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1raw","","rerunMVAIsolationOnMiniAOD"));
-   mvaIsolationVLooseToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1VLoose","","rerunMVAIsolationOnMiniAOD"));
-   mvaIsolationLooseToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1Loose","","rerunMVAIsolationOnMiniAOD"));
-   mvaIsolationMediumToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1Medium","","rerunMVAIsolationOnMiniAOD"));
-   mvaIsolationTightToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1Tight","","rerunMVAIsolationOnMiniAOD"));
-   mvaIsolationVTightToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1VTight","","rerunMVAIsolationOnMiniAOD"));
-   mvaIsolationVVTightToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationByIsolationMVArun2v1VVTight","","rerunMVAIsolationOnMiniAOD"));
-   mvaEleRawToken_ = consumes<pat::PATTauDiscriminator>(edm::InputTag("rerunDiscriminationAgainstElectronMVA6","","rerunMVAIsolationOnMiniAOD"));
+   tauToken_ = consumes<pat::TauCollection>(edm::InputTag("NewTauIDsEmbedded"));
    pfTauToken_ = consumes<reco::PFTauCollection>(edm::InputTag("hpsPFTauProducer","","PAT"));
    dmfNewToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauDiscriminationByDecayModeFindingNewDMs","","PAT"));
    chargedIsoPtSumToken_ = consumes<reco::PFTauDiscriminator>(edm::InputTag("hpsPFTauChargedIsoPtSum","","PAT"));
@@ -254,53 +238,26 @@ rerunMVAIsolationOnMiniAOD::analyze(const edm::Event& iEvent, const edm::EventSe
 	edm::Handle<pat::TauCollection> taus;
 	iEvent.getByToken(tauToken_,taus);
 
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoRaw;
-	iEvent.getByToken(mvaIsolationToken_,mvaIsoRaw);
-
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoVLoose;
-	iEvent.getByToken(mvaIsolationVLooseToken_,mvaIsoVLoose);
-
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoLoose;
-	iEvent.getByToken(mvaIsolationLooseToken_,mvaIsoLoose);
-
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoMedium;
-	iEvent.getByToken(mvaIsolationMediumToken_,mvaIsoMedium);
-
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoTight;
-	iEvent.getByToken(mvaIsolationTightToken_,mvaIsoTight);
-
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoVTight;
-	iEvent.getByToken(mvaIsolationVTightToken_,mvaIsoVTight);
-
-	edm::Handle<pat::PATTauDiscriminator> mvaIsoVVTight;
-	iEvent.getByToken(mvaIsolationVVTightToken_,mvaIsoVVTight);
-
-        edm::Handle<reco::PFTauDiscriminator> rawElecMVA6;
-	iEvent.getByToken(rawElecMVA6Token_,rawElecMVA6);
-       
-        edm::Handle<pat::PATTauDiscriminator> mvaEleRaw;
-        iEvent.getByToken(mvaEleRawToken_,mvaEleRaw);
-
 	std::vector<pat::TauRef> unmatchedTaus;
 
 	for(unsigned iTau = 0; iTau < taus->size(); iTau++)
 	{
 		pat::TauRef tau(taus,iTau);
 		float valueAOD = tau->tauID("byIsolationMVArun2v1DBoldDMwLTraw");
-		float valueMiniAOD = (*mvaIsoRaw)[tau];
+		float valueMiniAOD = tau->tauID("byIsolationMVArun2v1DBoldDMwLTrawNew");
 
 		mvaValueAOD->Fill(valueAOD);
 		mvaValueMiniAOD->Fill(valueMiniAOD);
 
 		mvaValue->Fill(valueAOD,valueMiniAOD);
-		mvaValue_vLoose->Fill(tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoVLoose)[tau]);
-		mvaValue_Loose->Fill(tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoLoose)[tau]);
-		mvaValue_Medium->Fill(tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoMedium)[tau]);
-		mvaValue_Tight->Fill(tau->tauID("byTightIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoTight)[tau]);
-		mvaValue_vTight->Fill(tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoVTight)[tau]);
-		mvaValue_vvTight->Fill(tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLT"),(*mvaIsoVVTight)[tau]);
+		mvaValue_vLoose->Fill(tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byVLooseIsolationMVArun2v1DBoldDMwLTNew"));
+		mvaValue_Loose->Fill(tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byLooseIsolationMVArun2v1DBoldDMwLTNew"));
+		mvaValue_Medium->Fill(tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byMediumIsolationMVArun2v1DBoldDMwLTNew"));
+		mvaValue_Tight->Fill(tau->tauID("byTightIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byTightIsolationMVArun2v1DBoldDMwLTNew"));
+		mvaValue_vTight->Fill(tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byVTightIsolationMVArun2v1DBoldDMwLTNew"));
+		mvaValue_vvTight->Fill(tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLT"),tau->tauID("byVVTightIsolationMVArun2v1DBoldDMwLTNew"));
 		mvaValueDiff->Fill(fabs(valueAOD - valueMiniAOD));
-                mvaValue_antiEMVA6->Fill((*mvaEleRaw)[tau] , taus->at(iTau).tauID("againstElectronMVA6Raw"));
+                mvaValue_antiEMVA6->Fill(tau->tauID("againstElectronMVA6Raw"), tau->tauID("againstElectronMVA6RawNew"));
 
 		if(valueAOD != valueMiniAOD)
 			unmatchedTaus.push_back(tau);

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.py
@@ -8,7 +8,7 @@ process.load('Configuration.Geometry.GeometrySimDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
 	fileNames = cms.untracked.vstring(

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD.py
@@ -8,7 +8,7 @@ process.load('Configuration.Geometry.GeometrySimDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000) )
 
 process.source = cms.Source("PoolSource",
 	fileNames = cms.untracked.vstring(
@@ -100,8 +100,25 @@ process.rerunMVAIsolationOnMiniAOD = cms.EDAnalyzer('rerunMVAIsolationOnMiniAOD'
 process.rerunMVAIsolationOnMiniAOD.verbosity = cms.int32(0)
 process.rerunMVAIsolationOnMiniAOD.additionalCollectionsAvailable = cms.bool(False)
 
+# embed new id's into tau
+embedID = cms.EDProducer("PATTauIDEmbedder",
+	src = cms.InputTag('slimmedTaus'),
+	tauIDSources = cms.PSet(
+		byIsolationMVArun2v1DBoldDMwLTrawNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1raw'),
+		byVLooseIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VLoose'),
+		byLooseIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1Loose'),
+		byMediumIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1Medium'),
+		byTightIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1Tight'),
+		byVTightIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VTight'),
+		byVVTightIsolationMVArun2v1DBoldDMwLTNew = cms.InputTag('rerunDiscriminationByIsolationMVArun2v1VVTight'),
+		againstElectronMVA6RawNew = cms.InputTag('rerunDiscriminationAgainstElectronMVA6')
+		),
+	)
+setattr(process, "NewTauIDsEmbedded", embedID)
+
 process.p = cms.Path(
 	process.rerunMvaIsolation2SeqRun2
 	*process.rerunDiscriminationAgainstElectronMVA6
+	*getattr(process, "NewTauIDsEmbedded")
 	*process.rerunMVAIsolationOnMiniAOD
 )


### PR DESCRIPTION
Dear all,

with this PR the ability to embed new (e.g., rerun) tau ids into a new pat::Tau collection via the PATTauIDEmbedder is added. This makes updating to new ids much more transparent for the user.

The changes in the DataFormats/PatCandidates package ensure that one can save the new tau collection in edm format if desired.

The testing files in RecoTauTag/RecoTau/test have been adapted to make use of the new PATTauIDEmbedder.

Cheers,
Alex