### PR TITLE
Modified MVAIso tau-id 2017v1 for miniAODv2 with 94X (X>3)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -330,6 +330,11 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 	  edm::Handle<reco::CaloTauDiscriminator> caloTauIdDiscr;
 	  iEvent.getByToken(caloTauIDTokens_[i], caloTauIdDiscr);
 
+	  if(!caloTauIdDiscr.isValid()){
+	    edm::LogWarning("DataSource") << "Tau discriminator '" << tauIDSrcs_[i].first
+					  << "' has not been found in the event. It will not be embedded into the pat::Tau object.";
+	    continue;
+	  }
 	  ids[i].first = tauIDSrcs_[i].first;
 	  ids[i].second = getTauIdDiscriminator(caloTauCollection, idx, caloTauIdDiscr);
 	} else {

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -372,7 +372,7 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 	sumPhiTimesEnergy += icand->positionAtECALEntrance().phi()*icand->energy();		
 	sumEtaTimesEnergy += icand->positionAtECALEntrance().eta()*icand->energy();
         sumEnergy += icand->energy();	 
-	const reco::Track* track = 0;
+	const reco::Track* track = nullptr;
      	if ( icand->trackRef().isNonnull() ) track = icand->trackRef().get();
      	else if ( icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull()  ) track = icand->muonRef()->innerTrack().get();
      	else if ( icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull() ) track = icand->muonRef()->globalTrack().get();

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -315,6 +315,11 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 	  edm::Handle<reco::PFTauDiscriminator> pfTauIdDiscr;
 	  iEvent.getByToken(pfTauIDTokens_[i], pfTauIdDiscr);
 
+	  if(!pfTauIdDiscr.isValid()){
+	    edm::LogWarning("DataSource") << "Tau discriminator '" << tauIDSrcs_[i].first
+					  << "' has not been found in the event. It will not be embedded into the pat::Tau object.";
+	    continue;
+	  }
 	  ids[i].first = tauIDSrcs_[i].first;
 	  ids[i].second = getTauIdDiscriminator(pfTauCollection, idx, pfTauIdDiscr);
 	} else if ( typeid(*tausRef) == typeid(reco::CaloTau) ) {

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -93,7 +93,7 @@ namespace pat {
       std::vector<NameTag> tauIDSrcs_;
       std::vector<edm::EDGetTokenT<reco::CaloTauDiscriminator> > caloTauIDTokens_;
       std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > pfTauIDTokens_;
-
+      bool          skipMissingTauID_;
       // tools
       GreaterByPt<Tau>       pTTauComparator_;
 

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -48,9 +48,9 @@ namespace pat {
     public:
 
       explicit PATTauProducer(const edm::ParameterSet & iConfig);
-      ~PATTauProducer();
+      ~PATTauProducer() override;
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+      void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -55,7 +55,8 @@ namespace pat {
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
     private:
-      
+      bool firstOccurence_; // used to print LogWarnings only at first occurnece in the event loop
+
       // configurables
       edm::EDGetTokenT<edm::View<reco::BaseTau> > baseTauToken_;
       edm::EDGetTokenT<PFTauTIPAssociationByRef> tauTransverseImpactParameterToken_;

--- a/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py
@@ -133,7 +133,7 @@ patTaus = cms.EDProducer("PATTauProducer",
         againstElectronTightMVA6 = cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection"),
         againstElectronVTightMVA6 = cms.InputTag("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),
     ),
-
+    skipMissingTauID = cms.bool(False), #Allow to skip a tau ID variable when not present in the event"
     # mc matching configurables
     addGenMatch      = cms.bool(True),
     embedGenMatch    = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -323,6 +323,10 @@ def miniAOD_customizeCommon(process):
     from RecoTauTag.Configuration.boostedHPSPFTaus_cfi import addBoostedTaus
     addBoostedTaus(process)
     #---------------------------------------------------------------------------
+    #Modify taus by adding MVAIso tau-Ids with 2017v1 training for 94X MiniAODv2
+    from RecoTauTag.Configuration.updateHPSPFTaus import cloneAndModifyMVAIsolationFor94XMiniAODv2
+    cloneAndModifyMVAIsolationFor94XMiniAODv2(process)
+    #---------------------------------------------------------------------------
     #Adding tau reco for 80X legacy reMiniAOD
     #make a copy of makePatTauTask to avoid labels and substitution problems
     _makePatTausTaskWithTauReReco = process.makePatTausTask.copy()

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -248,7 +248,7 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2016.items():
     )
 tauIdDiscrMVA_2017_version = "v1"
 for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2017.items():
-    process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(
             record = cms.string('GBRWrapperRcd'),
             tag = cms.string("RecoTauTag_%s%s" % (gbrForestName, tauIdDiscrMVA_2017_version)),
@@ -256,7 +256,7 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2017.items():
         )
     )
     for WP in tauIdDiscrMVA_WPs_run2_2017[training].keys():
-        process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+        loadRecoTauTagMVAsFromPrepDB.toGet.append(
             cms.PSet(
                 record = cms.string('PhysicsTGraphPayloadRcd'),
                 tag = cms.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, tauIdDiscrMVA_2017_version, WP)),
@@ -267,7 +267,7 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2017.items():
 	cms.PSet(
 	    record = cms.string('PhysicsTFormulaPayloadRcd'),
 	    tag = cms.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017_version)),
-	    label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017version))
+	    label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017_version))
 	)
     )
 

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -39,6 +39,9 @@ tauIdDiscrMVA_trainings_run2_2016 = {
     'tauIdMVAIsoDBoldDMwLT2016' : "tauIdMVAIsoDBoldDMwLT2016",
     'tauIdMVAIsoDBnewDMwLT2016' : "tauIdMVAIsoDBnewDMwLT2016"
 }
+tauIdDiscrMVA_trainings_run2_2017 = {
+    'tauIdMVAIsoDBoldDMwLT2017' : "tauIdMVAIsoDBoldDMwLT2017",
+}
 tauIdDiscrMVA_WPs = {
     'tauIdMVAoldDMwoLT' : {
         'Eff90' : "oldDMwoLTEff90",
@@ -141,6 +144,17 @@ tauIdDiscrMVA_WPs_run2_2016 = {
 	'Eff40' : "DBnewDMwLT2016Eff40"
     }
 }
+tauIdDiscrMVA_WPs_run2_2017 = {
+    'tauIdMVAIsoDBoldDMwLT2017' : {
+        'Eff95' : "DBoldDMwLTEff95",
+        'Eff90' : "DBoldDMwLTEff90",
+        'Eff80' : "DBoldDMwLTEff80",
+        'Eff70' : "DBoldDMwLTEff70",
+        'Eff60' : "DBoldDMwLTEff60",
+        'Eff50' : "DBoldDMwLTEff50",
+        'Eff40' : "DBoldDMwLTEff40"
+    }
+}
 tauIdDiscrMVA_mvaOutput_normalizations = {
     'tauIdMVAoldDMwoLT' : "mvaOutput_normalization_oldDMwoLT",
     'tauIdMVAoldDMwLT'  : "mvaOutput_normalization_oldDMwLT",
@@ -158,6 +172,9 @@ tauIdDiscrMVA_mvaOutput_normalizations_run2 = {
 tauIdDiscrMVA_mvaOutput_normalizations_run2_2016 = {
     'tauIdMVAIsoDBoldDMwLT2016' : "mvaOutput_normalization_DBoldDMwLT2016",
     'tauIdMVAIsoDBnewDMwLT2016' : "mvaOutput_normalization_DBnewDMwLT2016"
+}
+tauIdDiscrMVA_mvaOutput_normalizations_run2_2017 = {
+    'tauIdMVAIsoDBoldDMwLT2017' : "mvaOutput_normalization"
 }
 tauIdDiscrMVA_version = "v1"
 for training, gbrForestName in tauIdDiscrMVA_trainings.items():
@@ -229,7 +246,32 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2016.items():
 	    label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_version))
 	)
     )
+tauIdDiscrMVA_2017_version = "v1"
+for training, gbrForestName in tauIdDiscrMVA_trainings_run2_2017.items():
+    process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+        cms.PSet(
+            record = cms.string('GBRWrapperRcd'),
+            tag = cms.string("RecoTauTag_%s%s" % (gbrForestName, tauIdDiscrMVA_2017_version)),
+            label = cms.untracked.string("RecoTauTag_%s%s" % (gbrForestName, tauIdDiscrMVA_2017_version))
+        )
+    )
+    for WP in tauIdDiscrMVA_WPs_run2_2017[training].keys():
+        process.loadRecoTauTagMVAsFromPrepDB.toGet.append(
+            cms.PSet(
+                record = cms.string('PhysicsTGraphPayloadRcd'),
+                tag = cms.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, tauIdDiscrMVA_2017_version, WP)),
+                label = cms.untracked.string("RecoTauTag_%s%s_WP%s" % (gbrForestName, tauIdDiscrMVA_2017_version, WP))
+            )
+        )
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
+	cms.PSet(
+	    record = cms.string('PhysicsTFormulaPayloadRcd'),
+	    tag = cms.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017_version)),
+	    label = cms.untracked.string("RecoTauTag_%s%s_mvaOutput_normalization" % (gbrForestName, tauIdDiscrMVA_2017version))
+	)
+    )
 
+####
 # register anti-electron discriminator MVA
 antiElectronDiscrMVA5_categories = {
      '0' : "gbr_NoEleMatch_woGwoGSF_BL",

--- a/RecoTauTag/Configuration/python/updateHPSPFTaus.py
+++ b/RecoTauTag/Configuration/python/updateHPSPFTaus.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+'''
+Tools to update tau configuration for special runs like re-MiniAOD production
+'''
+
+# Update MVAIso tau-Id for MiniAODv2 production with CMSSW_9_4_X (X>3) 
+def cloneAndModifyMVAIsolationFor94XMiniAODv2(process):
+    process.load("RecoTauTag.Configuration.RecoPFTauTag_cff")
+    ##Clone and modify modules of interest
+    process.hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTrawMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw.clone(
+        mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1"),
+        mvaOpt = cms.string("DBoldDMwLTwGJ")
+    )
+    process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLT.clone(
+        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization") 
+    )
+    process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff90")
+    process.hpsPFTauDiscriminationByVVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()
+    process.hpsPFTauDiscriminationByVVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff95")
+    process.hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()
+    process.hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff80")
+    process.hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()
+    process.hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff70")
+    process.hpsPFTauDiscriminationByTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()
+    process.hpsPFTauDiscriminationByTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff60")
+    process.hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()
+    process.hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff50")
+    process.hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()
+    process.hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff40")    
+    #create a new task and put the moduled therin
+    process.hpsPFTauMVAIsoFor94XMiniv2Task = cms.Task()
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTrawMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByVVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    process.hpsPFTauMVAIsoFor94XMiniv2Task.add(process.hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2)
+    #Add all this to makePatTausTask
+    process.makePatTausTask.add(process.hpsPFTauMVAIsoFor94XMiniv2Task)
+    #Now modify patTau by replacing old by new discriminats
+    process.patTaus.tauIDSources.byIsolationMVArun2v1DBoldDMwLTraw = cms.InputTag("hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTrawMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byVVLooseIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByVVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byVLooseIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byLooseIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byMediumIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byTightIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byVTightIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")
+    process.patTaus.tauIDSources.byVVTightIsolationMVArun2v1DBoldDMwLT = cms.InputTag("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2")

--- a/RecoTauTag/Configuration/python/updateHPSPFTaus.py
+++ b/RecoTauTag/Configuration/python/updateHPSPFTaus.py
@@ -13,7 +13,9 @@ def cloneAndModifyMVAIsolationFor94XMiniAODv2(process):
         mvaOpt = cms.string("DBoldDMwLTwGJ")
     )
     process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLT.clone(
-        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization") 
+        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_mvaOutput_normalization"),
+        key = cms.InputTag("hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTrawMVAIsoFor94XMiniv2","category"),
+        toMultiplex = cms.InputTag("hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTrawMVAIsoFor94XMiniv2")
     )
     process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.mapping[0].cut = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT2017v1_WPEff90")
     process.hpsPFTauDiscriminationByVVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2 = process.hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBoldDMwLTMVAIsoFor94XMiniv2.clone()


### PR DESCRIPTION
This PR consists of modification of MiniAOD sequences by adding MVAIso tau-id discriminants trained with 2017 MCv1. The modification impacts both standard and legacy80X workflows via updated makePatTausTask.

In addition to the tau-Id modification the PR consists of protection of PATTauProducer plugin against newly added tau-Ids. This feature is backported from 100X releases.

P.S. Please start your tests. From my side the stuff looks be working, but massive tests (performances) are still ongoing. I'll keep you posted
