### PR TITLE
Migration from Sequences to Tasks

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cff.py
@@ -20,10 +20,8 @@ from PhysicsTools.PatAlgos.producersLayer1.tauProducer_cfi import *
 
 makePatTausTask = cms.Task(
     # reco pre-production
-    #patHPSPFTauDiscriminationTask,
     patPFCandidateIsoDepositSelectionTask,
     patPFTauIsolationTask,
-    #patTauJetCorrections *
     # pat specifics
     tauMatch,
     tauGenJets,

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -266,9 +266,7 @@ def miniAOD_customizeCommon(process):
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()
     #add PFTau reco modules to cloned makePatTauTask
     process.load("RecoTauTag.Configuration.RecoPFTauTag_cff")
-    from PhysicsTools.PatAlgos.tools.helpers import listModules
-    for module in listModules(process.PFTau):
-        _makePatTausTaskWithTauReReco.add(module)
+    _makePatTausTaskWithTauReReco.add(process.PFTauTask)
     #replace original task by extended one for the miniAOD_80XLegacy era
     from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
     run2_miniAOD_80XLegacy.toReplaceWith(

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -175,11 +175,14 @@ hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits = hpsPFTauDiscrimin
     storeRawSumPt = cms.bool(True)
 )
 ## hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3Hits 
-hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3Hits = cms.Sequence(
-    hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits  *
-    hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits *
-    hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits  *
+hpsPFTauDiscriminationByCombinedIsolationDBSumPtCorr3HitsTask = cms.Task(
+    hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits,
+    hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits,
+    hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits,
     hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits
+)
+hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3Hits = cms.Sequence(
+    hpsPFTauDiscriminationByCombinedIsolationDBSumPtCorr3HitsTask
 )
 ## Discrimination ByLooseCombinedIsolationDBSumPtCorr3HitsdR03
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsdR03 = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits.clone()
@@ -194,10 +197,13 @@ hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03 = hpsPFTauDis
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03.deltaBetaFactor = cms.string('0.0720') # 0.2*(0.3/0.5)^2
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03.customOuterCone = cms.double(0.3)
 ## hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3HitsdR03
-hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3HitsdR03 = cms.Sequence(
-    hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsdR03  *
-    hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsdR03 *
+hpsPFTauDiscriminationByCombinedIsolationDBSumPtCorr3HitsdR03Task = cms.Task(
+    hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsdR03,
+    hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsdR03,
     hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03
+)
+hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3HitsdR03 = cms.Sequence(
+    hpsPFTauDiscriminationByCombinedIsolationDBSumPtCorr3HitsdR03Task
 )
 ## ByLoosePileupWeightedIsolation3Hits (kept for Validation)
 hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits.clone(
@@ -233,14 +239,16 @@ hpsPFTauDiscriminationByPhotonPtSumOutsideSignalCone = hpsPFTauDiscriminationByL
     applySumPtCut = cms.bool(False)
 )
 ## hpsPFTauDiscriminationByPileupWeightedIsolationSeq3Hits
-hpsPFTauDiscriminationByPileupWeightedIsolationSeq3Hits = cms.Sequence(
-   hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits  *
-   hpsPFTauDiscriminationByMediumPileupWeightedIsolation3Hits *
-   hpsPFTauDiscriminationByTightPileupWeightedIsolation3Hits  *
-   hpsPFTauDiscriminationByPhotonPtSumOutsideSignalCone       *
+hpsPFTauDiscriminationByPileupWeightedIsolation3HitsTask = cms.Task(
+   hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits,
+   hpsPFTauDiscriminationByMediumPileupWeightedIsolation3Hits,
+   hpsPFTauDiscriminationByTightPileupWeightedIsolation3Hits,
+   hpsPFTauDiscriminationByPhotonPtSumOutsideSignalCone,
    hpsPFTauDiscriminationByRawPileupWeightedIsolation3Hits
 )
-
+hpsPFTauDiscriminationByPileupWeightedIsolationSeq3Hits = cms.Sequence(
+    hpsPFTauDiscriminationByPileupWeightedIsolation3HitsTask
+)
 
 
 ## ByLooseMuonRejection3
@@ -445,12 +453,14 @@ hpsPFTauTransverseImpactParameters = PFTauTransverseImpactParameters.clone(
     PFTauSVATag = cms.InputTag("hpsPFTauSecondaryVertexProducer"),
     useFullCalculation = cms.bool(True)
 )
-hpsPFTauVertexAndImpactParametersSeq = cms.Sequence(
-    hpsPFTauPrimaryVertexProducer*
-    hpsPFTauSecondaryVertexProducer*
+hpsPFTauVertexAndImpactParametersTask = cms.Task(
+    hpsPFTauPrimaryVertexProducer,
+    hpsPFTauSecondaryVertexProducer,
     hpsPFTauTransverseImpactParameters
 )
-
+hpsPFTauVertexAndImpactParametersSeq = cms.Sequence(
+    hpsPFTauVertexAndImpactParametersTask
+)
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByMVAIsolation2_cff import *
 hpsPFTauChargedIsoPtSum = hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits.clone(
     PFTauProducer = cms.InputTag('hpsPFTauProducer'),
@@ -742,95 +752,103 @@ hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWdR03oldDMwLT.mapping[0].cut = 
 hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWdR03oldDMwLT = hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWdR03oldDMwLT.clone()
 hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWdR03oldDMwLT.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAPWdR03oldDMwLTv1_WPEff40")
 
-hpsPFTauMVAIsolation2Seq = cms.Sequence(
-    hpsPFTauChargedIsoPtSum
-   + hpsPFTauNeutralIsoPtSum
-   + hpsPFTauPUcorrPtSum
-   + hpsPFTauNeutralIsoPtSumWeight
-   + hpsPFTauFootprintCorrection
-   + hpsPFTauPhotonPtSumOutsideSignalCone
-   + hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw
-   + hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLT
-   + hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBoldDMwLT
-   + hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBoldDMwLT
-   + hpsPFTauDiscriminationByTightIsolationMVArun2v1DBoldDMwLT
-   + hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBoldDMwLT
-   + hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBoldDMwLT
-   + hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw
-   + hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT
-   + hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT
-   + hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT
-   + hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT
-   + hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT
-   + hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT
-   + hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLTraw
-   + hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWoldDMwLT
-   + hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWoldDMwLT
-   + hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWoldDMwLT
-   + hpsPFTauDiscriminationByTightIsolationMVArun2v1PWoldDMwLT
-   + hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWoldDMwLT
-   + hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWoldDMwLT
-   + hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLTraw
-   + hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT
-   + hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT
-   + hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT
-   + hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT
-   + hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT
-   + hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT
-   + hpsPFTauChargedIsoPtSumdR03
-   + hpsPFTauNeutralIsoPtSumdR03
-   + hpsPFTauPUcorrPtSumdR03
-   + hpsPFTauNeutralIsoPtSumWeightdR03
-   + hpsPFTauFootprintCorrectiondR03
-   + hpsPFTauPhotonPtSumOutsideSignalConedR03
-   + hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw
-   + hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBdR03oldDMwLT
-   + hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBdR03oldDMwLT
-   + hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBdR03oldDMwLT
-   + hpsPFTauDiscriminationByTightIsolationMVArun2v1DBdR03oldDMwLT
-   + hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBdR03oldDMwLT
-   + hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBdR03oldDMwLT
-   + hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw
-   + hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWdR03oldDMwLT
-   + hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWdR03oldDMwLT
-   + hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWdR03oldDMwLT
-   + hpsPFTauDiscriminationByTightIsolationMVArun2v1PWdR03oldDMwLT
-   + hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWdR03oldDMwLT
-   + hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWdR03oldDMwLT
+hpsPFTauMVAIsolation2Task = cms.Task(
+    hpsPFTauChargedIsoPtSum,
+    hpsPFTauNeutralIsoPtSum,
+    hpsPFTauPUcorrPtSum,
+    hpsPFTauNeutralIsoPtSumWeight,
+    hpsPFTauFootprintCorrection,
+    hpsPFTauPhotonPtSumOutsideSignalCone,
+    hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw,
+    hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLT,
+    hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBoldDMwLT,
+    hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBoldDMwLT,
+    hpsPFTauDiscriminationByTightIsolationMVArun2v1DBoldDMwLT,
+    hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBoldDMwLT,
+    hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBoldDMwLT,
+    hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw,
+    hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT,
+    hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT,
+    hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT,
+    hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT,
+    hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT,
+    hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT,
+    hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLTraw,
+    hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWoldDMwLT,
+    hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWoldDMwLT,
+    hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWoldDMwLT,
+    hpsPFTauDiscriminationByTightIsolationMVArun2v1PWoldDMwLT,
+    hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWoldDMwLT,
+    hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWoldDMwLT,
+    hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLTraw,
+    hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT,
+    hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT,
+    hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT,
+    hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT,
+    hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT,
+    hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT,
+    hpsPFTauChargedIsoPtSumdR03,
+    hpsPFTauNeutralIsoPtSumdR03,
+    hpsPFTauPUcorrPtSumdR03,
+    hpsPFTauNeutralIsoPtSumWeightdR03,
+    hpsPFTauFootprintCorrectiondR03,
+    hpsPFTauPhotonPtSumOutsideSignalConedR03,
+    hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw,
+    hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBdR03oldDMwLT,
+    hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBdR03oldDMwLT,
+    hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBdR03oldDMwLT,
+    hpsPFTauDiscriminationByTightIsolationMVArun2v1DBdR03oldDMwLT,
+    hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBdR03oldDMwLT,
+    hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBdR03oldDMwLT,
+    hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw,
+    hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWdR03oldDMwLT,
+    hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWdR03oldDMwLT,
+    hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWdR03oldDMwLT,
+    hpsPFTauDiscriminationByTightIsolationMVArun2v1PWdR03oldDMwLT,
+    hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWdR03oldDMwLT,
+    hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWdR03oldDMwLT
 )    
-
-produceHPSPFTaus = cms.Sequence(
-    hpsSelectionDiscriminator
-    #*hpsTightIsolationCleaner
-    #*hpsMediumIsolationCleaner
-    #*hpsLooseIsolationCleaner
-    #*hpsVLooseIsolationCleaner
-    *hpsPFTauProducerSansRefs
-    *hpsPFTauProducer
+hpsPFTauMVAIsolation2Seq = cms.Sequence(
+    hpsPFTauMVAIsolation2Task
 )
 
+produceHPSPFTausTask = cms.Task(
+    hpsSelectionDiscriminator,
+    #hpsTightIsolationCleaner,
+    #hpsMediumIsolationCleaner,
+    #hpsLooseIsolationCleaner,
+    #hpsVLooseIsolationCleaner,
+    hpsPFTauProducerSansRefs,
+    hpsPFTauProducer
+)
+produceHPSPFTaus = cms.Sequence(
+    produceHPSPFTausTask
+)
+produceAndDiscriminateHPSPFTausTask = cms.Task(
+    produceHPSPFTausTask,
+    hpsPFTauDiscriminationByDecayModeFindingNewDMs,
+    hpsPFTauDiscriminationByDecayModeFindingOldDMs,
+    hpsPFTauDiscriminationByDecayModeFinding, # CV: kept for backwards compatibility
+    hpsPFTauDiscriminationByLooseChargedIsolation,
+    hpsPFTauDiscriminationByLooseIsolation,
+    hpsPFTauDiscriminationByCombinedIsolationDBSumPtCorr3HitsTask,
+    hpsPFTauDiscriminationByCombinedIsolationDBSumPtCorr3HitsdR03Task,
+    hpsPFTauDiscriminationByPileupWeightedIsolation3HitsTask,
+    hpsPFTauDiscriminationByLooseElectronRejection,
+    hpsPFTauDiscriminationByMediumElectronRejection,
+    hpsPFTauDiscriminationByTightElectronRejection,
+    hpsPFTauDiscriminationByMVA6rawElectronRejection,
+    hpsPFTauDiscriminationByMVA6VLooseElectronRejection,
+    hpsPFTauDiscriminationByMVA6LooseElectronRejection,
+    hpsPFTauDiscriminationByMVA6MediumElectronRejection,
+    hpsPFTauDiscriminationByMVA6TightElectronRejection,
+    hpsPFTauDiscriminationByMVA6VTightElectronRejection,
+    hpsPFTauDiscriminationByDeadECALElectronRejection,
+    hpsPFTauDiscriminationByLooseMuonRejection3,
+    hpsPFTauDiscriminationByTightMuonRejection3,
+    hpsPFTauVertexAndImpactParametersTask,
+    hpsPFTauMVAIsolation2Task
+)
 produceAndDiscriminateHPSPFTaus = cms.Sequence(
-    produceHPSPFTaus*
-    hpsPFTauDiscriminationByDecayModeFindingNewDMs*
-    hpsPFTauDiscriminationByDecayModeFindingOldDMs*
-    hpsPFTauDiscriminationByDecayModeFinding* # CV: kept for backwards compatibility
-    hpsPFTauDiscriminationByLooseChargedIsolation*
-    hpsPFTauDiscriminationByLooseIsolation*
-    hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3Hits*
-    hpsPFTauDiscriminationByCombinedIsolationSeqDBSumPtCorr3HitsdR03*
-    hpsPFTauDiscriminationByPileupWeightedIsolationSeq3Hits*
-    hpsPFTauDiscriminationByLooseElectronRejection*
-    hpsPFTauDiscriminationByMediumElectronRejection*
-    hpsPFTauDiscriminationByTightElectronRejection*
-    hpsPFTauDiscriminationByMVA6rawElectronRejection*
-    hpsPFTauDiscriminationByMVA6VLooseElectronRejection*
-    hpsPFTauDiscriminationByMVA6LooseElectronRejection*
-    hpsPFTauDiscriminationByMVA6MediumElectronRejection*
-    hpsPFTauDiscriminationByMVA6TightElectronRejection*
-    hpsPFTauDiscriminationByMVA6VTightElectronRejection*
-    hpsPFTauDiscriminationByDeadECALElectronRejection*
-    hpsPFTauDiscriminationByLooseMuonRejection3*
-    hpsPFTauDiscriminationByTightMuonRejection3*
-    hpsPFTauVertexAndImpactParametersSeq*
-    hpsPFTauMVAIsolation2Seq
+    produceAndDiscriminateHPSPFTausTask
 )

--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -87,23 +87,31 @@ recoTauPileUpVertices = cms.EDFilter("RecoTauPileUpVertexSelector",
     filter = cms.bool(False),
 )
 
-recoTauCommonSequence = cms.Sequence(
-    ak4PFJetTracksAssociatorAtVertex *
-    recoTauAK4PFJets08Region *
-    recoTauPileUpVertices *
+recoTauCommonTask = cms.Task(
+    ak4PFJetTracksAssociatorAtVertex,
+    recoTauAK4PFJets08Region,
+    recoTauPileUpVertices,
     pfRecoTauTagInfoProducer
+)
+recoTauCommonSequence = cms.Sequence(
+    recoTauCommonTask
 )
 
 # Produce only classic HPS taus
+recoTauClassicHPSTask = cms.Task(
+    ak4PFJetsLegacyHPSPiZeros,
+    ak4PFJetsRecoTauChargedHadrons,
+    combinatoricRecoTaus,
+    produceAndDiscriminateHPSPFTausTask
+)
 recoTauClassicHPSSequence = cms.Sequence(
-    ak4PFJetsLegacyHPSPiZeros *
-    ak4PFJetsRecoTauChargedHadrons *
-    combinatoricRecoTaus *
-    produceAndDiscriminateHPSPFTaus
+    recoTauClassicHPSTask
 )
 
+PFTauTask = cms.Task(
+    recoTauCommonTask,
+    recoTauClassicHPSTask
+)
 PFTau = cms.Sequence(
-    recoTauCommonSequence *
-    recoTauClassicHPSSequence
+    PFTauTask
 )
-


### PR DESCRIPTION
As title says, this PR consists of set of changes to migrate PFTau reco configuration from the classic cms.Sequence based to the cms.Task based. 

Changes are not expected in standard workflows.

Implemented in a context of 80XLegacy rereco, but generally not  related to the rereco itself => changes not expected on top of #58.
 