### PR TITLE
Modified Cone-based Tau Builder (90X)

### DIFF
--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -17,7 +17,7 @@ SiPixelPhase1Geometry = cms.PSet(
   n_rocs = cms.int32(16), # two-row geometry is assumed
 
   # "time geometry" parameters
-  max_lumisection = cms.int32(1000),
+  max_lumisection = cms.int32(5000),
   max_bunchcrossing = cms.int32(3600),
 
   # to select a different cabling map (for pilotBlade)

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -163,7 +163,7 @@ SiPixelPhase1DigisConf = cms.VPSet(
 )
 
 SiPixelPhase1DigisAnalyzer = cms.EDAnalyzer("SiPixelPhase1Digis",
-        src = cms.InputTag("simSiPixelDigis"), 
+        src = cms.InputTag("siPixelDigis"), 
         histograms = SiPixelPhase1DigisConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
+++ b/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
@@ -69,7 +69,7 @@ SiPixelPhase1RawDataTypeNErrors = DefaultHisto.clone(
   name = "nerrors_per_type",
   title = "Number of Errors per Type",
   xlabel = "Error Type",
-  range_min = 0, range_max = 50, range_nbins = 51,#TODO: proper range here
+  range_min = -0.5, range_max = 50.5, range_nbins = 51,#TODO: proper range here
   dimensions = 1,
   specs = VPSet(
     Specification().groupBy("FED/FED").save(),

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -176,13 +176,19 @@ HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& eventS
              it != digi->end(); ++it)
         {
             const QIE10DataFrame& frame(*it);
+            const HcalDetId cell(frame.id());
+
+            // Protection against calibration channels which are not
+            // in the database but can still come in the QIE10DataFrame
+            // in the laser calibs, etc.
+            if (cell.subdet() != HcalSubdetector::HcalForward)
+                continue;
 
             // Check zero suppression
             if (dropZSmarkedPassed_)
                 if (frame.zsMarkAndPass())
                     continue;
 
-            const HcalDetId cell(it->id());
             const HcalCalibrations& calibrations(conditions->getHcalCalibrations(cell));
             const HcalQIECoder* channelCoder = conditions->getHcalCoder(cell);
             const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -55,11 +55,19 @@ class RecoTauBuilderConePlugin : public RecoTauBuilderPlugin {
     JetFunc signalConeChargedHadrons_;
     JetFunc isoConeChargedHadrons_;
     JetFunc signalConePiZeros_;
+    StringObjectFunction<reco::PFTau> signalConeSizeToStore_;
     JetFunc isoConePiZeros_;
     JetFunc signalConeNeutralHadrons_;
     JetFunc isoConeNeutralHadrons_;
 
     int maxSignalConeChargedHadrons_;
+
+    void setTauQuantities(reco::PFTau& aTau,
+			  double minAbsPhotonSumPt_insideSignalCone = 2.5,
+			  double minRelPhotonSumPt_insideSignalCone = 0.,
+			  double minAbsPhotonSumPt_outsideSignalCone = 1.e+9,
+			  double minRelPhotonSumPt_outsideSignalCone = 1.e+9) const;
+
 };
 
 // ctor - initialize all of our variables
@@ -76,6 +84,8 @@ RecoTauBuilderConePlugin::RecoTauBuilderConePlugin(
         pset.getParameter<std::string>("isoConeChargedHadrons")),
     signalConePiZeros_(
         pset.getParameter<std::string>("signalConePiZeros")),
+    signalConeSizeToStore_(//MB: stored inside PFTau and used to compte photon-pt-out-of-signal-cone and DM hypothsis
+	pset.getParameter<std::string>("signalConePiZeros")),
     isoConePiZeros_(
         pset.getParameter<std::string>("isoConePiZeros")),
     signalConeNeutralHadrons_(
@@ -107,6 +117,63 @@ namespace xclean
   }
 }
 
+void RecoTauBuilderConePlugin::setTauQuantities(reco::PFTau& aTau,
+						double minAbsPhotonSumPt_insideSignalCone,
+						double minRelPhotonSumPt_insideSignalCone,
+						double minAbsPhotonSumPt_outsideSignalCone,
+						double minRelPhotonSumPt_outsideSignalCone) const {
+  //MB: Set tau quantities which are computed by RecoTauConstructor::get() 
+  //    method with PFRecoTauChargedHadrons not used here
+  
+  // Set charge
+  int charge = 0;
+  int leadCharge = aTau.leadPFChargedHadrCand().isNonnull() ? aTau.leadPFChargedHadrCand()->charge() : 0;
+  const std::vector<reco::PFCandidatePtr>& pfChs = aTau.signalPFChargedHadrCands();
+  for(std::vector<reco::PFCandidatePtr>::const_iterator pfCh = pfChs.begin();
+      pfCh != pfChs.end(); ++pfCh)
+    charge += (*pfCh)->charge();
+  charge = charge==0 ? leadCharge : charge;
+  aTau.setCharge(charge);
+  
+  // Set PDG id
+  aTau.setPdgId(aTau.charge() < 0 ? 15 : -15); 
+  
+  // Set Decay Mode
+  PFTau::hadronicDecayMode dm = PFTau::kNull; 
+  unsigned int nPiZeros = 0;
+  const std::vector<RecoTauPiZero>& piZeros = aTau.signalPiZeroCandidates();
+  for(std::vector<RecoTauPiZero>::const_iterator piZero = piZeros.begin();
+      piZero != piZeros.end(); ++piZero) {
+    double photonSumPt_insideSignalCone = 0.;
+    double photonSumPt_outsideSignalCone = 0.;
+      int numPhotons = piZero->numberOfDaughters();
+      for(int idxPhoton = 0; idxPhoton < numPhotons; ++idxPhoton) {
+	const reco::Candidate* photon = piZero->daughter(idxPhoton);
+	double dR = deltaR(photon->p4(), aTau.p4());
+	if(dR < aTau.signalConeSize() ){
+	  photonSumPt_insideSignalCone += photon->pt();
+	  } else {
+	    photonSumPt_outsideSignalCone += photon->pt();
+	  }
+	}
+	if( photonSumPt_insideSignalCone  > minAbsPhotonSumPt_insideSignalCone  || photonSumPt_insideSignalCone  > (minRelPhotonSumPt_insideSignalCone*aTau.pt())  ||
+	    photonSumPt_outsideSignalCone > minAbsPhotonSumPt_outsideSignalCone || photonSumPt_outsideSignalCone > (minRelPhotonSumPt_outsideSignalCone*aTau.pt()) ) ++nPiZeros;
+    }
+    // Find the maximum number of PiZeros our parameterization can hold
+    const unsigned int maxPiZeros = PFTau::kOneProngNPiZero;
+    // Determine our track index
+    unsigned int nCharged = pfChs.size();
+    unsigned int trackIndex = (nCharged - 1)*(maxPiZeros + 1);
+    // Check if we handle the given number of tracks
+    if(trackIndex >= PFTau::kRareDecayMode) 
+      dm = PFTau::kRareDecayMode;    
+    else
+      dm = static_cast<PFTau::hadronicDecayMode>(trackIndex + std::min(nPiZeros,maxPiZeros) );
+    aTau.setDecayMode(dm);
+    
+    return;
+}
+
 RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
     const reco::PFJetRef& jet,
     const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons, 
@@ -122,7 +189,11 @@ RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
 
   // Our tau builder - the true indicates to automatically copy gamma candidates
   // from the pizeros.
-  RecoTauConstructor tau(jet, getPFCands(), true);
+  double minAbsPhotonPt_inSignalCone=2.5, minRelPhotonPt_inSignalCone=0.1;//MB: sensible defults to set a DM hypothesis
+  RecoTauConstructor tau(jet, getPFCands(), true, 
+			 &signalConeSizeToStore_, 
+			 minAbsPhotonPt_inSignalCone, 
+			 minRelPhotonPt_inSignalCone);
   // Setup our quality cuts to use the current vertex (supplied by base class)
   qcuts_.setPV(primaryVertex(jet));
 
@@ -381,6 +452,12 @@ RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
   reco::VertexRef primaryVertexRef = primaryVertex(jet);
   if ( primaryVertexRef.isNonnull() )
     tauPtr->setVertex(primaryVertexRef->position());
+
+  // Set missing tau quantities
+  setTauQuantities(*tauPtr,
+  		   minAbsPhotonPt_inSignalCone,
+  		   minRelPhotonPt_inSignalCone
+		   );
 
   output.push_back(tauPtr);
   return output.release();


### PR DESCRIPTION
This PR is to modify the Cone-based tau builder (used at HLT) to fill some additional data members of produced PFTau not filled so far:
1. Size of signal cone (cone for PiZeros used);
2. Pt carried by signal PiZeros outside of the signal cone; it is an important shape variable supporting isolation in rejecting jet->tau fakes;
3. Charge, pdgId, tau decay mode hypothesis.

The changes does not modify current HLT work-flow (the builder is used only at HLT), but provides new features (cf. 2) allowing better jet->tau fake rejection during 2017 data-taking.

This version of #44 for 90X without changes proposed for tau vertex association for 91X. This PR is prepared on top of the CMSSW_9_0_1 release.