### PR TITLE
Temporary customize to the unit tests that fail due to old input samples

### DIFF
--- a/PhysicsTools/PatAlgos/test/patMiniAOD_standard_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patMiniAOD_standard_cfg.py
@@ -5,6 +5,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import cms, process, patAlgosToolsTas
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -5,6 +5,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 patAlgosToolsTask.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 patAlgosToolsTask.add(process.selectedPatCandidatesTask)

--- a/PhysicsTools/PatAlgos/test/patTuple_onlyTaus_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_onlyTaus_cfg.py
@@ -6,6 +6,8 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import *
 ## load tau sequences up to selectedPatTaus
 process.load("PhysicsTools.PatAlgos.producersLayer1.tauProducer_cff")
 patAlgosToolsTask.add(process.makePatTausTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.tauSelector_cfi")
 patAlgosToolsTask.add(process.selectedPatTaus)
 


### PR DESCRIPTION
As title says: temporary customize to the unit tests that fail due to old input samples. Second bunch tests forgotten in the first go (previous PR).