### PR TITLE
Move piZeros from signal to isolation if not get into a decay mode

### DIFF
--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -47,11 +47,11 @@ combinatoricRecoTaus.jetSrc = PFRecoTauPFJetInputs.inputJetCollection
 
 #--------------------------------------------------------------------------------
 # CV: set mass of tau candidates reconstructed in 1Prong0pi0 decay mode to charged pion mass
-combinatoricRecoTaus.modifiers.append(cms.PSet(
-    name = cms.string("tau_mass"),
-    plugin = cms.string("PFRecoTauMassPlugin"),
-    verbosity = cms.int32(0)                                    
-))    
+#combinatoricRecoTaus.modifiers.append(cms.PSet(
+#    name = cms.string("tau_mass"),
+#    plugin = cms.string("PFRecoTauMassPlugin"),
+#    verbosity = cms.int32(0)                                    
+#))    
 #--------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -57,7 +57,8 @@ class RecoTauConstructor {
 	bool copyGammasFromPiZeros = false,
 	const StringObjectFunction<reco::PFTau>* signalConeSize = 0,
 	double minAbsPhotonSumPt_insideSignalCone = 2.5, double minRelPhotonSumPt_insideSignalCone = 0.,
-	double minAbsPhotonSumPt_outsideSignalCone = 1.e+9, double minRelPhotonSumPt_outsideSignalCone = 1.e+9);
+	double minAbsPhotonSumPt_outsideSignalCone = 1.e+9, double minRelPhotonSumPt_outsideSignalCone = 1.e+9,
+	bool moveUnusedSignalPiZeros = false);
 
     /*
      * Code to set leading candidates.  These are just wrappers about
@@ -124,6 +125,9 @@ class RecoTauConstructor {
       }
     }
 
+    /// Move piZeros not used to form a decay mode from signal to isolation category
+    void moveUnusedSignalPiZeros();
+
     // Build and return the associated tau
     std::auto_ptr<reco::PFTau> get(bool setupLeadingCandidates=true);
 
@@ -137,6 +141,7 @@ class RecoTauConstructor {
     typedef std::map<CollectionKey, SortedListPtr> SortedCollectionMap;
 
     bool copyGammas_;
+    bool moveSignalPiZeros_;
 
     const StringObjectFunction<reco::PFTau>* signalConeSize_;
     double minAbsPhotonSumPt_insideSignalCone_;

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -276,7 +276,8 @@ RecoTauBuilderCombinatoricPlugin::operator()(
         RecoTauConstructor tau(
           jet, getPFCands(), true, 
 	  &signalConeSize_, 
-	  minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_, minAbsPhotonSumPt_outsideSignalCone_, minRelPhotonSumPt_outsideSignalCone_);
+	  minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_, minAbsPhotonSumPt_outsideSignalCone_, minRelPhotonSumPt_outsideSignalCone_,
+	  true);
         // Reserve space in our collections
         tau.reserve(
 	    RecoTauConstructor::kSignal,


### PR DESCRIPTION
As title says: this PR adds a code which moves PiZeros (and related photons) from signal to isolation collections if the PiZeros are not used to build a decay mode. Tau 4-momentum is modified accordingly. As byproduct mass of 1p+0pi0 taus is equal to pion mass and it is not necessary to correct it by hand, so corresponding modifier removed from standard collection.

Expected changes: energy and momentum of decay modes w/o pi0, i.e. 1p+0pi0 (dm==0), 3p+0pi0 (dm=10) and 2p+0pi0 (dm=5) is slightly smaller and their direction a bit changed. In addition neutral (photon) isolation PtSum is a bit higher in these decay modes, while photon-PtSum-outside-signal-cone is explicitly 0. The changes translate to a bit lower efficiency after decay mode finding and charged isolation (esp. at low-Pt) and slightly higher efficiency when full combined cut-based isolation is applied. Fake rate also increases a bit. MVA-based isolation is, however, only infinitesimally modified. 

Note: this should be integrated to Tau POG repo, but integration to official CMSSW should be discussed (needs tests with higher statistics than used for development)