### PR TITLE
Switch to allow/disallow skipping missing tauID products

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -93,7 +93,7 @@ namespace pat {
       std::vector<NameTag> tauIDSrcs_;
       std::vector<edm::EDGetTokenT<reco::CaloTauDiscriminator> > caloTauIDTokens_;
       std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > pfTauIDTokens_;
-
+      bool          skipMissingTauID_;
       // tools
       GreaterByPt<Tau>       pTTauComparator_;
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py
@@ -134,7 +134,7 @@ patTaus = cms.EDProducer("PATTauProducer",
         againstElectronTightMVA6 = cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection"),
         againstElectronVTightMVA6 = cms.InputTag("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),
     ),
-
+    skipMissingTauID = cms.bool(False), #Allow to skip a tau ID variable when not present in the event"
     # mc matching configurables
     addGenMatch      = cms.bool(True),
     embedGenMatch    = cms.bool(True),

--- a/PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py
+++ b/PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py
@@ -10,6 +10,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 ## to run in un-scheduled mode uncomment the following lines
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+# Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_PATandPF2PAT_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_PATandPF2PAT_cfg.py
@@ -17,6 +17,8 @@ else:
 # load the PAT config (for the PAT only part)
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_PF2PAT_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_PF2PAT_cfg.py
@@ -1,5 +1,6 @@
 ## import skeleton process
 from PhysicsTools.PatAlgos.patTemplate_cfg import *
+
 # verbose flags for the PF2PAT modules
 
 #process.Tracer = cms.Service("Tracer")
@@ -10,6 +11,8 @@ from PhysicsTools.PatAlgos.tools.pfTools import *
 postfix = "PFlow"
 jetAlgo="AK4"
 usePF2PAT(process,runPF2PAT=True, jetAlgo=jetAlgo, runOnMC=True, postfix=postfix)
+#Temporary customize to the unit tests that fail due to old input samples
+getattr(process,"patTaus"+postfix).skipMissingTauID = True
 
 # to turn on type-1 MET corrections, use the following call
 #usePF2PAT(process,runPF2PAT=True, jetAlgo=jetAlgo, runOnMC=True, postfix=postfix, typeIMetCorrections=True)

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -4,6 +4,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 ## to run in un-scheduled mode uncomment the following lines
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py
@@ -6,6 +6,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 # load the PAT config
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_addTracks_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addTracks_cfg.py
@@ -5,6 +5,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_addTriggerInfo_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addTriggerInfo_cfg.py
@@ -8,6 +8,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 # Load default PAT
 process.load( "PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff" )
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load( "PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff" )
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_addVertexInfo_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addVertexInfo_cfg.py
@@ -5,6 +5,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_data_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_data_cfg.py
@@ -48,6 +48,8 @@ process.outpath = cms.EndPath(
 ## Processing
 process.load( "PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff" )
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load( "PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff" )
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_fastsim_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_fastsim_cfg.py
@@ -5,6 +5,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py
@@ -3,6 +3,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_standard_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_standard_cfg.py
@@ -5,6 +5,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)


### PR DESCRIPTION
Add a switch to allow/disallow skipping missing tauID products. The switch is set to False (disallows skipping) by default. The switch is set to True for a set of PAT unit tests to pass them when run on old inputs w/o reruning RECO/AOD