### PR TITLE
Implementing requests made by Slava

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -37,7 +37,6 @@
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include <TMath.h>
 #include <TFile.h>
 
 #include <iostream>
@@ -219,103 +218,103 @@ double PATTauDiscriminationByMVAIsolationRun2::discriminate(const TauRef& tau) c
         double mTau = 1.77682;
         double mAOne = tau->p4().M();
         double pAOneMag = tau->p();
-        double thetaGJmax = TMath::ASin( (TMath::Power(mTau,2) - TMath::Power(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
-        double thetaGJmeasured = TMath::ACos( ( tau->p4().px() * decayDistX + tau->p4().py() * decayDistY + tau->p4().pz() * decayDistZ ) / ( pAOneMag * decayDistMag ) );
+        double thetaGJmax = std::asin( (std::pow(mTau,2) - std::pow(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
+        double thetaGJmeasured = std::acos( ( tau->p4().px() * decayDistX + tau->p4().py() * decayDistY + tau->p4().pz() * decayDistZ ) / ( pAOneMag * decayDistMag ) );
         gjAngleDiff = thetaGJmeasured - thetaGJmax;
     }
 		
     if ( mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum - (float)0.125*puCorrPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
       mvaInput_[5]  = tauDecayMode;
     } else if ( mvaOpt_ == kOldDMwLT || mvaOpt_ == kNewDMwLT  ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum - (float)0.125*puCorrPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
       mvaInput_[5]  = tauDecayMode;
-      mvaInput_[6]  = TMath::Sign((float)+1., tau->dxy());
-      mvaInput_[7]  = std::sqrt(std::min((float)1., std::fabs(tau->dxy())));
-      mvaInput_[8]  = std::min((float)10., std::fabs(tau->dxy_Sig()));
+      mvaInput_[6]  = std::copysign(+1.f, tau->dxy());
+      mvaInput_[7]  = std::sqrt(std::min(1.f, std::fabs(tau->dxy())));
+      mvaInput_[8]  = std::min(10.f, std::fabs(tau->dxy_Sig()));
       mvaInput_[9]  = ( tau->hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[10] = std::sqrt(decayDistMag);
-      mvaInput_[11] = std::min((float)10., tau->flightLengthSig());
+      mvaInput_[11] = std::min(10.f, tau->flightLengthSig());
     } else if ( mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
-      mvaInput_[1]  = std::fabs(tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
-      mvaInput_[5]  = std::log(std::max((float)1.e-2, photonPtSumOutsideSignalCone));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
+      mvaInput_[1]  = std::fabs((float)tau->eta());
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
+      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
       mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min((float)30., nPhoton);
-      mvaInput_[8]  = std::min((float)0.5, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min((float)0.5, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min((float)0.5, ptWeightedDrSignal);
-      mvaInput_[11] = std::min((float)0.5, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min((float)100., leadingTrackChi2);
-      mvaInput_[13] = std::min((float)1., eRatio);
-      mvaInput_[14]  = TMath::Sign((float)+1., tau->dxy());
-      mvaInput_[15]  = std::sqrt(std::min((float)1., std::fabs(tau->dxy())));
-      mvaInput_[16]  = std::min((float)10., std::fabs(tau->dxy_Sig()));
-      mvaInput_[17]  = TMath::Sign((float)+1., tau->ip3d());
-      mvaInput_[18]  = std::sqrt(std::min((float)1., std::fabs(tau->ip3d())));
-      mvaInput_[19]  = std::min((float)10., std::fabs(tau->ip3d_Sig()));
+      mvaInput_[7]  = std::min(30.f, nPhoton);
+      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
+      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
+      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+      mvaInput_[12] = std::min(100.f, leadingTrackChi2);
+      mvaInput_[13] = std::min(1.f, eRatio);
+      mvaInput_[14]  = std::copysign(+1.f, tau->dxy());
+      mvaInput_[15]  = std::sqrt(std::min(1.f, std::fabs(tau->dxy())));
+      mvaInput_[16]  = std::min(10.f, std::fabs(tau->dxy_Sig()));
+      mvaInput_[17]  = std::copysign(+1.f, tau->ip3d());
+      mvaInput_[18]  = std::sqrt(std::min(1.f, std::fabs(tau->ip3d())));
+      mvaInput_[19]  = std::min(10.f, std::fabs(tau->ip3d_Sig()));
       mvaInput_[20]  = ( tau->hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[21] = std::sqrt(decayDistMag);
-      mvaInput_[22] = std::min((float)10., tau->flightLengthSig());
+      mvaInput_[22] = std::min(10.f, tau->flightLengthSig());
     } else if ( mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
-      mvaInput_[1]  = std::fabs(tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, footprintCorrection));
-      mvaInput_[5]  = std::log(std::max((float)1.e-2, photonPtSumOutsideSignalCone));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
+      mvaInput_[1]  = std::fabs((float)tau->eta());
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, footprintCorrection));
+      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
       mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min((float)30., nPhoton);
-      mvaInput_[8]  = std::min((float)0.5, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min((float)0.5, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min((float)0.5, ptWeightedDrSignal);
-      mvaInput_[11] = std::min((float)0.5, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min((float)100., leadingTrackChi2);
-      mvaInput_[13] = std::min((float)1., eRatio);
-      mvaInput_[14]  = TMath::Sign((float)+1., tau->dxy());
-      mvaInput_[15]  = std::sqrt(std::min((float)1., std::fabs(tau->dxy())));
-      mvaInput_[16]  = std::min((float)10., std::fabs(tau->dxy_Sig()));
-      mvaInput_[17]  = TMath::Sign((float)+1., tau->ip3d());
-      mvaInput_[18]  = std::sqrt(std::min((float)1., std::fabs(tau->ip3d())));
-      mvaInput_[19]  = std::min((float)10., std::fabs(tau->ip3d_Sig()));
+      mvaInput_[7]  = std::min(30.f, nPhoton);
+      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
+      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
+      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+      mvaInput_[12] = std::min(100.f, leadingTrackChi2);
+      mvaInput_[13] = std::min(1.f, eRatio);
+      mvaInput_[14]  = std::copysign(+1.f, tau->dxy());
+      mvaInput_[15]  = std::sqrt(std::min(1.f, std::fabs(tau->dxy())));
+      mvaInput_[16]  = std::min(10.f, std::fabs(tau->dxy_Sig()));
+      mvaInput_[17]  = std::copysign(+1.f, tau->ip3d());
+      mvaInput_[18]  = std::sqrt(std::min(1.f, std::fabs(tau->ip3d())));
+      mvaInput_[19]  = std::min(10.f, std::fabs(tau->ip3d_Sig()));
       mvaInput_[20]  = ( tau->hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[21] = std::sqrt(decayDistMag);
-      mvaInput_[22] = std::min((float)10., tau->flightLengthSig());
+      mvaInput_[22] = std::min(10.f, tau->flightLengthSig());
     } else if ( mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
-      mvaInput_[1]  = std::fabs(tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
-      mvaInput_[5]  = std::log(std::max((float)1.e-2, photonPtSumOutsideSignalCone));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
+      mvaInput_[1]  = std::fabs((float)tau->eta());
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
+      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
       mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min((float)30., nPhoton);
-      mvaInput_[8]  = std::min((float)0.5, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min((float)0.5, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min((float)0.5, ptWeightedDrSignal);
-      mvaInput_[11] = std::min((float)0.5, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min((float)1., eRatio);
-      mvaInput_[13]  = TMath::Sign((float)+1., tau->dxy());
-      mvaInput_[14]  = std::sqrt(std::min((float)1., std::fabs(tau->dxy())));
-      mvaInput_[15]  = std::min((float)10., std::fabs(tau->dxy_Sig()));
-      mvaInput_[16]  = TMath::Sign((float)+1., tau->ip3d());
-      mvaInput_[17]  = std::sqrt(std::min((float)1., std::fabs(tau->ip3d())));
-      mvaInput_[18]  = std::min((float)10., std::fabs(tau->ip3d_Sig()));
+      mvaInput_[7]  = std::min(30.f, nPhoton);
+      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
+      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
+      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+      mvaInput_[12] = std::min(1.f, eRatio);
+      mvaInput_[13]  = std::copysign(+1.f, tau->dxy());
+      mvaInput_[14]  = std::sqrt(std::min(1.f, std::fabs(tau->dxy())));
+      mvaInput_[15]  = std::min(10.f, std::fabs(tau->dxy_Sig()));
+      mvaInput_[16]  = std::copysign(+1.f, tau->ip3d());
+      mvaInput_[17]  = std::sqrt(std::min(1.f, std::fabs(tau->ip3d())));
+      mvaInput_[18]  = std::min(10.f, std::fabs(tau->ip3d_Sig()));
       mvaInput_[19]  = ( tau->hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[20] = std::sqrt(decayDistMag);
-      mvaInput_[21] = std::min((float)10., tau->flightLengthSig());
-      mvaInput_[22] = std::max((float)-1., gjAngleDiff);
+      mvaInput_[21] = std::min(10.f, tau->flightLengthSig());
+      mvaInput_[22] = std::max(-1.f, gjAngleDiff);
     }
 		
     double mvaValue = mvaReader_->GetClassifier(mvaInput_);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
@@ -29,7 +29,6 @@
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include <TMath.h>
 #include <TFile.h>
 
 #include <iostream>
@@ -230,103 +229,103 @@ double PFRecoTauDiscriminationByMVAIsolationRun2::discriminate(const PFTauRef& t
         double mTau = 1.77682;
         double mAOne = tau->p4().M();
         double pAOneMag = tau->p();
-        double thetaGJmax = TMath::ASin( (TMath::Power(mTau,2) - TMath::Power(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
-        double thetaGJmeasured = TMath::ACos( ( tau->p4().px() * decayDistX + tau->p4().py() * decayDistY + tau->p4().pz() * decayDistZ ) / ( pAOneMag * decayDistMag ) );
+        double thetaGJmax = std::asin( (std::pow(mTau,2) - std::pow(mAOne,2) ) / ( 2 * mTau * pAOneMag ) );
+        double thetaGJmeasured = std::acos( ( tau->p4().px() * decayDistX + tau->p4().py() * decayDistY + tau->p4().pz() * decayDistZ ) / ( pAOneMag * decayDistMag ) );
         gjAngleDiff = thetaGJmeasured - thetaGJmax;
     }
 
     if ( mvaOpt_ == kOldDMwoLT || mvaOpt_ == kNewDMwoLT ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum - (float)0.125*puCorrPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
       mvaInput_[5]  = tauDecayMode;
     } else if ( mvaOpt_ == kOldDMwLT || mvaOpt_ == kNewDMwLT  ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum - (float)0.125*puCorrPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum - 0.125f*puCorrPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
       mvaInput_[5]  = tauDecayMode;
-      mvaInput_[6]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.dxy());
-      mvaInput_[7]  = std::sqrt(std::fabs(std::min((float)1., (float)tauLifetimeInfo.dxy())));
-      mvaInput_[8]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.dxy_Sig()));
+      mvaInput_[6]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+      mvaInput_[7]  = std::sqrt(std::fabs(std::min(1.f, (float)tauLifetimeInfo.dxy())));
+      mvaInput_[8]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.dxy_Sig()));
       mvaInput_[9]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[10] = std::sqrt(decayDistMag);
-      mvaInput_[11] = std::min((float)10., (float)tauLifetimeInfo.flightLengthSig());
+      mvaInput_[11] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
     } else if ( mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
-      mvaInput_[5]  = std::log(std::max((float)1.e-2, photonPtSumOutsideSignalCone));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
+      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
       mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min((float)30., nPhoton);
-      mvaInput_[8]  = std::min((float)0.5, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min((float)0.5, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min((float)0.5, ptWeightedDrSignal);
-      mvaInput_[11] = std::min((float)0.5, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min((float)100., leadingTrackChi2);
-      mvaInput_[13] = std::min((float)1., eRatio);
-      mvaInput_[14]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.dxy());
-      mvaInput_[15]  = std::sqrt(std::fabs(std::min((float)1., std::fabs((float)tauLifetimeInfo.dxy()))));
-      mvaInput_[16]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[17]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.ip3d());
-      mvaInput_[18]  = std::sqrt(std::fabs(std::min((float)1., std::fabs((float)tauLifetimeInfo.ip3d()))));
-      mvaInput_[19]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.ip3d_Sig()));
+      mvaInput_[7]  = std::min(30.f, nPhoton);
+      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
+      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
+      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+      mvaInput_[12] = std::min(100.f, leadingTrackChi2);
+      mvaInput_[13] = std::min(1.f, eRatio);
+      mvaInput_[14]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+      mvaInput_[15]  = std::sqrt(std::fabs(std::min(1.f, std::fabs((float)tauLifetimeInfo.dxy()))));
+      mvaInput_[16]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.dxy_Sig()));
+      mvaInput_[17]  = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
+      mvaInput_[18]  = std::sqrt(std::fabs(std::min(1.f, std::fabs((float)tauLifetimeInfo.ip3d()))));
+      mvaInput_[19]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.ip3d_Sig()));
       mvaInput_[20]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[21] = std::sqrt(decayDistMag);
-      mvaInput_[22] = std::min((float)10., (float)tauLifetimeInfo.flightLengthSig());
+      mvaInput_[22] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
     } else if ( mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, footprintCorrection));
-      mvaInput_[5]  = std::log(std::max((float)1.e-2, photonPtSumOutsideSignalCone));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, footprintCorrection));
+      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
       mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min((float)30., nPhoton);
-      mvaInput_[8]  = std::min((float)0.5, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min((float)0.5, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min((float)0.5, ptWeightedDrSignal);
-      mvaInput_[11] = std::min((float)0.5, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min((float)100., leadingTrackChi2);
-      mvaInput_[13] = std::min((float)1., eRatio);
-      mvaInput_[14]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.dxy());
-      mvaInput_[15]  = std::sqrt(std::fabs(std::min((float)1., std::fabs((float)tauLifetimeInfo.dxy()))));
-      mvaInput_[16]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[17]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.ip3d());
-      mvaInput_[18]  = std::sqrt(std::fabs(std::min((float)1., std::fabs((float)tauLifetimeInfo.ip3d()))));
-      mvaInput_[19]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.ip3d_Sig()));
+      mvaInput_[7]  = std::min(30.f, nPhoton);
+      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
+      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
+      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+      mvaInput_[12] = std::min(100.f, leadingTrackChi2);
+      mvaInput_[13] = std::min(1.f, eRatio);
+      mvaInput_[14]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+      mvaInput_[15]  = std::sqrt(std::fabs(std::min(1.f, std::fabs((float)tauLifetimeInfo.dxy()))));
+      mvaInput_[16]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.dxy_Sig()));
+      mvaInput_[17]  = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
+      mvaInput_[18]  = std::sqrt(std::fabs(std::min(1.f, std::fabs((float)tauLifetimeInfo.ip3d()))));
+      mvaInput_[19]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.ip3d_Sig()));
       mvaInput_[20]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[21] = std::sqrt(decayDistMag);
-      mvaInput_[22] = std::min((float)10., (float)tauLifetimeInfo.flightLengthSig());
+      mvaInput_[22] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
     } else if ( mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ ) {
-      mvaInput_[0]  = std::log(std::max((float)1., (float)tau->pt()));
+      mvaInput_[0]  = std::log(std::max(1.f, (float)tau->pt()));
       mvaInput_[1]  = std::fabs((float)tau->eta());
-      mvaInput_[2]  = std::log(std::max((float)1.e-2, chargedIsoPtSum));
-      mvaInput_[3]  = std::log(std::max((float)1.e-2, neutralIsoPtSum));
-      mvaInput_[4]  = std::log(std::max((float)1.e-2, puCorrPtSum));
-      mvaInput_[5]  = std::log(std::max((float)1.e-2, photonPtSumOutsideSignalCone));
+      mvaInput_[2]  = std::log(std::max(1.e-2f, chargedIsoPtSum));
+      mvaInput_[3]  = std::log(std::max(1.e-2f, neutralIsoPtSum));
+      mvaInput_[4]  = std::log(std::max(1.e-2f, puCorrPtSum));
+      mvaInput_[5]  = std::log(std::max(1.e-2f, photonPtSumOutsideSignalCone));
       mvaInput_[6]  = tauDecayMode;
-      mvaInput_[7]  = std::min((float)30., nPhoton);
-      mvaInput_[8]  = std::min((float)0.5, ptWeightedDetaStrip);
-      mvaInput_[9]  = std::min((float)0.5, ptWeightedDphiStrip);
-      mvaInput_[10] = std::min((float)0.5, ptWeightedDrSignal);
-      mvaInput_[11] = std::min((float)0.5, ptWeightedDrIsolation);
-      mvaInput_[12] = std::min((float)1., eRatio);
-      mvaInput_[13]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.dxy());
-      mvaInput_[14]  = std::sqrt(std::fabs(std::min((float)1., std::fabs((float)tauLifetimeInfo.dxy()))));
-      mvaInput_[15]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.dxy_Sig()));
-      mvaInput_[16]  = TMath::Sign((float)+1., (float)tauLifetimeInfo.ip3d());
-      mvaInput_[17]  = std::sqrt(std::fabs(std::min((float)1., std::fabs((float)tauLifetimeInfo.ip3d()))));
-      mvaInput_[18]  = std::min((float)10., std::fabs((float)tauLifetimeInfo.ip3d_Sig()));
+      mvaInput_[7]  = std::min(30.f, nPhoton);
+      mvaInput_[8]  = std::min(0.5f, ptWeightedDetaStrip);
+      mvaInput_[9]  = std::min(0.5f, ptWeightedDphiStrip);
+      mvaInput_[10] = std::min(0.5f, ptWeightedDrSignal);
+      mvaInput_[11] = std::min(0.5f, ptWeightedDrIsolation);
+      mvaInput_[12] = std::min(1.f, eRatio);
+      mvaInput_[13]  = std::copysign(+1.f, (float)tauLifetimeInfo.dxy());
+      mvaInput_[14]  = std::sqrt(std::fabs(std::min(1.f, std::fabs((float)tauLifetimeInfo.dxy()))));
+      mvaInput_[15]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.dxy_Sig()));
+      mvaInput_[16]  = std::copysign(+1.f, (float)tauLifetimeInfo.ip3d());
+      mvaInput_[17]  = std::sqrt(std::fabs(std::min(1.f, std::fabs((float)tauLifetimeInfo.ip3d()))));
+      mvaInput_[18]  = std::min(10.f, std::fabs((float)tauLifetimeInfo.ip3d_Sig()));
       mvaInput_[19]  = ( tauLifetimeInfo.hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[20] = std::sqrt(decayDistMag);
-      mvaInput_[21] = std::min((float)10., (float)tauLifetimeInfo.flightLengthSig());
-      mvaInput_[22] = std::max((float)-1., gjAngleDiff);
+      mvaInput_[21] = std::min(10.f, (float)tauLifetimeInfo.flightLengthSig());
+      mvaInput_[22] = std::max(-1.f, gjAngleDiff);
     }
 
     double mvaValue = mvaReader_->GetClassifier(mvaInput_);


### PR DESCRIPTION
This PR implements the two requests made by Slava during integration into official CMSSW:
- use `std` instead of `TMath` functions whereever possible
- use `1.f` instead of `(float)1`.