### PR TITLE
Tau rereco for MiniAOD of 80X legacy samples

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cff.py
@@ -20,7 +20,7 @@ from PhysicsTools.PatAlgos.producersLayer1.tauProducer_cfi import *
 
 makePatTausTask = cms.Task(
     # reco pre-production
-    patHPSPFTauDiscriminationTask,
+    #patHPSPFTauDiscriminationTask,
     patPFCandidateIsoDepositSelectionTask,
     patPFTauIsolationTask,
     #patTauJetCorrections *

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -261,6 +261,19 @@ def miniAOD_customizeCommon(process):
     from RecoTauTag.Configuration.boostedHPSPFTaus_cfi import addBoostedTaus
     addBoostedTaus(process)
     #---------------------------------------------------------------------------
+    #Adding tau reco for 80X legacy reMiniAOD
+    #make a copy of makePatTauTask to avoid labels and substitution problems
+    _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()
+    #add PFTau reco modules to cloned makePatTauTask
+    process.load("RecoTauTag.Configuration.RecoPFTauTag_cff")
+    from PhysicsTools.PatAlgos.tools.helpers import listModules
+    for module in listModules(process.PFTau):
+        _makePatTausTaskWithTauReReco.add(module)
+    #replace original task by extended one for the miniAOD_80XLegacy era
+    from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+    run2_miniAOD_80XLegacy.toReplaceWith(
+        process.makePatTausTask, _makePatTausTaskWithTauReReco)
+    #---------------------------------------------------------------------------
 
     # Adding puppi jets
     if not hasattr(process, 'ak4PFJetsPuppi'): #MM: avoid confilct with substructure call


### PR DESCRIPTION
This pull requests adds tau re-reconstruction to MiniAOD step for legacy re-reco of 2016 data and MC produced with CMSSW_80X. The re-reconstruction is added to MiniAOD setup (`PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py`) when the `run2_miniAOD_80XLegacy` Era is requested.

Expected effect of the PR is was discussed in the xPOG on 5 September 2017 [1].

Note 1: During the xPOG meeting it was agreed that the PR (when sent to official CMSSW repo) will be scrutinized, but its integration will be hold until Tau POG conveners give their final green light. The (unusual) procedure is to speedup the integration process. 

Note 2: The PR consists of purely technical modification of `PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cff.py` file: it is a cleaning which avoids re-reco of cut-based tau discriminants which in not necessary.

@roger-wolf I hope that the PR is simple one and can be quickly forwarded to the official CMSSW repo. I can however suppose some remarks from RECO experts on a way in which tau reco modules are included to a clone of the `makePatTausTask`. The reason is that there is not a tau-reco task containing the modules and I wanted to keep changes limited to a small number of files. Of course, I will change this, i.e. add corresponding task to RecoPFTau configuration files [2] if demanded.

[1] https://indico.cern.ch/event/663315/contributions/2708403/attachments/1518558/2371260/mbluj_TauId_80XLegacyMiniAOD_5Sep2017.pdf
[2] E.g. this one `RecoTauTag/Configuration/python/RecoPFTauTag_cff.py`
