### PR TITLE
Small tau IP fixes

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -429,7 +429,6 @@ hpsPFTauPrimaryVertexProducer = PFTauPrimaryVertexProducer.clone(
     MuonTag = cms.InputTag(""),
     PVTag = cms.InputTag("offlinePrimaryVertices"),
     beamSpot = cms.InputTag("offlineBeamSpot"),
-    TrackCollectionTag = cms.InputTag("generalTracks"),
     Algorithm = cms.int32(0),
     useBeamSpot = cms.bool(True),
     RemoveMuonTracks = cms.bool(False),

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -85,9 +85,6 @@ class PFTauPrimaryVertexProducer final : public edm::stream::EDProducer<> {
   edm::EDGetTokenT<reco::VertexCollection> PVToken_;
   edm::InputTag beamSpotTag_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-  edm::InputTag TrackCollectionTag_;
-  edm::EDGetTokenT<reco::TrackCollection> TrackCollectionToken_;
-  edm::InputTag TracksTag_;
   int Algorithm_;
   edm::ParameterSet qualityCutsPSet_;
   bool useBeamSpot_;
@@ -110,8 +107,6 @@ PFTauPrimaryVertexProducer::PFTauPrimaryVertexProducer(const edm::ParameterSet& 
   PVToken_(consumes<reco::VertexCollection>(PVTag_)),
   beamSpotTag_(iConfig.getParameter<edm::InputTag>("beamSpot")),
   beamSpotToken_(consumes<reco::BeamSpot>(beamSpotTag_)),
-  TrackCollectionTag_(iConfig.getParameter<edm::InputTag>("TrackCollectionTag")),
-  TrackCollectionToken_(consumes<reco::TrackCollection>(TrackCollectionTag_)),
   Algorithm_(iConfig.getParameter<int>("Algorithm")),
   qualityCutsPSet_(iConfig.getParameter<edm::ParameterSet>("qualityCuts")),
   useBeamSpot_(iConfig.getParameter<bool>("useBeamSpot")),
@@ -161,8 +156,6 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByToken(beamSpotToken_,beamSpot);
 
-  edm::Handle<reco::TrackCollection> trackCollection;
-  iEvent.getByToken(TrackCollectionToken_,trackCollection);
 
   // Set Association Map
   auto AVPFTauPV = std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>>(PFTauRefProd(Tau));
@@ -238,21 +231,6 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// Get Non-Tau tracks
 	reco::TrackCollection nonTauTracks;
-// 	if (trackCollection.isValid()) {
-// 	  // remove tau tracks and only tracks associated with the vertex
-// 	  unsigned int idx = 0;
-// 	  for (reco::TrackCollection::const_iterator iTrk = trackCollection->begin(); iTrk != trackCollection->end(); ++iTrk, idx++) {
-// 	    reco::TrackRef tmpRef(trackCollection, idx);
-// 	    reco::TrackRef tmpRefForBase=tmpRef;
-// 	    bool isSigTrk = false;
-// 	    bool fromVertex=false;
-// 	    for (unsigned int sigTrk = 0; sigTrk < SignalTracks.size(); sigTrk++) {
-// 	      if (reco::TrackBaseRef(tmpRefForBase)==SignalTracks.at(sigTrk)){isSigTrk = true; break;}
-// 	    }
-// 	  if (!isSigTrk) nonSigTracks.push_back(*iTrk);
-// 	  }
-// 	}
-	
 	for(std::vector<reco::TrackBaseRef>::const_iterator vtxTrkRef=thePV.tracks_begin();vtxTrkRef<thePV.tracks_end();vtxTrkRef++){
 	  bool matched = false;
 	  for (unsigned int sigTrk = 0; sigTrk < SignalTracks.size(); sigTrk++) {

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -156,7 +156,6 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByToken(beamSpotToken_,beamSpot);
 
-
   // Set Association Map
   auto AVPFTauPV = std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>>(PFTauRefProd(Tau));
   auto VertexCollection_out = std::make_unique<VertexCollection>();

--- a/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
@@ -22,7 +22,6 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
-#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
 #include "RecoBTag/SecondaryVertex/interface/SecondaryVertex.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "RecoVertex/VertexPrimitives/interface/ConvertToFromReco.h"
@@ -31,15 +30,10 @@
 
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/EgammaCandidates/interface/Electron.h"
-#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterFwd.h"
 
@@ -56,7 +50,6 @@ using namespace std;
 
 class PFTauTransverseImpactParameters : public edm::stream::EDProducer<> {
  public:
-  enum Alg{useInputPV=0, useFont};
   enum CMSSWPerigee{aCurv=0,aTheta,aPhi,aTip,aLip};
   explicit PFTauTransverseImpactParameters(const edm::ParameterSet& iConfig);
   ~PFTauTransverseImpactParameters() override;
@@ -113,9 +106,14 @@ void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::Even
       double ip3d(-999), ip3d_err(-999);
       reco::Vertex::Point ip3d_poca(0,0,0);
       if(RefPFTau->leadPFChargedHadrCand().isNonnull()){
-	if(RefPFTau->leadPFChargedHadrCand()->trackRef().isNonnull()){
+	const reco::Track* track = nullptr;
+	if(RefPFTau->leadPFChargedHadrCand()->trackRef().isNonnull())
+	  track = RefPFTau->leadPFChargedHadrCand()->trackRef().get();
+	else if(RefPFTau->leadPFChargedHadrCand()->gsfTrackRef().isNonnull())
+	  track = RefPFTau->leadPFChargedHadrCand()->gsfTrackRef().get();
+	if(track != nullptr){
 	  if(useFullCalculation_){
-	    reco::TransientTrack transTrk=transTrackBuilder->build(RefPFTau->leadPFChargedHadrCand()->trackRef());
+	    reco::TransientTrack transTrk=transTrackBuilder->build(*track);
 	    GlobalVector direction(RefPFTau->p4().px(), RefPFTau->p4().py(), RefPFTau->p4().pz()); //To compute sign of IP
 	    std::pair<bool,Measurement1D> signed_IP2D = IPTools::signedTransverseImpactParameter(transTrk, direction, (*PV));
 	    dxy=signed_IP2D.second.value();
@@ -131,10 +129,10 @@ void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::Even
 	    ip3d_poca=reco::Vertex::Point(pos3d.x(),pos3d.y(),pos3d.z());
 	  }
 	  else{
-	    dxy_err=RefPFTau->leadPFChargedHadrCand()->trackRef()->d0Error();
-	    dxy=RefPFTau->leadPFChargedHadrCand()->trackRef()->dxy(PV->position());
-	    ip3d_err=RefPFTau->leadPFChargedHadrCand()->trackRef()->dzError(); //store dz, ip3d not available
-	    ip3d=RefPFTau->leadPFChargedHadrCand()->trackRef()->dz(PV->position()); //store dz, ip3d not available 
+	    dxy_err=track->d0Error();
+	    dxy=track->dxy(PV->position());
+	    ip3d_err=track->dzError(); //store dz, ip3d not available
+	    ip3d=track->dz(PV->position()); //store dz, ip3d not available
 	  }
 	}
       }

--- a/RecoTauTag/RecoTau/python/PFTauPrimaryVertexProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFTauPrimaryVertexProducer_cfi.py
@@ -6,7 +6,6 @@ PFTauPrimaryVertexProducer = cms.EDProducer("PFTauPrimaryVertexProducer",
                                             MuonTag = cms.InputTag("MyMuons"),
                                             PVTag = cms.InputTag("offlinePrimaryVertices"),
                                             beamSpot = cms.InputTag("offlineBeamSpot"),
-                                            TrackCollectionTag = cms.InputTag("generalTracks"),
                                             #Algorithm: 0 - use tau-jet vertex, 1 - use vertex[0]
                                             Algorithm = cms.int32(0),
                                             qualityCuts = PFTauQualityCuts,


### PR DESCRIPTION
This is a set of small changes in tau modules for computation of impact parameters identifed during work on tau reco&Id on top of MiniAOD. Namely, it concerns:
* Fix in the RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc module allowing to use a gsfTrack associated to the tau leading charged candidate when it does not posses a KFTrack. It happens for candidates identified by PFlow as electrons (id==+-11). Usage of gsfTrack in a such case is a standard procedure in other tau modules, e.g. PV and SV producers.
* Cleaning of unused code: usually removal of not needed includes, once removal of a handle of not used collection.

The changes will result in small changes in reconstructed impact parameters and output of MVAIso discriminants.

As the changes are small, I propose to integrate them into official CMSSW soon to not interfere with other, more complex, developments, e.g. cleaning by Alex Toldaiev.
