### PR TITLE
Customize to the unit tests that fail due to old input samples

### DIFF
--- a/TopQuarkAnalysis/Examples/test/analyzeTopElectron_cfg.py
+++ b/TopQuarkAnalysis/Examples/test/analyzeTopElectron_cfg.py
@@ -35,6 +35,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/Examples/test/analyzeTopHypotheses_cfg.py
+++ b/TopQuarkAnalysis/Examples/test/analyzeTopHypotheses_cfg.py
@@ -42,6 +42,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/Examples/test/analyzeTopJet_cfg.py
+++ b/TopQuarkAnalysis/Examples/test/analyzeTopJet_cfg.py
@@ -35,6 +35,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/Examples/test/analyzeTopMuon_cfg.py
+++ b/TopQuarkAnalysis/Examples/test/analyzeTopMuon_cfg.py
@@ -35,6 +35,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/Examples/test/analyzeTopTau_cfg.py
+++ b/TopQuarkAnalysis/Examples/test/analyzeTopTau_cfg.py
@@ -35,6 +35,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventProducers/test/tqaf_cfg.py
+++ b/TopQuarkAnalysis/TopEventProducers/test/tqaf_cfg.py
@@ -32,6 +32,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventProducers/test/tqaf_woGeneratorInfo_cfg.py
+++ b/TopQuarkAnalysis/TopEventProducers/test/tqaf_woGeneratorInfo_cfg.py
@@ -36,6 +36,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventProducers/test/ttFullHadEvtBuilder_cfg.py
+++ b/TopQuarkAnalysis/TopEventProducers/test/ttFullHadEvtBuilder_cfg.py
@@ -38,6 +38,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventProducers/test/ttFullLepEvtBuilder_cfg.py
+++ b/TopQuarkAnalysis/TopEventProducers/test/ttFullLepEvtBuilder_cfg.py
@@ -38,6 +38,8 @@ process.task = cms.Task()
 ## std sequence for pat
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventProducers/test/ttSemiLepEvtBuilder_cfg.py
+++ b/TopQuarkAnalysis/TopEventProducers/test/ttSemiLepEvtBuilder_cfg.py
@@ -40,6 +40,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVAComputer_cfg.py
+++ b/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVAComputer_cfg.py
@@ -82,6 +82,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 process.load("TopQuarkAnalysis.TopEventSelection.TtFullHadSignalSelMVAComputer_cff")

--- a/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVATrainTreeSaver_cfg.py
+++ b/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVATrainTreeSaver_cfg.py
@@ -35,6 +35,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 

--- a/TopQuarkAnalysis/TopEventSelection/test/ttSemiLepSignalSelMVAComputer_cfg.py
+++ b/TopQuarkAnalysis/TopEventSelection/test/ttSemiLepSignalSelMVAComputer_cfg.py
@@ -34,6 +34,8 @@ process.task = cms.Task()
 ## std sequence for PAT
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 process.load("TopQuarkAnalysis.TopEventSelection.TtSemiLepSignalSelMVAComputer_cff")

--- a/TopQuarkAnalysis/TopEventSelection/test/ttSemiLepSignalSelMVATrainTreeSaver_cfg.py
+++ b/TopQuarkAnalysis/TopEventSelection/test/ttSemiLepSignalSelMVATrainTreeSaver_cfg.py
@@ -34,6 +34,8 @@ process.task = cms.Task()
 ## std sequence for pat
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.task.add(process.patCandidatesTask)
+#Temporary customize to the unit tests that fail due to old input samples
+process.patTaus.skipMissingTauID = True
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 process.task.add(process.selectedPatCandidatesTask)
 


### PR DESCRIPTION
Temporary customize to the unit tests in the TopQuarkAnalysis packages that fail due to old RECO/AOD input samples; completing #21022 (update to MVAIso 2017v1).
