### PR TITLE
Tau reconstruction on MiniAOD input

### DIFF
--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -23,6 +23,7 @@
 #include "DataFormats/PatCandidates/interface/Lepton.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 #include "DataFormats/PatCandidates/interface/TauPFSpecific.h"
 #include "DataFormats/PatCandidates/interface/TauCaloSpecific.h"
@@ -160,7 +161,7 @@ namespace pat {
       const pat::tau::TauPFEssential & pfEssential() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const reco::PFJetRef & pfJetRef() const { return pfSpecific().pfJetRef_; }
+      const reco::JetBaseRef & pfJetRef() const { return pfSpecific().pfJetRef_; }
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
       reco::PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;
@@ -178,16 +179,16 @@ namespace pat {
       const reco::PFCandidatePtr leadPFCand() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFCands() const;
+      const std::vector<reco::PFCandidatePtr> signalPFCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFChargedHadrCands() const;
+      const std::vector<reco::PFCandidatePtr> signalPFChargedHadrCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFNeutrHadrCands() const;
+      const std::vector<reco::PFCandidatePtr> signalPFNeutrHadrCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& signalPFGammaCands() const;
+      const std::vector<reco::PFCandidatePtr> signalPFGammaCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
       const std::vector<reco::PFRecoTauChargedHadron> & signalTauChargedHadronCandidates() const;
@@ -196,16 +197,16 @@ namespace pat {
       const std::vector<reco::RecoTauPiZero> & signalPiZeroCandidates() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFCands() const;
+      const std::vector<reco::PFCandidatePtr> isolationPFCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFChargedHadrCands() const;
+      const std::vector<reco::PFCandidatePtr> isolationPFChargedHadrCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFNeutrHadrCands() const;
+      const std::vector<reco::PFCandidatePtr> isolationPFNeutrHadrCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
-      const std::vector<reco::PFCandidatePtr>& isolationPFGammaCands() const;
+      const std::vector<reco::PFCandidatePtr> isolationPFGammaCands() const;
       /// Method copied from reco::PFTau. 
       /// Throws an exception if this pat::Tau was not made from a reco::PFTau
       const std::vector<reco::PFRecoTauChargedHadron> & isolationTauChargedHadronCandidates() const;

--- a/DataFormats/PatCandidates/interface/TauPFSpecific.h
+++ b/DataFormats/PatCandidates/interface/TauPFSpecific.h
@@ -24,21 +24,21 @@ struct TauPFSpecific {
 // constructor from PFTau
   TauPFSpecific(const reco::PFTau& tau);
 // datamembers 
-  reco::PFJetRef pfJetRef_;
-  reco::PFCandidatePtr leadPFChargedHadrCand_;
+  reco::JetBaseRef pfJetRef_;
+  reco::CandidatePtr leadPFChargedHadrCand_;
   float leadPFChargedHadrCandsignedSipt_;
-  reco::PFCandidatePtr leadPFNeutralCand_;
-  reco::PFCandidatePtr leadPFCand_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFChargedHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFNeutrHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedSignalPFGammaCands_;
+  reco::CandidatePtr leadPFNeutralCand_;
+  reco::CandidatePtr leadPFCand_;
+  std::vector<reco::CandidatePtr> selectedSignalPFCands_;
+  std::vector<reco::CandidatePtr> selectedSignalPFChargedHadrCands_;
+  std::vector<reco::CandidatePtr> selectedSignalPFNeutrHadrCands_;
+  std::vector<reco::CandidatePtr> selectedSignalPFGammaCands_;
   std::vector<reco::PFRecoTauChargedHadron> signalTauChargedHadronCandidates_;
   std::vector<reco::RecoTauPiZero> signalPiZeroCandidates_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFCands_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFChargedHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFNeutrHadrCands_;
-  std::vector<reco::PFCandidatePtr> selectedIsolationPFGammaCands_;
+  std::vector<reco::CandidatePtr> selectedIsolationPFCands_;
+  std::vector<reco::CandidatePtr> selectedIsolationPFChargedHadrCands_;
+  std::vector<reco::CandidatePtr> selectedIsolationPFNeutrHadrCands_;
+  std::vector<reco::CandidatePtr> selectedIsolationPFGammaCands_;
   std::vector<reco::PFRecoTauChargedHadron> isolationTauChargedHadronCandidates_;
   std::vector<reco::RecoTauPiZero> isolationPiZeroCandidates_;
   float isolationPFChargedHadrCandsPtSum_;

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -3,6 +3,7 @@
 
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include <algorithm>
 #include <boost/bind.hpp>
 
@@ -49,7 +50,31 @@ Tau::Tau(const reco::BaseTau & aTau) :
 {
     const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(&aTau);
     if (pfTau != nullptr){
-      pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
+      // If PFTau is made from PackedCandidates, directly fill slimmed version
+      // without PFSpecific
+      const pat::PackedCandidate* pc = dynamic_cast<const pat::PackedCandidate*>(pfTau->leadPFChargedHadrCand().get());
+      if (pc != nullptr) {
+        for (const auto& ptr : pfTau->signalPFChargedHadrCands())
+          signalChargedHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->signalPFNeutrHadrCands())
+          signalNeutralHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->signalPFGammaCands())
+          signalGammaCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFChargedHadrCands())
+        isolationChargedHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFNeutrHadrCands())
+          isolationNeutralHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFGammaCands())
+          isolationGammaCandPtrs_.push_back(ptr);
+      }
+      else {
+        pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
+      }
       pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
     }
     const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(&aTau);
@@ -76,7 +101,31 @@ Tau::Tau(const edm::RefToBase<reco::BaseTau> & aTauRef) :
 {
     const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(aTauRef.get());
     if (pfTau != nullptr){
-      pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
+      // If PFTau is made from PackedCandidates, directly fill slimmed version
+      // without PFSpecific
+      const pat::PackedCandidate* pc = dynamic_cast<const pat::PackedCandidate*>(pfTau->leadPFChargedHadrCand().get());
+      if (pc != nullptr) {
+        for (const auto& ptr : pfTau->signalPFChargedHadrCands())
+          signalChargedHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->signalPFNeutrHadrCands())
+          signalNeutralHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->signalPFGammaCands())
+          signalGammaCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFChargedHadrCands())
+        isolationChargedHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFNeutrHadrCands())
+          isolationNeutralHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFGammaCands())
+          isolationGammaCandPtrs_.push_back(ptr);
+      }
+      else {
+        pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
+      }
       pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
     }
     const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(aTauRef.get());
@@ -103,7 +152,31 @@ Tau::Tau(const edm::Ptr<reco::BaseTau> & aTauRef) :
 {
     const reco::PFTau * pfTau = dynamic_cast<const reco::PFTau *>(aTauRef.get());
     if (pfTau != nullptr){
-      pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
+      // If PFTau is made from PackedCandidates, directly fill slimmed version
+      // without PFSpecific
+      const pat::PackedCandidate* pc = dynamic_cast<const pat::PackedCandidate*>(pfTau->leadPFChargedHadrCand().get());
+      if (pc != nullptr) {
+        for (const auto& ptr : pfTau->signalPFChargedHadrCands())
+          signalChargedHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->signalPFNeutrHadrCands())
+          signalNeutralHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->signalPFGammaCands())
+          signalGammaCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFChargedHadrCands())
+        isolationChargedHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFNeutrHadrCands())
+          isolationNeutralHadrCandPtrs_.push_back(ptr);
+
+        for (const auto& ptr : pfTau->isolationPFGammaCands())
+          isolationGammaCandPtrs_.push_back(ptr);
+      }
+      else {
+        pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
+      }
       pfEssential_.push_back(pat::tau::TauPFEssential(*pfTau));
     }
     const reco::CaloTau * caloTau = dynamic_cast<const reco::CaloTau *>(aTauRef.get());

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -448,14 +448,14 @@ reco::PFRecoTauChargedHadronRef Tau::leadTauChargedHadronCandidate() const {
 const reco::PFCandidatePtr convertToPFCandidatePtr(const reco::CandidatePtr& ptr) {
   const reco::PFCandidate* pf_cand = dynamic_cast<const reco::PFCandidate*>(&*ptr);
   if (pf_cand)
-    return pf_cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
+    return edm::Ptr<reco::PFCandidate>(ptr);
   return reco::PFCandidatePtr();
 }
 
 std::vector<reco::PFCandidatePtr> convertPtrVector(const std::vector<reco::CandidatePtr>& cands) {
   std::vector<reco::PFCandidatePtr> newSignalPFCands;
   for (auto& cand : cands) {
-    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
+    const auto& newPtr = edm::Ptr<reco::PFCandidate>(cand);
     newSignalPFCands.push_back(newPtr);
   }
   return newSignalPFCands;

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -326,7 +326,7 @@ void Tau::embedLeadPFCand() {
   }
   leadPFCand_.clear();
   if (pfSpecific_[0].leadPFCand_.isNonnull() ) {
-    leadPFCand_.push_back(*pfSpecific_[0].leadPFCand_); //already set in C-tor
+    leadPFCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFCand_)); //already set in C-tor
     embeddedLeadPFCand_ = true;
   }
 }
@@ -337,7 +337,7 @@ void Tau::embedLeadPFChargedHadrCand() {
   }
   leadPFChargedHadrCand_.clear();
   if (pfSpecific_[0].leadPFChargedHadrCand_.isNonnull() ) {
-    leadPFChargedHadrCand_.push_back(*pfSpecific_[0].leadPFChargedHadrCand_); //already set in C-tor
+    leadPFChargedHadrCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFChargedHadrCand_)); //already set in C-tor
     embeddedLeadPFChargedHadrCand_ = true;
   }
 }
@@ -348,7 +348,7 @@ void Tau::embedLeadPFNeutralCand() {
   }
   leadPFNeutralCand_.clear();
   if (pfSpecific_[0].leadPFNeutralCand_.isNonnull() ) {
-    leadPFNeutralCand_.push_back(*pfSpecific_[0].leadPFNeutralCand_); //already set in C-tor
+    leadPFNeutralCand_.push_back(*static_cast<const reco::PFCandidate*>(&*pfSpecific_[0].leadPFNeutralCand_)); //already set in C-tor
     embeddedLeadPFNeutralCand_ = true;
   }
 }
@@ -357,9 +357,9 @@ void Tau::embedSignalPFCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    signalPFCands_.push_back(*candPtrs.at(i));
+    signalPFCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedSignalPFCands_ = true;
 }
@@ -367,9 +367,9 @@ void Tau::embedSignalPFChargedHadrCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFChargedHadrCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFChargedHadrCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    signalPFChargedHadrCands_.push_back(*candPtrs.at(i));
+    signalPFChargedHadrCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedSignalPFChargedHadrCands_ = true;
 }
@@ -377,9 +377,9 @@ void Tau::embedSignalPFNeutralHadrCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFNeutrHadrCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFNeutrHadrCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    signalPFNeutralHadrCands_.push_back(*candPtrs.at(i));
+    signalPFNeutralHadrCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedSignalPFNeutralHadrCands_ = true;
 }
@@ -387,9 +387,9 @@ void Tau::embedSignalPFGammaCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFGammaCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedSignalPFGammaCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    signalPFGammaCands_.push_back(*candPtrs.at(i));
+    signalPFGammaCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedSignalPFGammaCands_ = true;
 }
@@ -398,9 +398,9 @@ void Tau::embedIsolationPFCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    isolationPFCands_.push_back(*candPtrs.at(i));
+    isolationPFCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedIsolationPFCands_ = true;
 }
@@ -409,9 +409,9 @@ void Tau::embedIsolationPFChargedHadrCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFChargedHadrCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFChargedHadrCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    isolationPFChargedHadrCands_.push_back(*candPtrs.at(i));
+    isolationPFChargedHadrCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedIsolationPFChargedHadrCands_ = true;
 }
@@ -419,9 +419,9 @@ void Tau::embedIsolationPFNeutralHadrCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFNeutrHadrCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFNeutrHadrCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    isolationPFNeutralHadrCands_.push_back(*candPtrs.at(i));
+    isolationPFNeutralHadrCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedIsolationPFNeutralHadrCands_ = true;
 }
@@ -429,9 +429,9 @@ void Tau::embedIsolationPFGammaCands() {
   if (!isPFTau() ) {//additional check with warning in pat::tau producer
     return;
   }
-  std::vector<reco::PFCandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFGammaCands_;
+  std::vector<reco::CandidatePtr> candPtrs = pfSpecific_[0].selectedIsolationPFGammaCands_;
   for (unsigned int i = 0; i < candPtrs.size(); i++) {
-    isolationPFGammaCands_.push_back(*candPtrs.at(i));
+    isolationPFGammaCands_.push_back(*static_cast<const reco::PFCandidate*>(&*candPtrs.at(i)));
   }
   embeddedIsolationPFGammaCands_ = true;
 }
@@ -445,10 +445,26 @@ reco::PFRecoTauChargedHadronRef Tau::leadTauChargedHadronCandidate() const {
   }
 }
 
+const reco::PFCandidatePtr convertToPFCandidatePtr(const reco::CandidatePtr& ptr) {
+  const reco::PFCandidate* pf_cand = dynamic_cast<const reco::PFCandidate*>(&*ptr);
+  if (pf_cand)
+    return pf_cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
+  return reco::PFCandidatePtr();
+}
+
+std::vector<reco::PFCandidatePtr> convertPtrVector(const std::vector<reco::CandidatePtr>& cands) {
+  std::vector<reco::PFCandidatePtr> newSignalPFCands;
+  for (auto& cand : cands) {
+    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
+    newSignalPFCands.push_back(newPtr);
+  }
+  return newSignalPFCands;
+}
+
 const reco::PFCandidatePtr Tau::leadPFChargedHadrCand() const { 
   if(!embeddedLeadPFChargedHadrCand_){
     if(pfSpecific_.empty()) return reco::PFCandidatePtr(); 
-    else return pfSpecific().leadPFChargedHadrCand_; 
+    else return convertToPFCandidatePtr(pfSpecific().leadPFChargedHadrCand_); 
   }else
     return reco::PFCandidatePtr(&leadPFChargedHadrCand_,0);
 }
@@ -456,7 +472,7 @@ const reco::PFCandidatePtr Tau::leadPFChargedHadrCand() const {
 const reco::PFCandidatePtr Tau::leadPFNeutralCand() const { 
   if(!embeddedLeadPFNeutralCand_){
     if(pfSpecific_.empty()) return reco::PFCandidatePtr();
-    else return pfSpecific().leadPFNeutralCand_;
+    else return convertToPFCandidatePtr(pfSpecific().leadPFNeutralCand_);
   }else
     return reco::PFCandidatePtr(&leadPFNeutralCand_,0);
 }
@@ -464,12 +480,12 @@ const reco::PFCandidatePtr Tau::leadPFNeutralCand() const {
 const reco::PFCandidatePtr Tau::leadPFCand() const { 
   if(!embeddedLeadPFCand_){
     if(pfSpecific_.empty()) return reco::PFCandidatePtr();
-    return pfSpecific().leadPFCand_;
+    return convertToPFCandidatePtr(pfSpecific().leadPFCand_);
   }else
     return reco::PFCandidatePtr(&leadPFCand_,0);
 }
 
-const std::vector<reco::PFCandidatePtr>& Tau::signalPFCands() const { 
+const std::vector<reco::PFCandidatePtr> Tau::signalPFCands() const { 
   if (embeddedSignalPFCands_) {
    if (!signalPFCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
@@ -487,11 +503,11 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       signalPFCandsTransientPtrs_.set(std::move(aPtrs));
       return *signalPFCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFCands_;
+    } else return convertPtrVector(pfSpecific().selectedSignalPFCands_);
   }
 }
 
-const std::vector<reco::PFCandidatePtr>& Tau::signalPFChargedHadrCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::signalPFChargedHadrCands() const {
   if (embeddedSignalPFChargedHadrCands_) {
    if (!signalPFChargedHadrCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
@@ -509,11 +525,11 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFChargedHadrCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       signalPFChargedHadrCandsTransientPtrs_.set(std::move(aPtrs));
       return *signalPFChargedHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFChargedHadrCands_;
+    } else return convertPtrVector(pfSpecific().selectedSignalPFChargedHadrCands_);
   }
 } 
 
-const std::vector<reco::PFCandidatePtr>& Tau::signalPFNeutrHadrCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::signalPFNeutrHadrCands() const {
   if (embeddedSignalPFNeutralHadrCands_) {
    if (!signalPFNeutralHadrCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
@@ -531,11 +547,11 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFNeutrHadrCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       signalPFNeutralHadrCandsTransientPtrs_.set(std::move(aPtrs));
       return *signalPFNeutralHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFNeutrHadrCands_;
+    } else return convertPtrVector(pfSpecific().selectedSignalPFNeutrHadrCands_);
   }
 } 
 
-const std::vector<reco::PFCandidatePtr>& Tau::signalPFGammaCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::signalPFGammaCands() const {
   if (embeddedSignalPFGammaCands_) {
    if (!signalPFGammaCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
@@ -553,7 +569,7 @@ const std::vector<reco::PFCandidatePtr>& Tau::signalPFGammaCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       signalPFGammaCandsTransientPtrs_.set(std::move(aPtrs));
       return *signalPFGammaCandsTransientPtrs_;
-    } else return pfSpecific().selectedSignalPFGammaCands_;
+    } else return convertPtrVector(pfSpecific().selectedSignalPFGammaCands_);
   }
 }
 
@@ -567,7 +583,7 @@ const std::vector<reco::RecoTauPiZero> & Tau::signalPiZeroCandidates() const {
   return pfSpecific().signalPiZeroCandidates_;
 }
 
-const std::vector<reco::PFCandidatePtr>& Tau::isolationPFCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::isolationPFCands() const {
   if (embeddedIsolationPFCands_) {
   if (!isolationPFCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
@@ -585,11 +601,11 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       isolationPFCandsTransientPtrs_.set(std::move(aPtrs));
       return *isolationPFCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFCands_;
+    } else return convertPtrVector(pfSpecific().selectedIsolationPFCands_);
   }
 } 
 
-const std::vector<reco::PFCandidatePtr>& Tau::isolationPFChargedHadrCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::isolationPFChargedHadrCands() const {
   if (embeddedIsolationPFChargedHadrCands_) {
    if (!isolationPFChargedHadrCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
@@ -607,11 +623,11 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFChargedHadrCands() cons
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       isolationPFChargedHadrCandsTransientPtrs_.set(std::move(aPtrs));
       return *isolationPFChargedHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFChargedHadrCands_;
+    } else return convertPtrVector(pfSpecific().selectedIsolationPFChargedHadrCands_);
   }
 }
 
-const std::vector<reco::PFCandidatePtr>& Tau::isolationPFNeutrHadrCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::isolationPFNeutrHadrCands() const {
   if (embeddedIsolationPFNeutralHadrCands_) {
     if (!isolationPFNeutralHadrCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{ new std::vector<reco::PFCandidatePtr>{}};
@@ -629,11 +645,11 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFNeutrHadrCands() const 
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       isolationPFNeutralHadrCandsTransientPtrs_.set(std::move(aPtrs));
       return *isolationPFNeutralHadrCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFNeutrHadrCands_;
+    } else return convertPtrVector(pfSpecific().selectedIsolationPFNeutrHadrCands_);
   }
 } 
 
-const std::vector<reco::PFCandidatePtr>& Tau::isolationPFGammaCands() const {
+const std::vector<reco::PFCandidatePtr> Tau::isolationPFGammaCands() const {
   if (embeddedIsolationPFGammaCands_) {
     if (!isolationPFGammaCandsTransientPtrs_.isSet()) {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
@@ -651,7 +667,7 @@ const std::vector<reco::PFCandidatePtr>& Tau::isolationPFGammaCands() const {
       std::unique_ptr<std::vector<reco::PFCandidatePtr> > aPtrs{new std::vector<reco::PFCandidatePtr>{}};
       isolationPFGammaCandsTransientPtrs_.set(std::move(aPtrs));
       return *isolationPFGammaCandsTransientPtrs_;
-    } else return pfSpecific().selectedIsolationPFGammaCands_;
+    } else return convertPtrVector(pfSpecific().selectedIsolationPFGammaCands_);
   }
 }
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -156,7 +156,8 @@
   <ioread sourceClass="pat::Tau" targetClass="pat::Tau" version="[1-]" source="" target="isolationPFGammaCandsTransientPtrs_">
   <![CDATA[isolationPFGammaCandsTransientPtrs_.reset();]]>
   </ioread>
-  <class name="pat::tau::TauPFSpecific"  ClassVersion="15">
+  <class name="pat::tau::TauPFSpecific"  ClassVersion="16">
+   <version ClassVersion="16" checksum="1525851101"/>
    <version ClassVersion="15" checksum="3425877587"/>
    <version ClassVersion="14" checksum="1401440164"/>
    <version ClassVersion="13" checksum="3129436753"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -166,6 +166,79 @@
    <version ClassVersion="10" checksum="2617942038"/>
   </class>
   <class name="std::vector<pat::tau::TauPFSpecific>" />
+  <ioread sourceClass="reco::TauPFSpecific" version="[-15]" source="edm::Ptr<reco::PFCandidate> leadPFChargedHadrCand_;" targetClass="reco::TauPFSpecific" target="leadPFChargedHadrCand_">
+   <![CDATA[leadPFChargedHadrCand_ = edm::Ptr<reco::Candidate>(onfile.leadPFChargedHadrCand_);]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="edm::Ptr<reco::PFCandidate> leadPFNeutralCand_;" targetClass="pat::tau::TauPFSpecific" target="leadPFNeutralCand_">
+    <![CDATA[leadPFNeutralCand_ = edm::Ptr<reco::Candidate>(onfile.leadPFNeutralCand_);]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="edm::Ptr<reco::PFCandidate> leadPFCand_;" targetClass="pat::tau::TauPFSpecific" target="leadPFCand_">
+    <![CDATA[leadPFCand_ = edm::Ptr<reco::Candidate>(onfile.leadPFCand_);]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedSignalPFCands_">
+    <![CDATA[
+    selectedSignalPFCands_.reserve(onfile.selectedSignalPFCands_.size());
+    for (const edm::Ptr<reco::PFCandidate>& cand : onfile.selectedSignalPFCands_) {
+      selectedSignalPFCands_.push_back(edm::Ptr<reco::Candidate>(cand));}
+      ]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFChargedHadrCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedSignalPFChargedHadrCands_">
+    <![CDATA[
+    selectedSignalPFChargedHadrCands_.reserve(onfile.selectedSignalPFChargedHadrCands_.size());
+    for (const auto& cand : onfile.selectedSignalPFChargedHadrCands_)
+      selectedSignalPFChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFNeutrHadrCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedSignalPFNeutrHadrCands_">
+    <![CDATA[
+    selectedSignalPFNeutrHadrCands_.reserve(onfile.selectedSignalPFNeutrHadrCands_.size());
+    for (const auto& cand : onfile.selectedSignalPFNeutrHadrCands_)
+      selectedSignalPFNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));;]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFGammaCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedSignalPFGammaCands_">
+    <![CDATA[
+    selectedSignalPFGammaCands_.reserve(onfile.selectedSignalPFGammaCands_.size());
+    for (const auto& cand : onfile.selectedSignalPFGammaCands_)
+      selectedSignalPFGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedIsolationPFCands_">
+    <![CDATA[
+    selectedIsolationPFCands_.reserve(onfile.selectedIsolationPFCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFCands_)
+      selectedIsolationPFCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFChargedHadrCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedIsolationPFChargedHadrCands_">
+    <![CDATA[
+    selectedIsolationPFChargedHadrCands_.reserve(onfile.selectedIsolationPFChargedHadrCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFChargedHadrCands_)
+      selectedIsolationPFChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFNeutrHadrCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedIsolationPFNeutrHadrCands_">
+    <![CDATA[
+    selectedIsolationPFNeutrHadrCands_.reserve(onfile.selectedIsolationPFNeutrHadrCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFNeutrHadrCands_)
+      selectedIsolationPFNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFGammaCands_;" targetClass="pat::tau::TauPFSpecific" target="selectedIsolationPFGammaCands_">
+    <![CDATA[
+    selectedIsolationPFGammaCands_.reserve(onfile.selectedIsolationPFGammaCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFGammaCands_)
+      selectedIsolationPFGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="pat::tau::TauPFSpecific" version="[-15]" source="edm::Ref<vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<vector<reco::PFJet>,reco::PFJet> > pfJetRef_;" targetClass="pat::tau::TauPFSpecific" target="pfJetRef_" include="DataFormats/JetReco/interface/PFJet.h">
+    <![CDATA[pfJetRef_ = reco::JetBaseRef(onfile.pfJetRef_);]]>
+  </ioread>
+
   <class name="pat::tau::TauCaloSpecific"  ClassVersion="11">
    <version ClassVersion="11" checksum="943826557"/>
    <version ClassVersion="10" checksum="2692173055"/>

--- a/DataFormats/TauReco/interface/JetPiZeroAssociation.h
+++ b/DataFormats/TauReco/interface/JetPiZeroAssociation.h
@@ -3,12 +3,12 @@
 
 #include "DataFormats/Common/interface/AssociationVector.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 
 namespace reco {
    // This base class improves the readability of the ROOT class name by hiding
    // the template crap
-   typedef edm::AssociationVector<PFJetRefProd, std::vector<std::vector<RecoTauPiZero> > >
+   typedef edm::AssociationVector<JetRefBaseProd, std::vector<std::vector<RecoTauPiZero> > >
      JetPiZeroAssociationBase;  
 
    class JetPiZeroAssociation : public JetPiZeroAssociationBase {
@@ -17,7 +17,7 @@ namespace reco {
       JetPiZeroAssociationBase()
       { }
     
-    JetPiZeroAssociation(const reco::PFJetRefProd & ref) :
+    JetPiZeroAssociation(const JetRefBaseProd & ref) :
       JetPiZeroAssociationBase(ref)
       { }
     

--- a/DataFormats/TauReco/interface/PFJetChargedHadronAssociation.h
+++ b/DataFormats/TauReco/interface/PFJetChargedHadronAssociation.h
@@ -3,13 +3,13 @@
 
 #include "DataFormats/Common/interface/AssociationVector.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 
 namespace reco 
 {
   // This base class improves the readability of the ROOT class name by hiding
   // the template crap
-  typedef edm::AssociationVector<PFJetRefProd, std::vector<std::vector<PFRecoTauChargedHadron> > > PFJetChargedHadronAssociationBase;  
+  typedef edm::AssociationVector<JetRefBaseProd, std::vector<std::vector<PFRecoTauChargedHadron> > > PFJetChargedHadronAssociationBase;  
 
   class PFJetChargedHadronAssociation : public PFJetChargedHadronAssociationBase 
   {
@@ -18,7 +18,7 @@ namespace reco
       : PFJetChargedHadronAssociationBase()
     {}
     
-    PFJetChargedHadronAssociation(const reco::PFJetRefProd& ref) 
+    PFJetChargedHadronAssociation(const reco::JetRefBaseProd& ref) 
       : PFJetChargedHadronAssociationBase(ref)
     {}
     

--- a/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
+++ b/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
@@ -2,7 +2,7 @@
 #define DataFormats_TauReco_PFRecoTauChargedHadron_h
 
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Math/interface/Point3D.h"

--- a/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
+++ b/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
@@ -10,6 +10,7 @@
 namespace reco { namespace tau {
   class PFRecoTauChargedHadronFromPFCandidatePlugin;
   class PFRecoTauChargedHadronFromTrackPlugin;
+  class PFRecoTauChargedHadronFromLostTrackPlugin;
   class RecoTauConstructor;
   class PFRecoTauEnergyAlgorithmPlugin;
 }} 
@@ -52,6 +53,9 @@ class PFRecoTauChargedHadron : public CompositePtrCandidate
   /// reference to reco::Track
   const TrackPtr& getTrack() const;
 
+  /// reference to "lostTrack Candidate" when chadron built with tracks stored as pat::PackedCandidates
+  const CandidatePtr& getLostTrackCandidate() const;
+
   /// references to additional neutral PFCandidates
   const std::vector<CandidatePtr>& getNeutralPFCandidates() const;  
 
@@ -69,6 +73,7 @@ class PFRecoTauChargedHadron : public CompositePtrCandidate
  private:
   friend class tau::PFRecoTauChargedHadronFromPFCandidatePlugin;
   friend class tau::PFRecoTauChargedHadronFromTrackPlugin;
+  friend class tau::PFRecoTauChargedHadronFromLostTrackPlugin;
   friend class tau::RecoTauConstructor;
   friend class tau::PFRecoTauEnergyAlgorithmPlugin;
   friend class ::PFRecoTauChargedHadronProducer;
@@ -76,6 +81,7 @@ class PFRecoTauChargedHadron : public CompositePtrCandidate
   PFRecoTauChargedHadronAlgorithm algo_;
 
   CandidatePtr chargedPFCandidate_;
+  CandidatePtr lostTrackCandidate_;
   TrackPtr track_;
   std::vector<CandidatePtr> neutralPFCandidates_;
 

--- a/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
+++ b/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
@@ -47,13 +47,13 @@ class PFRecoTauChargedHadron : public CompositePtrCandidate
   ~PFRecoTauChargedHadron() override;
 
   /// reference to "charged" PFCandidate (either charged PFCandidate or PFNeutralHadron)
-  const PFCandidatePtr& getChargedPFCandidate() const;
+  const CandidatePtr& getChargedPFCandidate() const;
 
   /// reference to reco::Track
   const TrackPtr& getTrack() const;
 
   /// references to additional neutral PFCandidates
-  const std::vector<PFCandidatePtr>& getNeutralPFCandidates() const;  
+  const std::vector<CandidatePtr>& getNeutralPFCandidates() const;  
 
   /// position at ECAL entrance
   const math::XYZPointF& positionAtECALEntrance() const;
@@ -75,9 +75,9 @@ class PFRecoTauChargedHadron : public CompositePtrCandidate
 
   PFRecoTauChargedHadronAlgorithm algo_;
 
-  PFCandidatePtr chargedPFCandidate_;
+  CandidatePtr chargedPFCandidate_;
   TrackPtr track_;
-  std::vector<PFCandidatePtr> neutralPFCandidates_;
+  std::vector<CandidatePtr> neutralPFCandidates_;
 
   math::XYZPointF positionAtECALEntrance_;
 };

--- a/DataFormats/TauReco/interface/PFTau.h
+++ b/DataFormats/TauReco/interface/PFTau.h
@@ -13,9 +13,9 @@
 #include "DataFormats/TauReco/interface/BaseTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/TauReco/interface/PFTauTagInfo.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZeroFwd.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
@@ -58,22 +58,22 @@ class PFTau : public BaseTau {
     ~PFTau() override {};
     PFTau* clone() const override;
 
-    const PFJetRef& jetRef() const;
-    void setjetRef(const PFJetRef&);
+    const JetBaseRef& jetRef() const;
+    void setjetRef(const JetBaseRef&);
 
     // functions to access the PFTauTagInfoRef used by HLT
     const PFTauTagInfoRef& pfTauTagInfoRef() const;
     void setpfTauTagInfoRef(const PFTauTagInfoRef);
 
     PFRecoTauChargedHadronRef leadTauChargedHadronCandidate() const;
-    const PFCandidatePtr& leadPFChargedHadrCand() const;
-    const PFCandidatePtr& leadPFNeutralCand() const;
+    const CandidatePtr& leadPFChargedHadrCand() const;
+    const CandidatePtr& leadPFNeutralCand() const;
     //Can be either the charged or the neutral one
-    const PFCandidatePtr& leadPFCand() const;
+    const CandidatePtr& leadPFCand() const;
 
-    void setleadPFChargedHadrCand(const PFCandidatePtr&);
-    void setleadPFNeutralCand(const PFCandidatePtr&);
-    void setleadPFCand(const PFCandidatePtr&);
+    void setleadPFChargedHadrCand(const CandidatePtr&);
+    void setleadPFNeutralCand(const CandidatePtr&);
+    void setleadPFCand(const CandidatePtr&);
 
     /// Signed transverse impact parameter significance of the Track
     /// associated to the leading charged PFCandidate
@@ -81,36 +81,36 @@ class PFTau : public BaseTau {
     void setleadPFChargedHadrCandsignedSipt(const float&);
 
     /// PFCandidates in signal region
-    const std::vector<reco::PFCandidatePtr>& signalPFCands() const;
-    void setsignalPFCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& signalPFCands() const;
+    void setsignalPFCands(const std::vector<reco::CandidatePtr>&);
 
     /// Charged hadrons in signal region
-    const std::vector<reco::PFCandidatePtr>& signalPFChargedHadrCands() const;
-    void setsignalPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& signalPFChargedHadrCands() const;
+    void setsignalPFChargedHadrCands(const std::vector<reco::CandidatePtr>&);
 
     /// Neutral hadrons in signal region
-    const std::vector<reco::PFCandidatePtr>& signalPFNeutrHadrCands() const;
-    void setsignalPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& signalPFNeutrHadrCands() const;
+    void setsignalPFNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
 
     /// Gamma candidates in signal region
-    const std::vector<reco::PFCandidatePtr>& signalPFGammaCands() const;
-    void setsignalPFGammaCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& signalPFGammaCands() const;
+    void setsignalPFGammaCands(const std::vector<reco::CandidatePtr>&);
 
     /// PFCandidates in isolation region
-    const std::vector<reco::PFCandidatePtr>& isolationPFCands() const;
-    void setisolationPFCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& isolationPFCands() const;
+    void setisolationPFCands(const std::vector<reco::CandidatePtr>&);
 
     /// Charged candidates in isolation region
-    const std::vector<reco::PFCandidatePtr>& isolationPFChargedHadrCands() const;
-    void setisolationPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& isolationPFChargedHadrCands() const;
+    void setisolationPFChargedHadrCands(const std::vector<reco::CandidatePtr>&);
 
     //// Neutral hadrons in isolation region
-    const std::vector<reco::PFCandidatePtr>& isolationPFNeutrHadrCands() const;
-    void setisolationPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& isolationPFNeutrHadrCands() const;
+    void setisolationPFNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
 
     /// Gamma candidates in isolation region
-    const std::vector<reco::PFCandidatePtr>& isolationPFGammaCands() const;
-    void setisolationPFGammaCands(const std::vector<reco::PFCandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& isolationPFGammaCands() const;
+    void setisolationPFGammaCands(const std::vector<reco::CandidatePtr>&);
 
     /// Sum of charged hadron candidate PT in isolation cone; returns NaN
     /// if isolation region is undefined.
@@ -244,24 +244,24 @@ class PFTau : public BaseTau {
 
     float signalConeSize_; 
 
-    reco::PFJetRef jetRef_;
+    reco::JetBaseRef jetRef_;
     PFTauTagInfoRef PFTauTagInfoRef_;
-    reco::PFCandidatePtr leadPFChargedHadrCand_;
-    reco::PFCandidatePtr leadPFNeutralCand_;
-    reco::PFCandidatePtr leadPFCand_;
+    reco::CandidatePtr leadPFChargedHadrCand_;
+    reco::CandidatePtr leadPFNeutralCand_;
+    reco::CandidatePtr leadPFCand_;
     reco::TrackRef electronPreIDTrack_;
 
     // Signal candidates
-    std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;
-    std::vector<reco::PFCandidatePtr> selectedSignalPFChargedHadrCands_;
-    std::vector<reco::PFCandidatePtr> selectedSignalPFNeutrHadrCands_;
-    std::vector<reco::PFCandidatePtr> selectedSignalPFGammaCands_;
+    std::vector<reco::CandidatePtr> selectedSignalPFCands_;
+    std::vector<reco::CandidatePtr> selectedSignalPFChargedHadrCands_;
+    std::vector<reco::CandidatePtr> selectedSignalPFNeutrHadrCands_;
+    std::vector<reco::CandidatePtr> selectedSignalPFGammaCands_;
 
     // Isolation candidates
-    std::vector<reco::PFCandidatePtr> selectedIsolationPFCands_;
-    std::vector<reco::PFCandidatePtr> selectedIsolationPFChargedHadrCands_;
-    std::vector<reco::PFCandidatePtr> selectedIsolationPFNeutrHadrCands_;
-    std::vector<reco::PFCandidatePtr> selectedIsolationPFGammaCands_;
+    std::vector<reco::CandidatePtr> selectedIsolationPFCands_;
+    std::vector<reco::CandidatePtr> selectedIsolationPFChargedHadrCands_;
+    std::vector<reco::CandidatePtr> selectedIsolationPFNeutrHadrCands_;
+    std::vector<reco::CandidatePtr> selectedIsolationPFGammaCands_;
 
     RecoTauPiZeroRefVector signalPiZeroCandidatesRefs_;
     RecoTauPiZeroRefVector isolationPiZeroCandidatesRefs_;

--- a/DataFormats/TauReco/interface/PFTauTagInfo.h
+++ b/DataFormats/TauReco/interface/PFTauTagInfo.h
@@ -11,7 +11,7 @@
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauTagInfoFwd.h"
 #include "DataFormats/TauReco/interface/BaseTauTagInfo.h"
 
@@ -24,22 +24,22 @@ namespace reco{
     virtual PFTauTagInfo* clone()const;
     
     //get the PFCandidates which compose the PF jet and were filtered by RecoTauTag/TauTagTools/ TauTagTools::filteredPFChargedHadrCands(.,...), filteredPFNeutrHadrCands(.), filteredPFGammaCands(.) functions through RecoTauTag/RecoTauTag/ PFRecoTauTagInfoProducer EDProducer
-    std::vector<reco::PFCandidatePtr> PFCands()const;
-    const std::vector<reco::PFCandidatePtr>& PFChargedHadrCands()const;
-    void  setPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>&);
-    const std::vector<reco::PFCandidatePtr>& PFNeutrHadrCands()const;
-    void  setPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>&);
-    const std::vector<reco::PFCandidatePtr>& PFGammaCands()const;
-    void  setPFGammaCands(const std::vector<reco::PFCandidatePtr>&);
+    std::vector<reco::CandidatePtr> PFCands()const;
+    const std::vector<reco::CandidatePtr>& PFChargedHadrCands()const;
+    void  setPFChargedHadrCands(const std::vector<reco::CandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& PFNeutrHadrCands()const;
+    void  setPFNeutrHadrCands(const std::vector<reco::CandidatePtr>&);
+    const std::vector<reco::CandidatePtr>& PFGammaCands()const;
+    void  setPFGammaCands(const std::vector<reco::CandidatePtr>&);
     
     //the reference to the PFJet
-    const PFJetRef& pfjetRef()const;
-    void setpfjetRef(const PFJetRef);
+    const JetBaseRef& pfjetRef()const;
+    void setpfjetRef(const JetBaseRef);
   private:
-    PFJetRef PFJetRef_;
-    std::vector<reco::PFCandidatePtr> PFChargedHadrCands_;
-    std::vector<reco::PFCandidatePtr> PFNeutrHadrCands_;
-    std::vector<reco::PFCandidatePtr> PFGammaCands_;
+    JetBaseRef PFJetRef_;
+    std::vector<reco::CandidatePtr> PFChargedHadrCands_;
+    std::vector<reco::CandidatePtr> PFNeutrHadrCands_;
+    std::vector<reco::CandidatePtr> PFGammaCands_;
   };
 }
 #endif

--- a/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
+++ b/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
@@ -49,6 +49,11 @@ const PFRecoTauChargedHadron::TrackPtr& PFRecoTauChargedHadron::getTrack() const
   return track_;
 }
 
+const CandidatePtr& PFRecoTauChargedHadron::getLostTrackCandidate() const
+{
+  return lostTrackCandidate_;
+}
+
 const std::vector<CandidatePtr>& PFRecoTauChargedHadron::getNeutralPFCandidates() const
 {
   return neutralPFCandidates_;
@@ -101,6 +106,9 @@ void PFRecoTauChargedHadron::print(std::ostream& stream) const
   stream << "reco::Track: ";
   if ( track_.isNonnull() ) {
     stream << "Pt = " << track_->pt() << " +/- " << track_->ptError() << ", eta = " << track_->eta() << ", phi = " << track_->phi() << std::endl;
+  } else if ( lostTrackCandidate_.isNonnull() ) {
+    stream << "(lostTrackCandidate: " << lostTrackCandidate_.id() << ":" << lostTrackCandidate_.key() << "):"
+	   << " Pt = " << lostTrackCandidate_->pt() << ", eta = " << lostTrackCandidate_->eta() << ", phi = " << lostTrackCandidate_->phi() << std::endl;
   } else {
     stream << "N/A" << std::endl;
   }

--- a/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
+++ b/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
@@ -39,7 +39,7 @@ PFRecoTauChargedHadron::PFRecoTauChargedHadron(const Candidate& c, PFRecoTauChar
 PFRecoTauChargedHadron::~PFRecoTauChargedHadron()
 {}
 
-const PFCandidatePtr& PFRecoTauChargedHadron::getChargedPFCandidate() const
+const CandidatePtr& PFRecoTauChargedHadron::getChargedPFCandidate() const
 {
   return chargedPFCandidate_;
 }
@@ -49,7 +49,7 @@ const PFRecoTauChargedHadron::TrackPtr& PFRecoTauChargedHadron::getTrack() const
   return track_;
 }
 
-const std::vector<PFCandidatePtr>& PFRecoTauChargedHadron::getNeutralPFCandidates() const
+const std::vector<CandidatePtr>& PFRecoTauChargedHadron::getNeutralPFCandidates() const
 {
   return neutralPFCandidates_;
 }
@@ -71,18 +71,19 @@ bool PFRecoTauChargedHadron::algoIs(PFRecoTauChargedHadron::PFRecoTauChargedHadr
 
 namespace
 {
-  std::string getPFCandidateType(reco::PFCandidate::ParticleType pfCandidateType)
-  {
-    if      ( pfCandidateType == reco::PFCandidate::X         ) return "undefined";
-    else if ( pfCandidateType == reco::PFCandidate::h         ) return "PFChargedHadron";
-    else if ( pfCandidateType == reco::PFCandidate::e         ) return "PFElectron";
-    else if ( pfCandidateType == reco::PFCandidate::mu        ) return "PFMuon";
-    else if ( pfCandidateType == reco::PFCandidate::gamma     ) return "PFGamma";
-    else if ( pfCandidateType == reco::PFCandidate::h0        ) return "PFNeutralHadron";
-    else if ( pfCandidateType == reco::PFCandidate::h_HF      ) return "HF_had";
-    else if ( pfCandidateType == reco::PFCandidate::egamma_HF ) return "HF_em";
-    else assert(0);
-  }
+  // JAN - FIXME - can still use this to print out based on PDG ID
+  // std::string getPFCandidateType(reco::PFCandidate::ParticleType pfCandidateType)
+  // {
+  //   if      ( pfCandidateType == reco::PFCandidate::X         ) return "undefined";
+  //   else if ( pfCandidateType == reco::PFCandidate::h         ) return "PFChargedHadron";
+  //   else if ( pfCandidateType == reco::PFCandidate::e         ) return "PFElectron";
+  //   else if ( pfCandidateType == reco::PFCandidate::mu        ) return "PFMuon";
+  //   else if ( pfCandidateType == reco::PFCandidate::gamma     ) return "PFGamma";
+  //   else if ( pfCandidateType == reco::PFCandidate::h0        ) return "PFNeutralHadron";
+  //   else if ( pfCandidateType == reco::PFCandidate::h_HF      ) return "HF_had";
+  //   else if ( pfCandidateType == reco::PFCandidate::egamma_HF ) return "HF_em";
+  //   else assert(0);
+  // }
 }
 
 void PFRecoTauChargedHadron::print(std::ostream& stream) const 
@@ -93,7 +94,7 @@ void PFRecoTauChargedHadron::print(std::ostream& stream) const
   if ( chargedPFCandidate_.isNonnull() ) {
     stream << " (" << chargedPFCandidate_.id() << ":" << chargedPFCandidate_.key() << "):"
 	   << " Pt = " << chargedPFCandidate_->pt() << ", eta = " << chargedPFCandidate_->eta() << ", phi = " << chargedPFCandidate_->phi() 
-	   << " (type = " << getPFCandidateType(chargedPFCandidate_->particleId()) << ")" << std::endl;
+	   << " (pdgId = " << chargedPFCandidate_->pdgId() << ")" << std::endl;
   } else {
     stream << ": N/A" << std::endl;
   }
@@ -107,11 +108,11 @@ void PFRecoTauChargedHadron::print(std::ostream& stream) const
   if ( !neutralPFCandidates_.empty() ) {
     stream << std::endl;
     int idx = 0;
-    for ( std::vector<PFCandidatePtr>::const_iterator neutralPFCandidate = neutralPFCandidates_.begin();
+    for ( std::vector<CandidatePtr>::const_iterator neutralPFCandidate = neutralPFCandidates_.begin();
 	  neutralPFCandidate != neutralPFCandidates_.end(); ++neutralPFCandidate ) {
       stream << " #" << idx << " (" << neutralPFCandidate->id() << ":" << neutralPFCandidate->key() << "):"
 	     << " Pt = " << (*neutralPFCandidate)->pt() << ", eta = " << (*neutralPFCandidate)->eta() << ", phi = " << (*neutralPFCandidate)->phi() 
-	     << " (type = " << getPFCandidateType((*neutralPFCandidate)->particleId()) << ")" << std::endl;
+	     << " (pdgId = " << (*neutralPFCandidate)->pdgId() << ")" << std::endl;
       ++idx;
     }
   } else {

--- a/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
+++ b/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
@@ -74,23 +74,6 @@ bool PFRecoTauChargedHadron::algoIs(PFRecoTauChargedHadron::PFRecoTauChargedHadr
   return (algo_ == algo);
 }
 
-namespace
-{
-  // JAN - FIXME - can still use this to print out based on PDG ID
-  // std::string getPFCandidateType(reco::PFCandidate::ParticleType pfCandidateType)
-  // {
-  //   if      ( pfCandidateType == reco::PFCandidate::X         ) return "undefined";
-  //   else if ( pfCandidateType == reco::PFCandidate::h         ) return "PFChargedHadron";
-  //   else if ( pfCandidateType == reco::PFCandidate::e         ) return "PFElectron";
-  //   else if ( pfCandidateType == reco::PFCandidate::mu        ) return "PFMuon";
-  //   else if ( pfCandidateType == reco::PFCandidate::gamma     ) return "PFGamma";
-  //   else if ( pfCandidateType == reco::PFCandidate::h0        ) return "PFNeutralHadron";
-  //   else if ( pfCandidateType == reco::PFCandidate::h_HF      ) return "HF_had";
-  //   else if ( pfCandidateType == reco::PFCandidate::egamma_HF ) return "HF_em";
-  //   else assert(0);
-  // }
-}
-
 void PFRecoTauChargedHadron::print(std::ostream& stream) const 
 {
   stream << " Pt = " << this->pt() << ", eta = " << this->eta() << ", phi = " << this->phi() << " (mass = " << this->mass() << ")" << std::endl;

--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -55,8 +55,8 @@ PFTau::PFTau(Charge q, const LorentzVector& p4, const Point& vtx)
 PFTau* PFTau::clone() const { return new PFTau(*this); }
 
 // Constituent getters and setters
-const PFJetRef& PFTau::jetRef() const { return jetRef_; }
-void PFTau::setjetRef(const PFJetRef& x) { jetRef_ = x; }
+const JetBaseRef& PFTau::jetRef() const { return jetRef_; }
+void PFTau::setjetRef(const JetBaseRef& x) { jetRef_ = x; }
 
 const PFTauTagInfoRef& PFTau::pfTauTagInfoRef() const {
   return PFTauTagInfoRef_;
@@ -64,34 +64,34 @@ const PFTauTagInfoRef& PFTau::pfTauTagInfoRef() const {
 
 void PFTau::setpfTauTagInfoRef(const PFTauTagInfoRef x) { PFTauTagInfoRef_ = x; }
 
-const PFCandidatePtr& PFTau::leadPFChargedHadrCand() const { return leadPFChargedHadrCand_; }
-const PFCandidatePtr& PFTau::leadPFNeutralCand() const { return leadPFNeutralCand_; }
-const PFCandidatePtr& PFTau::leadPFCand() const { return leadPFCand_; }
+const CandidatePtr& PFTau::leadPFChargedHadrCand() const { return leadPFChargedHadrCand_; }
+const CandidatePtr& PFTau::leadPFNeutralCand() const { return leadPFNeutralCand_; }
+const CandidatePtr& PFTau::leadPFCand() const { return leadPFCand_; }
 
-void PFTau::setleadPFChargedHadrCand(const PFCandidatePtr& myLead) { leadPFChargedHadrCand_ = myLead;}
-void PFTau::setleadPFNeutralCand(const PFCandidatePtr& myLead) { leadPFNeutralCand_ = myLead;}
-void PFTau::setleadPFCand(const PFCandidatePtr& myLead) { leadPFCand_ = myLead;}
+void PFTau::setleadPFChargedHadrCand(const CandidatePtr& myLead) { leadPFChargedHadrCand_ = myLead;}
+void PFTau::setleadPFNeutralCand(const CandidatePtr& myLead) { leadPFNeutralCand_ = myLead;}
+void PFTau::setleadPFCand(const CandidatePtr& myLead) { leadPFCand_ = myLead;}
 
 float PFTau::leadPFChargedHadrCandsignedSipt() const { return leadPFChargedHadrCandsignedSipt_; }
 void PFTau::setleadPFChargedHadrCandsignedSipt(const float& x){ leadPFChargedHadrCandsignedSipt_ = x; }
 
-const std::vector<PFCandidatePtr>& PFTau::signalPFCands() const { return selectedSignalPFCands_; }
-void PFTau::setsignalPFCands(const std::vector<PFCandidatePtr>& myParts)  { selectedSignalPFCands_ = myParts; }
-const std::vector<PFCandidatePtr>& PFTau::signalPFChargedHadrCands() const { return selectedSignalPFChargedHadrCands_; }
-void PFTau::setsignalPFChargedHadrCands(const std::vector<PFCandidatePtr>& myParts)  { selectedSignalPFChargedHadrCands_ = myParts; }
-const std::vector<PFCandidatePtr>& PFTau::signalPFNeutrHadrCands() const {return selectedSignalPFNeutrHadrCands_; }
-void PFTau::setsignalPFNeutrHadrCands(const std::vector<PFCandidatePtr>& myParts)  { selectedSignalPFNeutrHadrCands_ = myParts; }
-const std::vector<PFCandidatePtr>& PFTau::signalPFGammaCands() const { return selectedSignalPFGammaCands_; }
-void PFTau::setsignalPFGammaCands(const std::vector<PFCandidatePtr>& myParts)  { selectedSignalPFGammaCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::signalPFCands() const { return selectedSignalPFCands_; }
+void PFTau::setsignalPFCands(const std::vector<CandidatePtr>& myParts)  { selectedSignalPFCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::signalPFChargedHadrCands() const { return selectedSignalPFChargedHadrCands_; }
+void PFTau::setsignalPFChargedHadrCands(const std::vector<CandidatePtr>& myParts)  { selectedSignalPFChargedHadrCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::signalPFNeutrHadrCands() const {return selectedSignalPFNeutrHadrCands_; }
+void PFTau::setsignalPFNeutrHadrCands(const std::vector<CandidatePtr>& myParts)  { selectedSignalPFNeutrHadrCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::signalPFGammaCands() const { return selectedSignalPFGammaCands_; }
+void PFTau::setsignalPFGammaCands(const std::vector<CandidatePtr>& myParts)  { selectedSignalPFGammaCands_ = myParts; }
 
-const std::vector<PFCandidatePtr>& PFTau::isolationPFCands() const { return selectedIsolationPFCands_; }
-void PFTau::setisolationPFCands(const std::vector<PFCandidatePtr>& myParts)  { selectedIsolationPFCands_ = myParts;} 
-const std::vector<PFCandidatePtr>& PFTau::isolationPFChargedHadrCands() const { return selectedIsolationPFChargedHadrCands_; }
-void PFTau::setisolationPFChargedHadrCands(const std::vector<PFCandidatePtr>& myParts)  { selectedIsolationPFChargedHadrCands_ = myParts; }
-const std::vector<PFCandidatePtr>& PFTau::isolationPFNeutrHadrCands() const { return selectedIsolationPFNeutrHadrCands_; }
-void PFTau::setisolationPFNeutrHadrCands(const std::vector<PFCandidatePtr>& myParts)  { selectedIsolationPFNeutrHadrCands_ = myParts; }
-const std::vector<PFCandidatePtr>& PFTau::isolationPFGammaCands() const { return selectedIsolationPFGammaCands_; }
-void PFTau::setisolationPFGammaCands(const std::vector<PFCandidatePtr>& myParts)  { selectedIsolationPFGammaCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::isolationPFCands() const { return selectedIsolationPFCands_; }
+void PFTau::setisolationPFCands(const std::vector<CandidatePtr>& myParts)  { selectedIsolationPFCands_ = myParts;} 
+const std::vector<CandidatePtr>& PFTau::isolationPFChargedHadrCands() const { return selectedIsolationPFChargedHadrCands_; }
+void PFTau::setisolationPFChargedHadrCands(const std::vector<CandidatePtr>& myParts)  { selectedIsolationPFChargedHadrCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::isolationPFNeutrHadrCands() const { return selectedIsolationPFNeutrHadrCands_; }
+void PFTau::setisolationPFNeutrHadrCands(const std::vector<CandidatePtr>& myParts)  { selectedIsolationPFNeutrHadrCands_ = myParts; }
+const std::vector<CandidatePtr>& PFTau::isolationPFGammaCands() const { return selectedIsolationPFGammaCands_; }
+void PFTau::setisolationPFGammaCands(const std::vector<CandidatePtr>& myParts)  { selectedIsolationPFGammaCands_ = myParts; }
 
 
 namespace {
@@ -248,9 +248,12 @@ void PFTau::setelectronPreIDDecision(const bool& x) {electronPreIDDecision_ = x;
 bool PFTau::hasMuonReference() const { // check if muon ref exists
     if( leadPFChargedHadrCand_.isNull() ) return false;
     else if( leadPFChargedHadrCand_.isNonnull() ){
-        reco::MuonRef muonRef = leadPFChargedHadrCand_->muonRef();
-        if( muonRef.isNull() )   return false;
-        else if( muonRef.isNonnull() ) return  true;
+        const reco::PFCandidate* pf_cand = dynamic_cast<const reco::PFCandidate*>(&*leadPFChargedHadrCand_);
+        if (pf_cand) {
+            reco::MuonRef muonRef = pf_cand->muonRef();
+            if( muonRef.isNull() )   return false;
+            else if( muonRef.isNonnull() ) return  true;
+        }
     }
     return false;
 }
@@ -264,7 +267,7 @@ void PFTau::setMuonDecision(const bool& x) {muonDecision_ = x;}
 
 CandidatePtr PFTau::sourceCandidatePtr( size_type i ) const {
     if ( i!=0 ) return CandidatePtr();
-    return refToPtr(jetRef());
+    return jetRef().castTo<CandidatePtr>();
 }
 
 
@@ -284,24 +287,16 @@ void PFTau::dump(std::ostream& out) const {
       out<<"# PF neutral hadr. cand's "<<pfTauTagInfoRef()->PFNeutrHadrCands().size()<<std::endl;
       out<<"# PF gamma cand's "<<pfTauTagInfoRef()->PFGammaCands().size()<<std::endl;
     }
-    if (jetRef().isNonnull()) {
-      out << "Its constituents :"<< std::endl;
-      out<<"# PF charged hadr. cand's "<< jetRef()->chargedHadronMultiplicity()<<std::endl;
-      out<<"# PF neutral hadr. cand's "<< jetRef()->neutralHadronMultiplicity()<<std::endl;
-      out<<"# PF gamma cand's "<< jetRef()->photonMultiplicity()<<std::endl;
-      out<<"# Electron cand's "<< jetRef()->electronMultiplicity()<<std::endl;
-    }
     out<<"in detail :"<<std::endl;
 
     out<<"Pt of the PFTau "<<pt()<<std::endl;
-    const PFCandidatePtr& theLeadPFCand = leadPFChargedHadrCand();
+    const CandidatePtr& theLeadPFCand = leadPFChargedHadrCand();
     if(!theLeadPFCand){
         out<<"No Lead PFCand "<<std::endl;
     }else{
-        out<<"Lead PFCand Particle Id " << (*theLeadPFCand).particleId() << std::endl;
+        out<<"Lead PFCand PDG Id " << (*theLeadPFCand).pdgId() << std::endl;
         out<<"Lead PFCand Pt "<<(*theLeadPFCand).pt()<<std::endl;
         out<<"Lead PFCand Charge "<<(*theLeadPFCand).charge()<<std::endl;
-        out<<"Lead PFCand TrkRef "<<(*theLeadPFCand).trackRef().isNonnull()<<std::endl;
         out<<"Inner point position (x,y,z) of the PFTau ("<<vx()<<","<<vy()<<","<<vz()<<")"<<std::endl;
         out<<"Charge of the PFTau "<<charge()<<std::endl;
         out<<"Et of the highest Et HCAL PFCluster "<<maximumHCALPFClusterEt()<<std::endl;

--- a/DataFormats/TauReco/src/PFTauTagInfo.cc
+++ b/DataFormats/TauReco/src/PFTauTagInfo.cc
@@ -5,19 +5,19 @@ using namespace reco;
 
 PFTauTagInfo* PFTauTagInfo::clone()const{return new PFTauTagInfo(*this);}
 
-std::vector<reco::PFCandidatePtr> PFTauTagInfo::PFCands()const{
-  std::vector<reco::PFCandidatePtr> thePFCands;
-  for (std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=PFChargedHadrCands_.begin();iPFCand!=PFChargedHadrCands_.end();iPFCand++) thePFCands.push_back(*iPFCand);
-  for (std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=PFNeutrHadrCands_.begin();iPFCand!=PFNeutrHadrCands_.end();iPFCand++) thePFCands.push_back(*iPFCand);
-  for (std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=PFGammaCands_.begin();iPFCand!=PFGammaCands_.end();iPFCand++) thePFCands.push_back(*iPFCand);
+std::vector<reco::CandidatePtr> PFTauTagInfo::PFCands()const{
+  std::vector<reco::CandidatePtr> thePFCands;
+  for (std::vector<reco::CandidatePtr>::const_iterator iPFCand=PFChargedHadrCands_.begin();iPFCand!=PFChargedHadrCands_.end();iPFCand++) thePFCands.push_back(*iPFCand);
+  for (std::vector<reco::CandidatePtr>::const_iterator iPFCand=PFNeutrHadrCands_.begin();iPFCand!=PFNeutrHadrCands_.end();iPFCand++) thePFCands.push_back(*iPFCand);
+  for (std::vector<reco::CandidatePtr>::const_iterator iPFCand=PFGammaCands_.begin();iPFCand!=PFGammaCands_.end();iPFCand++) thePFCands.push_back(*iPFCand);
   return thePFCands;
 }
-const std::vector<reco::PFCandidatePtr>& PFTauTagInfo::PFChargedHadrCands() const {return PFChargedHadrCands_;}
-void  PFTauTagInfo::setPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& x){PFChargedHadrCands_=x;}
-const std::vector<reco::PFCandidatePtr>& PFTauTagInfo::PFNeutrHadrCands() const {return PFNeutrHadrCands_;}
-void  PFTauTagInfo::setPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>& x){PFNeutrHadrCands_=x;}
-const std::vector<reco::PFCandidatePtr>& PFTauTagInfo::PFGammaCands() const {return PFGammaCands_;}
-void  PFTauTagInfo::setPFGammaCands(const std::vector<reco::PFCandidatePtr>& x){PFGammaCands_=x;}
+const std::vector<reco::CandidatePtr>& PFTauTagInfo::PFChargedHadrCands() const {return PFChargedHadrCands_;}
+void  PFTauTagInfo::setPFChargedHadrCands(const std::vector<reco::CandidatePtr>& x){PFChargedHadrCands_=x;}
+const std::vector<reco::CandidatePtr>& PFTauTagInfo::PFNeutrHadrCands() const {return PFNeutrHadrCands_;}
+void  PFTauTagInfo::setPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& x){PFNeutrHadrCands_=x;}
+const std::vector<reco::CandidatePtr>& PFTauTagInfo::PFGammaCands() const {return PFGammaCands_;}
+void  PFTauTagInfo::setPFGammaCands(const std::vector<reco::CandidatePtr>& x){PFGammaCands_=x;}
 
-const PFJetRef& PFTauTagInfo::pfjetRef()const{return PFJetRef_;}
-void PFTauTagInfo::setpfjetRef(const PFJetRef x){PFJetRef_=x;}
+const JetBaseRef& PFTauTagInfo::pfjetRef()const{return PFJetRef_;}
+void PFTauTagInfo::setpfjetRef(const JetBaseRef x){PFJetRef_=x;}

--- a/DataFormats/TauReco/src/classes_3.h
+++ b/DataFormats/TauReco/src/classes_3.h
@@ -31,6 +31,7 @@
 #include "DataFormats/TauReco/interface/PFTau3ProngSummaryFwd.h"
 #include "DataFormats/TauReco/interface/PFTau3ProngSummaryAssociation.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
@@ -82,6 +83,9 @@ namespace DataFormats_TauReco {
     std::pair<reco::PFJetRef, std::vector<reco::RecoTauPiZero> >                              jetPiZeroAssoc_p;
     std::vector<std::pair<reco::PFJetRef, std::vector<reco::RecoTauPiZero> > >                jetPiZeroAssoc_v;
 
+    std::pair<reco::JetBaseRef, std::vector<reco::RecoTauPiZero> >                              jetBasePiZeroAssoc_p;
+    std::vector<std::pair<reco::JetBaseRef, std::vector<reco::RecoTauPiZero> > >                jetBasePiZeroAssoc_v;
+
     std::vector<std::vector<reco::RecoTauPiZero> >                jetPiZeroAssoc_v_v;
     
     reco::PFJetChargedHadronAssociationBase                     jetChHAssoc_b;
@@ -93,6 +97,9 @@ namespace DataFormats_TauReco {
 
     std::pair<reco::PFJetRef, std::vector<reco::PFRecoTauChargedHadron> >                              jetChHAssoc_p;
     std::vector<std::pair<reco::PFJetRef, std::vector<reco::PFRecoTauChargedHadron> > >                jetChHAssoc_v;
+
+    std::pair<reco::JetBaseRef, std::vector<reco::PFRecoTauChargedHadron> >                              jetBaseChHAssoc_p;
+    std::vector<std::pair<reco::JetBaseRef, std::vector<reco::PFRecoTauChargedHadron> > >                jetBaseChHAssoc_v;
 
     std::vector<std::vector<reco::PFRecoTauChargedHadron> >                jetChHAssoc_v_v;
 

--- a/DataFormats/TauReco/src/classes_3.h
+++ b/DataFormats/TauReco/src/classes_3.h
@@ -34,6 +34,8 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include <vector>
 #include <map>
@@ -242,8 +244,19 @@ namespace DataFormats_TauReco {
 /*     edm::helpers::KeyVal<edm::RefProd<std::vector<reco::PFJet> >,edm::RefProd<std::vector<reco::PFCandidate> > > jetPFCandidateAssociation_kv; */
 /*     edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > jetPFCandidateAssociation_kv2; */
 /*     std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > jetPFCandidateAssociation_mkv; */
-   
 
+    // PAT Jet associations, needed for miniAOD-based reconstruction
+    // JAN - FIXME - this should possibly go into PatCandidates
+    edm::Association<std::vector<pat::Jet> > patjet_assoc_vr;
+    edm::Wrapper<edm::Association<std::vector<pat::Jet> > > patjet_assoc_vr_wrapper;
+    edm::RefProd<vector<pat::Jet> > patjet_rp;
+    edm::AssociationMap<edm::OneToMany<std::vector<pat::Jet>,std::vector<pat::PackedCandidate>,unsigned int> >patjet_v_patpc_v_otm_am;
+    edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<pat::Jet>,std::vector<pat::PackedCandidate>,unsigned int> > > patjet_v_patpc_v_otm_am_w;
+    edm::helpers::KeyVal<edm::RefProd<vector<pat::Jet> >,edm::RefProd<vector<pat::PackedCandidate> > > patjet_v_patpc_v_kv;
 
+    // Generic association
+    edm::AssociationMap<edm::OneToOne<edm::View<reco::Jet>,edm::View<reco::Jet>,unsigned int> > v_j_v_j_am;
+    edm::Wrapper<edm::AssociationMap<edm::OneToOne<edm::View<reco::Jet>,edm::View<reco::Jet>,unsigned int> > > v_j_v_j_am_w;
+    edm::helpers::KeyVal<edm::RefToBaseProd<reco::Jet>,edm::RefToBaseProd<reco::Jet> > v_j_v_j_kv;
   };
 }

--- a/DataFormats/TauReco/src/classes_3.h
+++ b/DataFormats/TauReco/src/classes_3.h
@@ -246,7 +246,6 @@ namespace DataFormats_TauReco {
 /*     std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > jetPFCandidateAssociation_mkv; */
 
     // PAT Jet associations, needed for miniAOD-based reconstruction
-    // JAN - FIXME - this should possibly go into PatCandidates
     edm::Association<std::vector<pat::Jet> > patjet_assoc_vr;
     edm::Wrapper<edm::Association<std::vector<pat::Jet> > > patjet_assoc_vr_wrapper;
     edm::RefProd<vector<pat::Jet> > patjet_rp;

--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -29,7 +29,8 @@
   <class name="edm::RefProd<std::vector<reco::CaloTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::CaloTauTagInfo>,reco::CaloTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloTauTagInfo>,reco::CaloTauTagInfo> >"/>
 
-  <class name="reco::PFTauTagInfo" ClassVersion="12">
+  <class name="reco::PFTauTagInfo" ClassVersion="13">
+   <version ClassVersion="13" checksum="1453697092"/>
    <version ClassVersion="12" checksum="3598523528"/>
    <version ClassVersion="11" checksum="2849126593"/>
    <version ClassVersion="10" checksum="2791906466"/>

--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -43,6 +43,31 @@
 
 <!-- Adding ioread rules for backwards compatibility -->
 
+<ioread sourceClass="reco::PFTauTagInfo" version="[-12]" source="edm::Ref<vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<vector<reco::PFJet>,reco::PFJet> > PFJetRef_;" targetClass="reco::PFTauTagInfo" target="PFJetRef_" include="DataFormats/JetReco/interface/PFJet.h">
+    <![CDATA[PFJetRef_ = reco::JetBaseRef(onfile.PFJetRef_);]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTauTagInfo" version="[11-12]" source="std::vector<edm::Ptr<reco::PFCandidate> > PFChargedHadrCands_;" targetClass="reco::PFTauTagInfo" target="PFChargedHadrCands_">
+    <![CDATA[
+    PFChargedHadrCands_.reserve(onfile.PFChargedHadrCands_.size());
+    for (const auto& cand : onfile.PFChargedHadrCands_)
+      PFChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTauTagInfo" version="[11-12]" source="std::vector<edm::Ptr<reco::PFCandidate> > PFNeutrHadrCands_;" targetClass="reco::PFTauTagInfo" target="PFNeutrHadrCands_">
+    <![CDATA[
+    PFNeutrHadrCands_.reserve(onfile.PFNeutrHadrCands_.size());
+    for (const auto& cand : onfile.PFNeutrHadrCands_)
+      PFNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTauTagInfo" version="[11-12]" source="std::vector<edm::Ptr<reco::PFCandidate> > PFGammaCands_;" targetClass="reco::PFTauTagInfo" target="PFGammaCands_">
+    <![CDATA[
+    PFGammaCands_.reserve(onfile.PFGammaCands_.size());
+    for (const auto& cand : onfile.PFGammaCands_)
+      PFGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
 <ioread sourceClass="reco::PFTauTagInfo" version="[-10]"
 source="reco::PFCandidateRefVector PFChargedHadrCands_;"
  targetClass="reco::PFTauTagInfo"

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -283,7 +283,8 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::RefVector<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> > >" />
 
-  <class name="reco::PFRecoTauChargedHadron" ClassVersion="14">
+  <class name="reco::PFRecoTauChargedHadron" ClassVersion="15">
+   <version ClassVersion="15" checksum="2213708860"/>
    <version ClassVersion="14" checksum="3665832588"/>
    <version ClassVersion="13" checksum="591384956"/>
    <version ClassVersion="12" checksum="2480143236" />

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,7 +1,7 @@
 <lcgdict>
   
-  <class name="reco::PFTau" ClassVersion="19">
-   <version ClassVersion="20" checksum="3395041825"/>
+  <class name="reco::PFTau" ClassVersion="20">
+   <version ClassVersion="20" checksum="4159721589"/>
    <version ClassVersion="19" checksum="4003955973"/>
    <version ClassVersion="18" checksum="1318776182"/>
    <version ClassVersion="17" checksum="1523260402"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -284,7 +284,7 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> > >" />
 
   <class name="reco::PFRecoTauChargedHadron" ClassVersion="15">
-   <version ClassVersion="15" checksum="2213708860"/>
+   <version ClassVersion="15" checksum="377961877"/>
    <version ClassVersion="14" checksum="3665832588"/>
    <version ClassVersion="13" checksum="591384956"/>
    <version ClassVersion="12" checksum="2480143236" />

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -39,6 +39,79 @@
   <class name="edm::reftobase::Holder<reco::PFTau, reco::PFTauRef>" />
   <class name="edm::reftobase::RefHolder<reco::PFTauRef>" />
 
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="edm::Ptr<reco::PFCandidate> leadPFChargedHadrCand_;" targetClass="reco::PFTau" target="leadPFChargedHadrCand_">
+   <![CDATA[leadPFChargedHadrCand_ = edm::Ptr<reco::Candidate>(onfile.leadPFChargedHadrCand_);]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="edm::Ptr<reco::PFCandidate> leadPFNeutralCand_;" targetClass="reco::PFTau" target="leadPFNeutralCand_">
+    <![CDATA[leadPFNeutralCand_ = edm::Ptr<reco::Candidate>(onfile.leadPFNeutralCand_);]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="edm::Ptr<reco::PFCandidate> leadPFCand_;" targetClass="reco::PFTau" target="leadPFCand_">
+    <![CDATA[leadPFCand_ = edm::Ptr<reco::Candidate>(onfile.leadPFCand_);]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;" targetClass="reco::PFTau" target="selectedSignalPFCands_">
+    <![CDATA[
+    selectedSignalPFCands_.reserve(onfile.selectedSignalPFCands_.size());
+    for (const edm::Ptr<reco::PFCandidate>& cand : onfile.selectedSignalPFCands_) {
+      selectedSignalPFCands_.push_back(edm::Ptr<reco::Candidate>(cand));}
+      ]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFChargedHadrCands_;" targetClass="reco::PFTau" target="selectedSignalPFChargedHadrCands_">
+    <![CDATA[
+    selectedSignalPFChargedHadrCands_.reserve(onfile.selectedSignalPFChargedHadrCands_.size());
+    for (const auto& cand : onfile.selectedSignalPFChargedHadrCands_)
+      selectedSignalPFChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFNeutrHadrCands_;" targetClass="reco::PFTau" target="selectedSignalPFNeutrHadrCands_">
+    <![CDATA[
+    selectedSignalPFNeutrHadrCands_.reserve(onfile.selectedSignalPFNeutrHadrCands_.size());
+    for (const auto& cand : onfile.selectedSignalPFNeutrHadrCands_)
+      selectedSignalPFNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));;]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedSignalPFGammaCands_;" targetClass="reco::PFTau" target="selectedSignalPFGammaCands_">
+    <![CDATA[
+    selectedSignalPFGammaCands_.reserve(onfile.selectedSignalPFGammaCands_.size());
+    for (const auto& cand : onfile.selectedSignalPFGammaCands_)
+      selectedSignalPFGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFCands_;" targetClass="reco::PFTau" target="selectedIsolationPFCands_">
+    <![CDATA[
+    selectedIsolationPFCands_.reserve(onfile.selectedIsolationPFCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFCands_)
+      selectedIsolationPFCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFChargedHadrCands_;" targetClass="reco::PFTau" target="selectedIsolationPFChargedHadrCands_">
+    <![CDATA[
+    selectedIsolationPFChargedHadrCands_.reserve(onfile.selectedIsolationPFChargedHadrCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFChargedHadrCands_)
+      selectedIsolationPFChargedHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFNeutrHadrCands_;" targetClass="reco::PFTau" target="selectedIsolationPFNeutrHadrCands_">
+    <![CDATA[
+    selectedIsolationPFNeutrHadrCands_.reserve(onfile.selectedIsolationPFNeutrHadrCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFNeutrHadrCands_)
+      selectedIsolationPFNeutrHadrCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[12-19]" source="std::vector<edm::Ptr<reco::PFCandidate> > selectedIsolationPFGammaCands_;" targetClass="reco::PFTau" target="selectedIsolationPFGammaCands_">
+    <![CDATA[
+    selectedIsolationPFGammaCands_.reserve(onfile.selectedIsolationPFGammaCands_.size());
+    for (const auto& cand : onfile.selectedIsolationPFGammaCands_)
+      selectedIsolationPFGammaCands_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFTau" version="[-19]" source="edm::Ref<vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<vector<reco::PFJet>,reco::PFJet> > jetRef_;" targetClass="reco::PFTau" target="jetRef_" include="DataFormats/JetReco/interface/PFJet.h">
+    <![CDATA[jetRef_ = reco::JetBaseRef(onfile.jetRef_);]]>
+  </ioread>
+
  <ioread sourceClass="reco::PFTau" version="[-11]" source="reco::PFCandidateRef leadPFChargedHadrCand_;" targetClass="reco::PFTau" target="leadPFChargedHadrCand_" include="DataFormats/Common/interface/RefToPtr.h">
     <![CDATA[leadPFChargedHadrCand_ = edm::refToPtr(onfile.leadPFChargedHadrCand_);]]>
   </ioread>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -372,6 +372,18 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::RefVector<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> > >" />
 
+<ioread sourceClass="reco::PFRecoTauChargedHadron" version="[-14]" source="edm::Ptr<reco::PFCandidate> chargedPFCandidate_;" targetClass="reco::PFRecoTauChargedHadron" target="chargedPFCandidate_">
+   <![CDATA[chargedPFCandidate_ = edm::Ptr<reco::Candidate>(onfile.chargedPFCandidate_);]]>
+  </ioread>
+
+<ioread sourceClass="reco::PFRecoTauChargedHadron" version="[-14]" source="std::vector<edm::Ptr<reco::PFCandidate> > neutralPFCandidates_;" targetClass="reco::PFRecoTauChargedHadron" target="neutralPFCandidates_">
+    <![CDATA[
+    neutralPFCandidates_.reserve(onfile.neutralPFCandidates_.size());
+    for (const auto& cand : onfile.neutralPFCandidates_)
+      neutralPFCandidates_.push_back(edm::Ptr<reco::Candidate>(cand));]]>
+  </ioread>
+
+
   <class name="reco::CaloTauDiscriminatorByIsolationBase">
     <field name="transientVector_" transient="true"/>
   </class>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -72,6 +72,9 @@
   <class name="std::pair<reco::PFJetRef, std::vector<reco::RecoTauPiZero> >"/>
   <class name="std::vector<std::pair<reco::PFJetRef, std::vector<reco::RecoTauPiZero> > >" />
 
+  <class name="std::pair<reco::JetBaseRef, std::vector<reco::RecoTauPiZero> >"/>
+  <class name="std::vector<std::pair<reco::JetBaseRef, std::vector<reco::RecoTauPiZero> > >" />
+
   <class name="reco::PFJetChargedHadronAssociationBase">
     <field name="transientVector_" transient="true"/>
   </class>
@@ -89,6 +92,9 @@
 
   <class name="std::pair<reco::PFJetRef, std::vector<reco::PFRecoTauChargedHadron> >"/>
   <class name="std::vector<std::pair<reco::PFJetRef, std::vector<reco::PFRecoTauChargedHadron> > >" />
+
+  <class name="std::pair<reco::JetBaseRef, std::vector<reco::PFRecoTauChargedHadron> >"/>
+  <class name="std::vector<std::pair<reco::JetBaseRef, std::vector<reco::PFRecoTauChargedHadron> > >" />
 
   <class name="reco::PFTauDecayModeAssociation">
     <field name="transientVector_" transient="true"/>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -58,9 +58,10 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::JetPiZeroAssociation" ClassVersion="11">
+  <class name="reco::JetPiZeroAssociation" ClassVersion="12">
    <version ClassVersion="10" checksum="3488813045"/>
    <version ClassVersion="11" checksum="2107652063"/>
+   <version ClassVersion="12" checksum="2981210128"/>
     <!-- <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::JetPiZeroAssociationRef"/>
@@ -75,9 +76,10 @@
     <field name="transientVector_" transient="true"/>
   </class>
 
-  <class name="reco::PFJetChargedHadronAssociation" ClassVersion="11">
+  <class name="reco::PFJetChargedHadronAssociation" ClassVersion="12">
    <version ClassVersion="10" checksum="3498827707"/>
    <version ClassVersion="11" checksum="269001295"/>
+   <version ClassVersion="12" checksum="1002363278"/>
 <!--     <field name="transientVector_" transient="true"/> -->
   </class>
   <class name="reco::PFJetChargedHadronAssociationRef"/>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -237,5 +237,19 @@
 <!--  <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/> -->
 <!--  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/> -->
 
+  <class name="edm::Association<std::vector<pat::Jet> >"/>
+  <class name="edm::Wrapper<edm::Association<std::vector<pat::Jet> > >"/>
+  <class name="edm::RefProd<vector<pat::Jet> >"/>
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<pat::Jet>,std::vector<pat::PackedCandidate>,unsigned int> >">
+    <field name="transientMap_" transient="true" />
+  </class>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<pat::Jet>,std::vector<pat::PackedCandidate>,unsigned int> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<pat::Jet> >,edm::RefProd<vector<pat::PackedCandidate> > >"/>
+
+  <class name="edm::AssociationMap<edm::OneToOne<edm::View<reco::Jet>,edm::View<reco::Jet>,unsigned int> >">
+      <field name="transientMap_" transient="true" />
+  </class>
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<edm::View<reco::Jet>,edm::View<reco::Jet>,unsigned int> > >"/>
+  <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::Jet>,edm::RefToBaseProd<reco::Jet> >"/>
 
 </lcgdict>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -62,7 +62,7 @@
    <version ClassVersion="10" checksum="3488813045"/>
    <version ClassVersion="11" checksum="2107652063"/>
    <version ClassVersion="12" checksum="2981210128"/>
-    <!-- <field name="transientVector_" transient="true"/> -->
+    <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::JetPiZeroAssociationRef"/>
   <class name="reco::JetPiZeroAssociationRefProd"/>
@@ -83,7 +83,7 @@
    <version ClassVersion="10" checksum="3498827707"/>
    <version ClassVersion="11" checksum="269001295"/>
    <version ClassVersion="12" checksum="1002363278"/>
-<!--     <field name="transientVector_" transient="true"/> -->
+    <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::PFJetChargedHadronAssociationRef"/>
   <class name="reco::PFJetChargedHadronAssociationRefProd"/>

--- a/Fireworks/Calo/plugins/FWPFTauProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWPFTauProxyBuilder.cc
@@ -63,7 +63,7 @@ FWPFTauProxyBuilder::buildViewType( const FWEventItem* iItem, TEveElementList* p
          // prepare phi-list and theta range
          try {
             const reco::PFTauTagInfo *tauTagInfo = dynamic_cast<const reco::PFTauTagInfo*>( (*it).pfTauTagInfoRef().get() );
-            const reco::PFJet *jet = dynamic_cast<const reco::PFJet*>( tauTagInfo->pfjetRef().get() );
+            const reco::Jet *jet = tauTagInfo->pfjetRef().get();
             m_minTheta =  100;
             m_maxTheta = -100;
             std::vector<double> phis;

--- a/PhysicsTools/IsolationAlgos/plugins/PFTauExtractor.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/PFTauExtractor.cc
@@ -4,8 +4,8 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/RecoCandidate/interface/IsoDepositDirection.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 #include "DataFormats/Math/interface/deltaR.h"
 
@@ -65,7 +65,7 @@ reco::IsoDeposit PFTauExtractor::depositFromObject(const edm::Event& evt, const 
 //--- check that the candidate is not associated to one of the tau decay products
 //    within the signal cone of the PFTau
 	bool isSignalCone = false;
-	for ( std::vector<reco::PFCandidatePtr>::const_iterator tauSignalConeConstituent = pfTau_matched->signalPFCands().begin();
+	for ( std::vector<reco::CandidatePtr>::const_iterator tauSignalConeConstituent = pfTau_matched->signalPFCands().begin();
 	      tauSignalConeConstituent != pfTau_matched->signalPFCands().end(); ++tauSignalConeConstituent ) {
 	  double dR = deltaR(candidate->momentum(), (*tauSignalConeConstituent)->momentum());
 	  if ( dR <= dRvetoPFTauSignalConeConstituents_ ) isSignalCone = true;

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -371,7 +371,7 @@ void PATTauProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
     }
 
     // extraction of variables needed to rerun MVA isolation and anti-electron discriminator on MiniAOD
-    if( aTau.isPFTau() ) {
+    if( !aTau.pfEssential_.empty() ) {
       edm::Handle<reco::PFTauCollection> pfTaus;
       iEvent.getByToken(pfTauToken_, pfTaus);
       reco::PFTauRef pfTauRef(pfTaus, idx);

--- a/RecoMET/METPUSubtraction/interface/PFMEtSignInterfaceBase.h
+++ b/RecoMET/METPUSubtraction/interface/PFMEtSignInterfaceBase.h
@@ -101,11 +101,27 @@ class PFMEtSignInterfaceBase
       if ( dynamic_cast<const pat::Tau*>(particle) != nullptr ) {
 	const pat::Tau* pfTau = dynamic_cast<const pat::Tau*>(particle);
 	//std::cout << "tau: pt = " << pt << ", eta = " << eta << ", phi = " << phi << std::endl;
-	return pfMEtResolution_->evalPFJet(pfTau->pfJetRef().get());
+	const reco::PFJet* pfJet = dynamic_cast<const reco::PFJet*>(pfTau->pfJetRef().get());
+	if (pfJet != nullptr)
+	  return pfMEtResolution_->evalPFJet(pfJet);
+
+	const pat::Jet* patJet = dynamic_cast<const pat::Jet*>(pfTau->pfJetRef().get());
+	if (patJet != nullptr) {
+	  reco::PFJet pfJet(patJet->p4(), patJet->vertex(), patJet->pfSpecific(), patJet->getJetConstituents());
+	  return pfMEtResolution_->evalPFJet(&pfJet);
+	}
+	else throw cms::Exception("addPFMEtSignObjects")
+	    << "Neither PAT jet nor PF Jet in tau object !!\n";
       } else if ( dynamic_cast<const reco::PFTau*>(particle) != nullptr  ) {
 	const reco::PFTau* pfTau = dynamic_cast<const reco::PFTau*>(particle);
 	//std::cout << "tau: pt = " << pt << ", eta = " << eta << ", phi = " << phi << std::endl;
-	return pfMEtResolution_->evalPFJet(pfTau->jetRef().get());
+	const pat::Jet* patJet = dynamic_cast<const pat::Jet*>(pfTau->jetRef().get());
+	if (patJet != nullptr) {
+	  reco::PFJet pfJet(patJet->p4(), patJet->vertex(), patJet->pfSpecific(), patJet->getJetConstituents());
+	  return pfMEtResolution_->evalPFJet(&pfJet);
+	}
+	else throw cms::Exception("addPFMEtSignObjects")
+	    << "Neither PAT jet nor PF Jet in tau object !!\n";
       } else assert(0);
     } else if ( dynamic_cast<const reco::PFJet*>(particle) != nullptr ||
 		dynamic_cast<const pat::Jet*>(particle) != nullptr ) {

--- a/RecoParticleFlow/Benchmark/src/PFTauElecRejectionBenchmark.cc
+++ b/RecoParticleFlow/Benchmark/src/PFTauElecRejectionBenchmark.cc
@@ -44,6 +44,7 @@ void PFTauElecRejectionBenchmark::write() {
     
 } 
 
+
 void PFTauElecRejectionBenchmark::setup(
 					string Filename,
 					string benchmarkLabel,
@@ -256,10 +257,13 @@ void PFTauElecRejectionBenchmark::process(edm::Handle<edm::HepMCProduct> mcevt, 
       if ((*thePFTau).et() > minRecoPt_ && std::abs((*thePFTau).eta()) < maxRecoAbsEta_) {
 
 	// Check if track goes to Ecal crack
-	TrackRef myleadTk;
+	reco::TrackRef myleadTk;
 	if(thePFTau->leadPFChargedHadrCand().isNonnull()){
-	  myleadTk=thePFTau->leadPFChargedHadrCand()->trackRef();
-	  myleadTkEcalPos = thePFTau->leadPFChargedHadrCand()->positionAtECALEntrance();
+	  const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(thePFTau->leadPFChargedHadrCand().get());
+	  if (pflch != nullptr) {
+	    myleadTk=pflch->trackRef();
+	    myleadTkEcalPos = pflch->positionAtECALEntrance();
+	  }
 	  
 	  if(myleadTk.isNonnull()){ 
 	    if (applyEcalCrackCut_ && isInEcalCrack(std::abs((double)myleadTkEcalPos.eta()))) {
@@ -321,14 +325,17 @@ void PFTauElecRejectionBenchmark::process(edm::Handle<edm::HepMCProduct> mcevt, 
 		}
 
 		// Loop over all PFCands for cluster plots  
-		std::vector<PFCandidatePtr> myPFCands=(*thePFTau).pfTauTagInfoRef()->PFCands();
+		std::vector<CandidatePtr> myPFCands=(*thePFTau).pfTauTagInfoRef()->PFCands();
 		for(int i=0;i<(int)myPFCands.size();i++){
-
+		  const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(myPFCands[i].get());
+		  if (pfCand == nullptr)
+		    continue;
+		  
 		  math::XYZPointF candPos;
-		  if (myPFCands[i]->particleId()==1 || myPFCands[i]->particleId()==2) // if charged hadron or electron
-		    candPos = myPFCands[i]->positionAtECALEntrance();
+		  if (std::abs(pfCand->pdgId()) == 211 || std::abs(pfCand->pdgId()) == 11) // if charged hadron or electron
+		    candPos = pfCand->positionAtECALEntrance();
 		  else
-		    candPos = math::XYZPointF(myPFCands[i]->px(),myPFCands[i]->py(),myPFCands[i]->pz());
+		    candPos = math::XYZPointF(pfCand->px(),pfCand->py(),pfCand->pz());
 
 		  //double deltaR   = ROOT::Math::VectorUtil::DeltaR(myleadTkEcalPos,candPos);
 		  double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myleadTkEcalPos,candPos);
@@ -336,9 +343,9 @@ void PFTauElecRejectionBenchmark::process(edm::Handle<edm::HepMCProduct> mcevt, 
 		  double deltaPhiOverQ = deltaPhi/(double)myleadTk->charge();
 		  
 		  hpfcand_deltaEta->Fill(deltaEta);
-		  hpfcand_deltaEta_weightE->Fill(deltaEta*myPFCands[i]->ecalEnergy());
+		  hpfcand_deltaEta_weightE->Fill(deltaEta*pfCand->ecalEnergy());
 		  hpfcand_deltaPhiOverQ->Fill(deltaPhiOverQ);
-		  hpfcand_deltaPhiOverQ_weightE->Fill(deltaPhiOverQ*myPFCands[i]->ecalEnergy());	
+		  hpfcand_deltaPhiOverQ_weightE->Fill(deltaPhiOverQ*pfCand->ecalEnergy());	
 		  
 		}
 

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -584,7 +584,7 @@ hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT.mapping[0].cut = cms
 hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLTraw = hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw.clone(
     mvaName = cms.string("RecoTauTag_tauIdMVAPWoldDMwLTv1"),
     mvaOpt = cms.string("PWoldDMwLT"),
-    srcPUcorrPtSum = cms.InputTag('hpsPFTauNeutralIsoPtSumWeight'),
+    srcNeutralIsoPtSum = cms.InputTag('hpsPFTauNeutralIsoPtSumWeight'),
     verbosity = cms.int32(0)
 )
 
@@ -726,7 +726,7 @@ hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBdR03oldDMwLT.mapping[0].cut =
 hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw = hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw.clone(
     mvaName = cms.string("RecoTauTag_tauIdMVAPWdR03oldDMwLTv1"),
     mvaOpt = cms.string("PWoldDMwLT"),
-    srcPUcorrPtSum = cms.InputTag('hpsPFTauNeutralIsoPtSumWeightdR03'),
+    srcNeutralIsoPtSum = cms.InputTag('hpsPFTauNeutralIsoPtSumWeightdR03'),
     verbosity = cms.int32(0)
 )
 hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWdR03oldDMwLT = hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBdR03oldDMwLT.clone(

--- a/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+++ b/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
@@ -1,0 +1,326 @@
+import FWCore.ParameterSet.Config as cms
+
+######
+# Tools to adapt Tau sequences to run tau ReReco+PAT at MiniAOD samples
+# M. Bluj, NCBJ Warsaw
+# based on work of J. Steggemann, CERN
+# Created: 9 Nov. 2017
+######
+
+#####
+def addTauReReco(process):
+	#PAT
+	process.load('PhysicsTools.PatAlgos.producersLayer1.tauProducer_cff')
+	process.load('PhysicsTools.PatAlgos.selectionLayer1.tauSelector_cfi')
+	process.selectedPatTaus.cut="pt > 18. && tauID(\'decayModeFindingNewDMs\')> 0.5" #Cut as in MiniAOD
+	#Tau RECO
+	process.load("RecoTauTag.Configuration.RecoPFTauTag_cff")
+        #Task/Sequence for tau rereco
+        process.miniAODTausTask = cms.Task()
+	process.miniAODTausTask.add(process.PFTauTask)
+	#Add PAT Tau modules to miniAODTausTask
+        process.miniAODTausTask.add(process.makePatTausTask)
+        process.miniAODTausTask.add(process.selectedPatTaus)
+	process.miniAODTausSequence = cms.Sequence(process.miniAODTausTask)
+	#Path with tau rereco (Needed?)
+        process.TauReco = cms.Path(process.miniAODTausSequence)
+
+#####
+def convertModuleToBaseTau(process, name):
+    module = getattr(process, name)
+    module.__dict__['_TypedParameterizable__type'] = module.type_().replace('RecoTau', 'RecoBaseTau')
+    #MBif hasattr(module, 'PFTauProducer'):
+    #MB    module.PFBaseTauProducer = module.PFTauProducer
+    #MB    # del module.PFTauProducer
+    if hasattr(module, 'particleFlowSrc'):
+        module.particleFlowSrc = cms.InputTag("packedPFCandidates", "", "")
+    if hasattr(module, 'vertexSrc'):
+        module.vertexSrc = cms.InputTag('offlineSlimmedPrimaryVertices')
+    if hasattr(module, 'qualityCuts') and hasattr(module.qualityCuts, 'primaryVertexSrc'):
+        module.qualityCuts.primaryVertexSrc = cms.InputTag('offlineSlimmedPrimaryVertices')
+
+#####
+def adaptTauToMiniAODReReco(process, reclusterJets=True):
+	# TRYING TO MAKE THINGS MINIAOD COMPATIBLE, FROM THE START, TO THE END, 1 BY 1
+	#print '[adaptTauToMiniAODReReco]: Start'
+
+	jetCollection = 'slimmedJets'
+	# Add new jet collections if reclustering is demanded
+	if reclusterJets:
+		jetCollection = 'patAK4PFJets'
+		from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+		process.ak4PFJetsPAT = ak4PFJets.clone(
+			src=cms.InputTag("packedPFCandidates")
+		)
+		# trivial PATJets
+		from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import _patJets
+		process.patAK4PFJets = _patJets.clone(
+			jetSource            = cms.InputTag("ak4PFJetsPAT"),
+			addJetCorrFactors    = cms.bool(False),
+			jetCorrFactorsSource = cms.VInputTag(),
+			addBTagInfo          = cms.bool(False),
+			addDiscriminators    = cms.bool(False),
+			discriminatorSources = cms.VInputTag(),
+			addAssociatedTracks  = cms.bool(False),
+			addJetCharge         = cms.bool(False),
+			addGenPartonMatch    = cms.bool(False),
+			embedGenPartonMatch  = cms.bool(False),
+			addGenJetMatch       = cms.bool(False),
+			getJetMCFlavour      = cms.bool(False),
+			addJetFlavourInfo    = cms.bool(False),
+		)
+		process.miniAODTausTask.add(process.ak4PFJetsPAT)
+		process.miniAODTausTask.add(process.patAK4PFJets)
+ 
+	# so this adds all tracks to jet in some deltaR region. we don't have tracks so don't need it :D
+	# process.ak4PFJetTracksAssociatorAtVertex.jets = cms.InputTag(jetCollection)
+	
+	# Remove ak4PFJetTracksAssociatorAtVertex from recoTauCommonSequence
+	# Remove pfRecoTauTagInfoProducer from recoTauCommonSequence since it uses the jet-track association
+	# HOWEVER, may use https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2017#Isolated_Tracks
+	# probably needs recovery of the two modules above
+
+
+	process.recoTauAK4PatJets08Region = cms.EDProducer("RecoTauPatJetRegionProducer",
+		deltaR = process.recoTauAK4PFJets08Region.deltaR,
+		maxJetAbsEta = process.recoTauAK4PFJets08Region.maxJetAbsEta,
+		minJetPt = process.recoTauAK4PFJets08Region.minJetPt,
+		pfCandAssocMapSrc = cms.InputTag(""),
+		pfCandSrc = cms.InputTag("packedPFCandidates"),
+		src = cms.InputTag(jetCollection)
+	)
+
+	process.recoTauPileUpVertices.src = cms.InputTag("offlineSlimmedPrimaryVertices")
+	# Redefine recoTauCommonTask 
+	# with redefined region and PU vertices, and w/o track-to-vertex associator and tauTagInfo (the two latter are probably obsolete and not needed at all)
+	process.recoTauCommonTask = cms.Task(
+		process.recoTauAK4PatJets08Region,
+		process.recoTauPileUpVertices
+	)
+
+	# Adapt TauPiZeros producer
+	process.ak4PFJetsLegacyHPSPiZeros.builders[0].qualityCuts.primaryVertexSrc = cms.InputTag("offlineSlimmedPrimaryVertices")
+	process.ak4PFJetsLegacyHPSPiZeros.jetSrc = cms.InputTag(jetCollection)
+
+	# Adapt TauChargedHadrons producer
+	for builder in process.ak4PFJetsRecoTauChargedHadrons.builders:
+		builder.qualityCuts.primaryVertexSrc = cms.InputTag("offlineSlimmedPrimaryVertices")
+		if builder.name.value() == 'tracks': #replace plugin based on generalTracks by one based on lostTracks
+			builder.name = 'lostTracks'
+			builder.plugin = 'PFRecoTauChargedHadronFromLostTrackPlugin'
+			builder.srcLostTracks = cms.InputTag("lostTracks")
+			del builder.srcTracks
+	process.ak4PFJetsRecoTauChargedHadrons.jetSrc = cms.InputTag(jetCollection)
+
+	# Adapt combinatoricRecoTau producer
+	convertModuleToBaseTau(process, 'combinatoricRecoTaus')
+	process.combinatoricRecoTaus.jetRegionSrc = 'recoTauAK4PatJets08Region'
+	process.combinatoricRecoTaus.jetSrc = jetCollection
+	# Adapt builders
+	for builer in process.combinatoricRecoTaus.builders:
+		builer.plugin = builer.plugin.value().replace('RecoTau', 'RecoBaseTau')
+		for name,value in builer.parameters_().iteritems():
+			if name == 'qualityCuts':
+				builer.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
+			elif name == 'pfCandSrc':
+				builer.pfCandSrc = 'packedPFCandidates'
+	# Adapt supported modifiers and remove unsupported ones 
+	modifiersToRemove_ = cms.VPSet()
+	for mod in process.combinatoricRecoTaus.modifiers:
+		if mod.name.value() == 'elec_rej':
+			modifiersToRemove_.append(mod)
+			continue
+		elif mod.name.value() == 'TTIworkaround':
+			modifiersToRemove_.append(mod)
+			continue
+		mod.plugin = mod.plugin.value().replace('RecoTau', 'RecoBaseTau')
+		for name,value in mod.parameters_().iteritems():
+			if name == 'qualityCuts':
+				mod.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
+	for mod in modifiersToRemove_:
+		process.combinatoricRecoTaus.modifiers.remove(mod)
+		#print "\t\t Removing '%s' modifier from 'combinatoricRecoTaus'" %mod.name.value()
+
+	# Adapt tau decay mode finding discrimiantor for the cleaning step
+	convertModuleToBaseTau(process, 'hpsSelectionDiscriminator')
+
+	# Adapt clean tau producer
+	convertModuleToBaseTau(process, 'hpsPFTauProducerSansRefs')
+	# Adapt cleaners
+	for cleaner in process.hpsPFTauProducerSansRefs.cleaners:
+		cleaner.plugin = cleaner.plugin.value().replace('RecoTau', 'RecoBaseTau')
+
+	# Adapt piZero unembedder
+	convertModuleToBaseTau(process, 'hpsPFTauProducer')
+
+	# Adapt classic discriminants
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByDecayModeFindingNewDMs')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByDecayModeFindingOldDMs')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByDecayModeFinding')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseChargedIsolation')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseIsolation')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits')
+
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsdR03')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsdR03')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03')
+
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByMediumPileupWeightedIsolation3Hits')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByTightPileupWeightedIsolation3Hits')
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByRawPileupWeightedIsolation3Hits')
+
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByPhotonPtSumOutsideSignalCone')
+
+	# Adapt isolation sums
+	convertModuleToBaseTau(process, 'hpsPFTauChargedIsoPtSum')
+	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSum')
+	convertModuleToBaseTau(process, 'hpsPFTauPUcorrPtSum')
+	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSumWeight')
+	convertModuleToBaseTau(process, 'hpsPFTauFootprintCorrection')
+	convertModuleToBaseTau(process, 'hpsPFTauPhotonPtSumOutsideSignalCone')
+	# Adapt isolation sums (R=0.3)
+	convertModuleToBaseTau(process, 'hpsPFTauChargedIsoPtSumdR03')
+	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSumdR03')
+	convertModuleToBaseTau(process, 'hpsPFTauPUcorrPtSumdR03')
+	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSumWeightdR03')
+	convertModuleToBaseTau(process, 'hpsPFTauFootprintCorrectiondR03')
+	convertModuleToBaseTau(process, 'hpsPFTauPhotonPtSumOutsideSignalConedR03')
+
+	# Redefine tau PV producer
+	process.hpsPFTauPrimaryVertexProducer.__dict__['_TypedParameterizable__type'] = 'PFBaseTauPrimaryVertexProducer'
+	process.hpsPFTauPrimaryVertexProducer.PVTag = 'offlineSlimmedPrimaryVertices'
+	process.hpsPFTauPrimaryVertexProducer.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
+	process.hpsPFTauPrimaryVertexProducer.packedCandidatesTag = cms.InputTag("packedPFCandidates")
+	process.hpsPFTauPrimaryVertexProducer.lostCandidatesTag = cms.InputTag("lostTracks")
+
+	# Redefine tau SV producer
+	process.hpsPFTauSecondaryVertexProducer = cms.EDProducer("PFBaseTauSecondaryVertexProducer",
+		PFTauTag = cms.InputTag("hpsPFTauProducer")
+	)
+	# Redefine IP producer
+	process.hpsPFTauTransverseImpactParameters.__dict__['_TypedParameterizable__type'] = 'PFBaseTauTransverseImpactParameters'
+
+	# Adapt MVAIso discriminants (DBoldDMwLT)
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw')
+	for wp in ['VVLoose', 'VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
+		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBoldDMwLT'.format(wp))
+	# Adapt MVAIso discriminants (DBnewDMwLT)
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw')
+	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
+		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBnewDMwLT'.format(wp))
+	# Adapt MVAIso discriminants (PWoldDMwLT)
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLTraw')
+	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
+		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWoldDMwLT'.format(wp))
+	# Adapt MVAIso discriminants (PWnewDMwLT)
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLTraw')
+	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
+		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWnewDMwLT'.format(wp))
+	# Adapt MVAIso discriminants (DBoldDMwLT, R=0.3)
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw')
+	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
+		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBdR03oldDMwLT'.format(wp))
+	# Adapt MVAIso discriminants (PWoldDMwLT, R=0.3)
+	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw')
+	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
+		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWdR03oldDMwLT'.format(wp))
+
+	# Remove RecoTau producers which are not supported (yet?), i.e. against-e/mu discriminats
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByTightElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMediumElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByLooseElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMVA6rawElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMVA6VLooseElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMVA6LooseElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMVA6MediumElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMVA6TightElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByMVA6VTightElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByDeadECALElectronRejection)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByLooseMuonRejection3)
+	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByTightMuonRejection3)
+	# add against-mu discriminants which are MiniAOD compatible
+	process.hpsPFTauDiscriminationByLooseMuonRejectionSimple = cms.EDProducer("PFRecoBaseTauDiscriminationAgainstMuonSimple",
+		PFTauProducer = cms.InputTag("hpsPFTauProducer"),
+		Prediscriminants = process.hpsPFTauDiscriminationByLooseMuonRejection3.Prediscriminants,
+		HoPMin = cms.double(0.1), #use smaller value that with AOD as raw energy is used
+		doCaloMuonVeto = cms.bool(False), #do not use it until tuned
+		srcPatMuons = cms.InputTag("slimmedMuons"),
+		minPtMatchedMuon = process.hpsPFTauDiscriminationByLooseMuonRejection3.minPtMatchedMuon,
+		dRmuonMatch = process.hpsPFTauDiscriminationByLooseMuonRejection3.dRmuonMatch,
+		dRmuonMatchLimitedToJetArea = process.hpsPFTauDiscriminationByLooseMuonRejection3.dRmuonMatchLimitedToJetArea,
+		maskHitsCSC = process.hpsPFTauDiscriminationByLooseMuonRejection3.maskHitsCSC,
+		maskHitsDT = process.hpsPFTauDiscriminationByLooseMuonRejection3.maskHitsDT,
+		maskHitsRPC = process.hpsPFTauDiscriminationByLooseMuonRejection3.maskHitsRPC,
+		maxNumberOfHitsLast2Stations = process.hpsPFTauDiscriminationByLooseMuonRejection3.maxNumberOfHitsLast2Stations,
+		maskMatchesCSC = process.hpsPFTauDiscriminationByLooseMuonRejection3.maskMatchesCSC,
+		maskMatchesDT = process.hpsPFTauDiscriminationByLooseMuonRejection3.maskMatchesDT,
+		maskMatchesRPC = process.hpsPFTauDiscriminationByLooseMuonRejection3.maskMatchesRPC,
+		maxNumberOfMatches = process.hpsPFTauDiscriminationByLooseMuonRejection3.maxNumberOfMatches,
+		maxNumberOfSTAMuons = cms.int32(-1),
+		maxNumberOfRPCMuons = cms.int32(-1),
+		verbosity = cms.int32(0)
+	)
+	process.hpsPFTauDiscriminationByTightMuonRejectionSimple = process.hpsPFTauDiscriminationByLooseMuonRejectionSimple.clone(
+		maxNumberOfHitsLast2Stations = process.hpsPFTauDiscriminationByTightMuonRejection3.maxNumberOfHitsLast2Stations
+	)
+	process.miniAODTausTask.add(process.hpsPFTauDiscriminationByLooseMuonRejectionSimple)
+	process.miniAODTausTask.add(process.hpsPFTauDiscriminationByTightMuonRejectionSimple)
+
+	#####
+	# OK NOW COMES PATTY PAT
+
+	# FIXME - check both if this is the OK collection...
+	process.tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")
+	process.tauMatch.matched = cms.InputTag("prunedGenParticles")
+
+
+	process.patTaus.__dict__['_TypedParameterizable__type'] = 'PATTauBaseProducer'
+	convertModuleToBaseTau(process, 'patTaus')
+
+	# Remove unsupported tauIDs
+	for name, src in process.patTaus.tauIDSources.parameters_().iteritems():
+		if name.find('againstElectron') > -1 or name.find('againstMuon') > -1:
+			delattr(process.patTaus.tauIDSources,name)
+	# Add MiniAOD specific ones
+	setattr(process.patTaus.tauIDSources,'againstMuonLooseSimple',cms.InputTag('hpsPFTauDiscriminationByLooseMuonRejectionSimple'))
+	setattr(process.patTaus.tauIDSources,'againstMuonTightSimple',cms.InputTag('hpsPFTauDiscriminationByTightMuonRejectionSimple'))
+	
+	#print '[adaptTauToMiniAODReReco]: Done!'
+
+#####
+def setOutputModule(mode=0):
+	#mode = 0: store original MiniAOD and new selectedPatTaus 
+	#mode = 1: store original MiniAOD, new selectedPatTaus, and all PFTau products as in AOD (except of unsuported ones)
+
+	import Configuration.EventContent.EventContent_cff as evtContent
+	output = cms.OutputModule(
+		'PoolOutputModule',
+		fileName=cms.untracked.string('miniAOD_TauReco.root'),
+		fastCloning=cms.untracked.bool(False),
+		dataset=cms.untracked.PSet(
+			dataTier=cms.untracked.string('MINIAODSIM'),
+			filterName=cms.untracked.string('')
+		),
+		outputCommands = evtContent.MINIAODSIMEventContent.outputCommands,
+		SelectEvents=cms.untracked.PSet(
+			SelectEvents=cms.vstring('*',)
+			)
+		)
+	output.outputCommands.append('keep *_selectedPatTaus_*_*')
+	if mode==1:
+                for prod in evtContent.RecoTauTagAOD.outputCommands:
+			if prod.find('ElectronRejection') > -1:
+				continue
+			if prod.find('MuonRejection') > -1:
+				continue
+			output.outputCommands.append(prod)
+		output.outputCommands.append('keep *_hpsPFTauDiscriminationByLooseMuonRejectionSimple_*_*')
+		output.outputCommands.append('keep *_hpsPFTauDiscriminationByTightMuonRejectionSimple_*_*')
+
+	return output
+
+#####

--- a/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+++ b/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
@@ -26,12 +26,8 @@ def addTauReReco(process):
         process.TauReco = cms.Path(process.miniAODTausSequence)
 
 #####
-def convertModuleToBaseTau(process, name):
+def convertModuleToMiniAODInput(process, name):
     module = getattr(process, name)
-    module.__dict__['_TypedParameterizable__type'] = module.type_().replace('RecoTau', 'RecoBaseTau')
-    #MBif hasattr(module, 'PFTauProducer'):
-    #MB    module.PFBaseTauProducer = module.PFTauProducer
-    #MB    # del module.PFTauProducer
     if hasattr(module, 'particleFlowSrc'):
         module.particleFlowSrc = cms.InputTag("packedPFCandidates", "", "")
     if hasattr(module, 'vertexSrc'):
@@ -113,17 +109,16 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 	process.ak4PFJetsRecoTauChargedHadrons.jetSrc = cms.InputTag(jetCollection)
 
 	# Adapt combinatoricRecoTau producer
-	convertModuleToBaseTau(process, 'combinatoricRecoTaus')
+	convertModuleToMiniAODInput(process, 'combinatoricRecoTaus')
 	process.combinatoricRecoTaus.jetRegionSrc = 'recoTauAK4PatJets08Region'
 	process.combinatoricRecoTaus.jetSrc = jetCollection
 	# Adapt builders
-	for builer in process.combinatoricRecoTaus.builders:
-		builer.plugin = builer.plugin.value().replace('RecoTau', 'RecoBaseTau')
-		for name,value in builer.parameters_().iteritems():
+	for builder in process.combinatoricRecoTaus.builders:
+		for name,value in builder.parameters_().iteritems():
 			if name == 'qualityCuts':
-				builer.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
+				builder.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
 			elif name == 'pfCandSrc':
-				builer.pfCandSrc = 'packedPFCandidates'
+				builder.pfCandSrc = 'packedPFCandidates'
 	# Adapt supported modifiers and remove unsupported ones 
 	modifiersToRemove_ = cms.VPSet()
 	for mod in process.combinatoricRecoTaus.modifiers:
@@ -133,7 +128,6 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 		elif mod.name.value() == 'TTIworkaround':
 			modifiersToRemove_.append(mod)
 			continue
-		mod.plugin = mod.plugin.value().replace('RecoTau', 'RecoBaseTau')
 		for name,value in mod.parameters_().iteritems():
 			if name == 'qualityCuts':
 				mod.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
@@ -142,92 +136,86 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 		#print "\t\t Removing '%s' modifier from 'combinatoricRecoTaus'" %mod.name.value()
 
 	# Adapt tau decay mode finding discrimiantor for the cleaning step
-	convertModuleToBaseTau(process, 'hpsSelectionDiscriminator')
+	convertModuleToMiniAODInput(process, 'hpsSelectionDiscriminator')
 
 	# Adapt clean tau producer
-	convertModuleToBaseTau(process, 'hpsPFTauProducerSansRefs')
-	# Adapt cleaners
-	for cleaner in process.hpsPFTauProducerSansRefs.cleaners:
-		cleaner.plugin = cleaner.plugin.value().replace('RecoTau', 'RecoBaseTau')
+	convertModuleToMiniAODInput(process, 'hpsPFTauProducerSansRefs')
 
 	# Adapt piZero unembedder
-	convertModuleToBaseTau(process, 'hpsPFTauProducer')
+	convertModuleToMiniAODInput(process, 'hpsPFTauProducer')
 
 	# Adapt classic discriminants
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByDecayModeFindingNewDMs')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByDecayModeFindingOldDMs')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByDecayModeFinding')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseChargedIsolation')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseIsolation')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByDecayModeFindingNewDMs')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByDecayModeFindingOldDMs')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByDecayModeFinding')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByLooseChargedIsolation')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByLooseIsolation')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits')
 
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsdR03')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsdR03')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3HitsdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3HitsdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3HitsdR03')
 
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByMediumPileupWeightedIsolation3Hits')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByTightPileupWeightedIsolation3Hits')
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByRawPileupWeightedIsolation3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByLoosePileupWeightedIsolation3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByMediumPileupWeightedIsolation3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByTightPileupWeightedIsolation3Hits')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByRawPileupWeightedIsolation3Hits')
 
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByPhotonPtSumOutsideSignalCone')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByPhotonPtSumOutsideSignalCone')
 
 	# Adapt isolation sums
-	convertModuleToBaseTau(process, 'hpsPFTauChargedIsoPtSum')
-	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSum')
-	convertModuleToBaseTau(process, 'hpsPFTauPUcorrPtSum')
-	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSumWeight')
-	convertModuleToBaseTau(process, 'hpsPFTauFootprintCorrection')
-	convertModuleToBaseTau(process, 'hpsPFTauPhotonPtSumOutsideSignalCone')
+	convertModuleToMiniAODInput(process, 'hpsPFTauChargedIsoPtSum')
+	convertModuleToMiniAODInput(process, 'hpsPFTauNeutralIsoPtSum')
+	convertModuleToMiniAODInput(process, 'hpsPFTauPUcorrPtSum')
+	convertModuleToMiniAODInput(process, 'hpsPFTauNeutralIsoPtSumWeight')
+	convertModuleToMiniAODInput(process, 'hpsPFTauFootprintCorrection')
+	convertModuleToMiniAODInput(process, 'hpsPFTauPhotonPtSumOutsideSignalCone')
 	# Adapt isolation sums (R=0.3)
-	convertModuleToBaseTau(process, 'hpsPFTauChargedIsoPtSumdR03')
-	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSumdR03')
-	convertModuleToBaseTau(process, 'hpsPFTauPUcorrPtSumdR03')
-	convertModuleToBaseTau(process, 'hpsPFTauNeutralIsoPtSumWeightdR03')
-	convertModuleToBaseTau(process, 'hpsPFTauFootprintCorrectiondR03')
-	convertModuleToBaseTau(process, 'hpsPFTauPhotonPtSumOutsideSignalConedR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauChargedIsoPtSumdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauNeutralIsoPtSumdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauPUcorrPtSumdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauNeutralIsoPtSumWeightdR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauFootprintCorrectiondR03')
+	convertModuleToMiniAODInput(process, 'hpsPFTauPhotonPtSumOutsideSignalConedR03')
 
 	# Redefine tau PV producer
-	process.hpsPFTauPrimaryVertexProducer.__dict__['_TypedParameterizable__type'] = 'PFBaseTauPrimaryVertexProducer'
 	process.hpsPFTauPrimaryVertexProducer.PVTag = 'offlineSlimmedPrimaryVertices'
 	process.hpsPFTauPrimaryVertexProducer.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
 	process.hpsPFTauPrimaryVertexProducer.packedCandidatesTag = cms.InputTag("packedPFCandidates")
 	process.hpsPFTauPrimaryVertexProducer.lostCandidatesTag = cms.InputTag("lostTracks")
 
 	# Redefine tau SV producer
-	process.hpsPFTauSecondaryVertexProducer = cms.EDProducer("PFBaseTauSecondaryVertexProducer",
+	process.hpsPFTauSecondaryVertexProducer = cms.EDProducer("PFTauSecondaryVertexProducer",
 		PFTauTag = cms.InputTag("hpsPFTauProducer")
 	)
-	# Redefine IP producer
-	process.hpsPFTauTransverseImpactParameters.__dict__['_TypedParameterizable__type'] = 'PFBaseTauTransverseImpactParameters'
 
 	# Adapt MVAIso discriminants (DBoldDMwLT)
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw')
 	for wp in ['VVLoose', 'VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
-		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBoldDMwLT'.format(wp))
+		convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBoldDMwLT'.format(wp))
 	# Adapt MVAIso discriminants (DBnewDMwLT)
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw')
 	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
-		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBnewDMwLT'.format(wp))
+		convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBnewDMwLT'.format(wp))
 	# Adapt MVAIso discriminants (PWoldDMwLT)
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLTraw')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWoldDMwLTraw')
 	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
-		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWoldDMwLT'.format(wp))
+		convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWoldDMwLT'.format(wp))
 	# Adapt MVAIso discriminants (PWnewDMwLT)
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLTraw')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWnewDMwLTraw')
 	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
-		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWnewDMwLT'.format(wp))
+		convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWnewDMwLT'.format(wp))
 	# Adapt MVAIso discriminants (DBoldDMwLT, R=0.3)
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw')
 	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
-		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBdR03oldDMwLT'.format(wp))
+		convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1DBdR03oldDMwLT'.format(wp))
 	# Adapt MVAIso discriminants (PWoldDMwLT, R=0.3)
-	convertModuleToBaseTau(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw')
+	convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw')
 	for wp in ['VLoose', 'Loose', 'Medium', 'Tight', 'VTight', 'VVTight']:
-		convertModuleToBaseTau(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWdR03oldDMwLT'.format(wp))
+		convertModuleToMiniAODInput(process, 'hpsPFTauDiscriminationBy{}IsolationMVArun2v1PWdR03oldDMwLT'.format(wp))
 
 	# Remove RecoTau producers which are not supported (yet?), i.e. against-e/mu discriminats
 	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByTightElectronRejection)
@@ -243,7 +231,7 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByLooseMuonRejection3)
 	process.miniAODTausTask.remove(process.hpsPFTauDiscriminationByTightMuonRejection3)
 	# add against-mu discriminants which are MiniAOD compatible
-	process.hpsPFTauDiscriminationByLooseMuonRejectionSimple = cms.EDProducer("PFRecoBaseTauDiscriminationAgainstMuonSimple",
+	process.hpsPFTauDiscriminationByLooseMuonRejectionSimple = cms.EDProducer("PFRecoTauDiscriminationAgainstMuonSimple",
 		PFTauProducer = cms.InputTag("hpsPFTauProducer"),
 		Prediscriminants = process.hpsPFTauDiscriminationByLooseMuonRejection3.Prediscriminants,
 		HoPMin = cms.double(0.1), #use smaller value that with AOD as raw energy is used
@@ -278,8 +266,7 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 	process.tauMatch.matched = cms.InputTag("prunedGenParticles")
 
 
-	process.patTaus.__dict__['_TypedParameterizable__type'] = 'PATTauBaseProducer'
-	convertModuleToBaseTau(process, 'patTaus')
+	convertModuleToMiniAODInput(process, 'patTaus')
 
 	# Remove unsupported tauIDs
 	for name, src in process.patTaus.tauIDSources.parameters_().iteritems():

--- a/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+++ b/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
@@ -182,6 +182,7 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 	convertModuleToMiniAODInput(process, 'hpsPFTauPhotonPtSumOutsideSignalConedR03')
 
 	# Redefine tau PV producer
+	process.hpsPFTauPrimaryVertexProducer.__dict__['_TypedParameterizable__type'] = 'PFTauMiniAODPrimaryVertexProducer'
 	process.hpsPFTauPrimaryVertexProducer.PVTag = 'offlineSlimmedPrimaryVertices'
 	process.hpsPFTauPrimaryVertexProducer.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'
 	process.hpsPFTauPrimaryVertexProducer.packedCandidatesTag = cms.InputTag("packedPFCandidates")
@@ -298,6 +299,10 @@ def setOutputModule(mode=0):
 			)
 		)
 	output.outputCommands.append('keep *_selectedPatTaus_*_*')
+	output.outputCommands.append('keep *_combinatoricReco*_*_*')
+	output.outputCommands.append('keep *_ak4PFJetsRecoTauChargedHadrons_*_*')
+	output.outputCommands.append('keep *_ak4PFJetsLegacyHPSPiZeros_*_*')
+	output.outputCommands.append('keep *_patAK4PFJets_*_*')
 	if mode==1:
                 for prod in evtContent.RecoTauTagAOD.outputCommands:
 			if prod.find('ElectronRejection') > -1:

--- a/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+++ b/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
@@ -260,9 +260,8 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 	process.miniAODTausTask.add(process.hpsPFTauDiscriminationByTightMuonRejectionSimple)
 
 	#####
-	# OK NOW COMES PATTY PAT
+	# PAT part in the following
 
-	# FIXME - check both if this is the OK collection...
 	process.tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")
 	process.tauMatch.matched = cms.InputTag("prunedGenParticles")
 
@@ -282,7 +281,7 @@ def adaptTauToMiniAODReReco(process, reclusterJets=True):
 #####
 def setOutputModule(mode=0):
 	#mode = 0: store original MiniAOD and new selectedPatTaus 
-	#mode = 1: store original MiniAOD, new selectedPatTaus, and all PFTau products as in AOD (except of unsuported ones)
+	#mode = 1: store original MiniAOD, new selectedPatTaus, and all PFTau products as in AOD (except of unsuported ones), plus a few additional collections (charged hadrons, pi zeros, combinatoric reco taus)
 
 	import Configuration.EventContent.EventContent_cff as evtContent
 	output = cms.OutputModule(
@@ -299,10 +298,6 @@ def setOutputModule(mode=0):
 			)
 		)
 	output.outputCommands.append('keep *_selectedPatTaus_*_*')
-	output.outputCommands.append('keep *_combinatoricReco*_*_*')
-	output.outputCommands.append('keep *_ak4PFJetsRecoTauChargedHadrons_*_*')
-	output.outputCommands.append('keep *_ak4PFJetsLegacyHPSPiZeros_*_*')
-	output.outputCommands.append('keep *_patAK4PFJets_*_*')
 	if mode==1:
                 for prod in evtContent.RecoTauTagAOD.outputCommands:
 			if prod.find('ElectronRejection') > -1:
@@ -312,6 +307,10 @@ def setOutputModule(mode=0):
 			output.outputCommands.append(prod)
 		output.outputCommands.append('keep *_hpsPFTauDiscriminationByLooseMuonRejectionSimple_*_*')
 		output.outputCommands.append('keep *_hpsPFTauDiscriminationByTightMuonRejectionSimple_*_*')
+		output.outputCommands.append('keep *_combinatoricReco*_*_*')
+		output.outputCommands.append('keep *_ak4PFJetsRecoTauChargedHadrons_*_*')
+		output.outputCommands.append('keep *_ak4PFJetsLegacyHPSPiZeros_*_*')
+		output.outputCommands.append('keep *_patAK4PFJets_*_*')
 
 	return output
 

--- a/RecoTauTag/Configuration/test/tauFromMiniAOD.py
+++ b/RecoTauTag/Configuration/test/tauFromMiniAOD.py
@@ -1,0 +1,117 @@
+import FWCore.ParameterSet.Config as cms
+######
+# Configuration to run tau ReReco+PAT at MiniAOD samples
+# M. Bluj, NCBJ Warsaw
+# based on work of J. Steggemann, CERN
+# Created: 9 Nov. 2017
+######
+
+######
+runSignal=True
+#runSignal=False
+maxEvents=1000
+#maxEvents=-1
+
+# If 'reclusterJets' set true a new collection of uncorrected ak4PFJets is 
+# built to seed taus (as at RECO), otherwise standard slimmedJets are used
+reclusterJets=True 
+#reclusterJets=False
+
+#set true for upgrade studies
+phase2=False
+#phase2=True
+
+#Output mode
+outMode = 0 #store original MiniAOD and new selectedPatTaus 
+#outMode = 1 #store original MiniAOD, new selectedPatTaus, and all PFtau products as in AOD (except of unsuported ones)
+
+print 'Running Tau reco&id with MiniAOD inputs:'
+print '\t Run on signal:', runSignal
+print '\t Recluster jets:', reclusterJets
+print '\t Use Phase2 settings:', phase2
+print '\t Output mode:', outMode
+ 
+#####
+from Configuration.StandardSequences.Eras import eras
+era = eras.Run2_2017
+if phase2:
+	era = eras.Phase2_timing
+process = cms.Process("TAURECO",era)
+process.load("Configuration.StandardSequences.MagneticField_cff") # for CH reco
+if not phase2:
+	process.load("Configuration.Geometry.GeometryRecoDB_cff")
+else:
+	process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+
+#####
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(maxEvents)
+)
+print '\t Max events:', process.maxEvents.input.value()
+
+if runSignal:
+	readFiles.extend( [
+			'root://cms-xrd-global.cern.ch///store/relval/CMSSW_10_0_0_pre2/RelValZTT_13/MINIAODSIM/PUpmx25ns_100X_mc2017_realistic_v1-v1/20000/94FC956F-17E1-E711-B672-0025905A60A6.root',
+			'root://cms-xrd-global.cern.ch///store/relval/CMSSW_10_0_0_pre2/RelValZTT_13/MINIAODSIM/PUpmx25ns_100X_mc2017_realistic_v1-v1/20000/B01F0774-17E1-E711-9826-0CC47A4D7654.root',
+	] )
+else:
+	readFiles.extend( [
+			'root://cms-xrd-global.cern.ch///store/relval/CMSSW_10_0_0_pre2/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/PUpmx25ns_100X_mcRun2_asymptotic_v2_FastSim-v1/20000/78318DC3-40E0-E711-BCFE-0CC47A4D763C.root',
+			'root://cms-xrd-global.cern.ch///store/relval/CMSSW_10_0_0_pre2/RelValQCD_FlatPt_15_3000HS_13/MINIAODSIM/PUpmx25ns_100X_mcRun2_asymptotic_v2_FastSim-v1/20000/E6F528C8-40E0-E711-9F06-0CC47A4C8E56.root',
+	] )
+
+#####
+import RecoTauTag.Configuration.tools.adaptToRunAtMiniAOD as tauAtMiniTools
+
+#####
+tauAtMiniTools.addTauReReco(process)
+
+#####
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+if not phase2:
+	process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+	process.GlobalTag.globaltag = '94X_mc2017_realistic_v1'
+else:
+	process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+#####
+#mode = 0: store original MiniAOD and new selectedPatTaus 
+#mode = 1: store original MiniAOD, new selectedPatTaus, and all PFtau products as in AOD (except of unsuported ones)
+process.output = tauAtMiniTools.setOutputModule(mode=outMode)
+if runSignal:
+	process.output.fileName='miniAOD_TauReco_ggH.root'
+	if reclusterJets:
+		process.output.fileName='miniAOD_TauReco_ak4PFJets_ggH.root'
+else:
+	process.output.fileName='miniAOD_TauReco_QCD.root'
+	if reclusterJets:
+		process.output.fileName='miniAOD_TauReco_ak4PFJets_QCD.root'
+process.out = cms.EndPath(process.output)
+
+#####
+tauAtMiniTools.adaptTauToMiniAODReReco(process, reclusterJets)
+
+#####
+process.load('FWCore.MessageService.MessageLogger_cfi')
+if process.maxEvents.input.value()>10:
+     process.MessageLogger.cerr.FwkReport.reportEvery = process.maxEvents.input.value()//10
+if process.maxEvents.input.value()>10000 or process.maxEvents.input.value()<0:
+     process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+#####
+process.options = cms.untracked.PSet(
+)
+process.options.numberOfThreads=cms.untracked.uint32(4)
+#process.options.numberOfThreads=cms.untracked.uint32(1)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+print '\t No. of threads:', process.options.numberOfThreads.value(),', no. of streams:',process.options.numberOfStreams.value()
+
+process.options = cms.untracked.PSet(
+     process.options,
+     wantSummary = cms.untracked.bool(True)
+)

--- a/RecoTauTag/ImpactParameter/plugins/PFTau3ProngReco.cc
+++ b/RecoTauTag/ImpactParameter/plugins/PFTau3ProngReco.cc
@@ -36,6 +36,7 @@
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
@@ -124,6 +125,23 @@ PFTau3ProngReco::~PFTau3ProngReco(){
 
 }
 
+namespace {
+  inline const reco::Track* getTrack(const reco::Candidate& cand)
+  {
+    const reco::PFCandidate* pfCandPtr = dynamic_cast<const reco::PFCandidate*>(&cand);
+    if (pfCandPtr) {
+      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
+      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
+      else return nullptr;
+    }
+    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (packedCand && packedCand->hasTrackDetails())
+    	return &packedCand->pseudoTrack();
+
+    return nullptr;
+  }
+}
+
 void PFTau3ProngReco::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
   // Obtain Collections
   edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
@@ -209,16 +227,14 @@ void PFTau3ProngReco::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
 	    // use Track Helix
 	    std::vector<TrackParticle> pions;
 	    GlobalPoint pvpoint(primaryVertex->position().x(),primaryVertex->position().y(),primaryVertex->position().z());
-	    const std::vector<edm::Ptr<reco::PFCandidate> > cands = tau->signalPFChargedHadrCands();
-	    for (std::vector<edm::Ptr<reco::PFCandidate> >::const_iterator iter = cands.begin(); iter!=cands.end(); ++iter) {
-	      if(iter->get()->trackRef().isNonnull()){
-		reco::TransientTrack transTrk=transTrackBuilder->build(iter->get()->trackRef());
+	    const std::vector<edm::Ptr<reco::Candidate> > cands = tau->signalPFChargedHadrCands();
+	    for (std::vector<edm::Ptr<reco::Candidate> >::const_iterator iter = cands.begin(); iter!=cands.end(); ++iter) {
+	      const reco::Track* track = getTrack(**iter);
+	      if (track != nullptr) {
+		reco::TransientTrack transTrk=transTrackBuilder->build(*track);
 		pions.push_back(ParticleBuilder::createTrackParticle(transTrk,pvpoint,true,true));
 	      }
-	      else if(iter->get()->gsfTrackRef().isNonnull()){
-		//reco::TransientTrack transTrk=transTrackBuilder->build(iter->get()->gsfTrackRef());
-		//pions.push_back(ParticleBuilder::CreateTrackParticle(transTrk,pvpoint,true,true));
-	      }
+
 	    }
 	    TVector3 pv(secVtx->position().x(),secVtx->position().y(),secVtx->position().z());
 	    Chi2VertexFitter chi2v(pions,pv);

--- a/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDCut2.h
@@ -53,21 +53,24 @@ class AntiElectronIDCut2
       {
 	float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
 	float TauLeadChargedPFCandPt = -99.;
-	const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-	for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	      pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-	  const reco::Track* track = nullptr;
-	  if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-	  else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-	  else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
-	  if ( track ) {
-	    if ( track->pt() > TauLeadChargedPFCandPt ) {
-	      TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
-	      TauLeadChargedPFCandPt = track->pt();
+	const std::vector<reco::CandidatePtr>& signalPFCands = thePFTau.signalPFCands();
+	for (const auto& cand : signalPFCands) {
+	  const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand.get());
+	  if (pfcand != nullptr) {
+	    const reco::Track* track = nullptr;
+	    if (pfcand->trackRef().isNonnull()) track = pfcand->trackRef().get();
+	    else if (pfcand->muonRef().isNonnull() && pfcand->muonRef()->innerTrack().isNonnull()) track = pfcand->muonRef()->innerTrack().get();
+	    else if (pfcand->muonRef().isNonnull() && pfcand->muonRef()->globalTrack().isNonnull()) track = pfcand->muonRef()->globalTrack().get();
+	    else if (pfcand->muonRef().isNonnull() && pfcand->muonRef()->outerTrack().isNonnull()) track = pfcand->muonRef()->outerTrack().get();
+	    else if (pfcand->gsfTrackRef().isNonnull()) track = pfcand->gsfTrackRef().get();
+	    if ( track ) {
+	      if ( track->pt() > TauLeadChargedPFCandPt ) {
+	        TauLeadChargedPFCandEtaAtEcalEntrance = pfcand->positionAtECALEntrance().eta();
+	        TauLeadChargedPFCandPt = track->pt();
+	      }
 	    }
 	  }
+	  else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
 	}
 	
 	float TauPt = thePFTau.pt();
@@ -76,14 +79,17 @@ class AntiElectronIDCut2
 	float TauLeadPFChargedHadrEoP = 0.;
 	if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
 	  //TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-	  TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+	  const reco::PFCandidate* leadPFCHCand = dynamic_cast<const reco::PFCandidate*>(thePFTau.leadPFChargedHadrCand().get());
+	  if (leadPFCHCand != nullptr)
+	    TauLeadPFChargedHadrEoP = leadPFCHCand->ecalEnergy()/leadPFCHCand->p();
+	  else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
 	}
 	
 	std::vector<float> GammasdEta;
 	std::vector<float> GammasdPhi;
 	std::vector<float> GammasPt;
 	for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
-	  reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
+	  reco::CandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
 	  if ( thePFTau.leadPFChargedHadrCand().isNonnull() ) {
 	    GammasdEta.push_back(gamma->eta() - thePFTau.leadPFChargedHadrCand()->eta());
 	    GammasdPhi.push_back(gamma->phi() - thePFTau.leadPFChargedHadrCand()->phi());

--- a/RecoTauTag/RecoTau/interface/ConeTools.h
+++ b/RecoTauTag/RecoTau/interface/ConeTools.h
@@ -49,6 +49,10 @@ typedef DeltaRPtrFilter<PFCandidatePtr> PFCandPtrDRFilter;
 typedef boost::filter_iterator< PFCandPtrDRFilter,
         std::vector<PFCandidatePtr>::const_iterator> PFCandPtrDRFilterIter;
 
+typedef DeltaRPtrFilter<CandidatePtr> CandPtrDRFilter;
+typedef boost::filter_iterator< CandPtrDRFilter,
+        std::vector<CandidatePtr>::const_iterator> CandPtrDRFilterIter;
+
 typedef DeltaRFilter<PFRecoTauChargedHadron> ChargedHadronDRFilter;
 typedef boost::filter_iterator< ChargedHadronDRFilter,
         std::vector<PFRecoTauChargedHadron>::const_iterator> ChargedHadronDRFilterIter;

--- a/RecoTauTag/RecoTau/interface/HPSPFRecoTauAlgorithm.h
+++ b/RecoTauTag/RecoTau/interface/HPSPFRecoTauAlgorithm.h
@@ -42,10 +42,10 @@ class HPSPFRecoTauAlgorithm : public PFRecoTauAlgorithmBase
   //* Helper Methods *//
 
   //Creators of the Decay Modes
-  void buildOneProng(const reco::PFTauTagInfoRef&,const std::vector<reco::PFCandidatePtr>& );
-  void buildOneProngStrip(const reco::PFTauTagInfoRef&,const std::vector<std::vector<reco::PFCandidatePtr>>&,const std::vector<reco::PFCandidatePtr>&);
-  void buildOneProngTwoStrips(const reco::PFTauTagInfoRef&,const std::vector<std::vector<reco::PFCandidatePtr>>&,const std::vector<reco::PFCandidatePtr>&);
-  void buildThreeProngs(const reco::PFTauTagInfoRef&,const std::vector<reco::PFCandidatePtr>&);
+  void buildOneProng(const reco::PFTauTagInfoRef&,const std::vector<reco::CandidatePtr>& );
+  void buildOneProngStrip(const reco::PFTauTagInfoRef&,const std::vector<std::vector<reco::CandidatePtr>>&,const std::vector<reco::CandidatePtr>&);
+  void buildOneProngTwoStrips(const reco::PFTauTagInfoRef&,const std::vector<std::vector<reco::CandidatePtr>>&,const std::vector<reco::CandidatePtr>&);
+  void buildThreeProngs(const reco::PFTauTagInfoRef&,const std::vector<reco::CandidatePtr>&);
 
   //Narrowness selection
   bool isNarrowTau(const reco::PFTau&,double);
@@ -60,9 +60,9 @@ class HPSPFRecoTauAlgorithm : public PFRecoTauAlgorithmBase
   void applyElectronRejection(reco::PFTau&,double);
 
   //Method to create a candidate from the merged EM Candidates vector;
-  math::XYZTLorentzVector createMergedLorentzVector(const std::vector<reco::PFCandidatePtr>&);
+  math::XYZTLorentzVector createMergedLorentzVector(const std::vector<reco::CandidatePtr>&);
 
-  void removeCandidateFromRefVector(const reco::PFCandidatePtr&,std::vector<reco::PFCandidatePtr>&); 
+  void removeCandidateFromRefVector(const reco::CandidatePtr&,std::vector<reco::CandidatePtr>&); 
   void applyMassConstraint(math::XYZTLorentzVector&,double );
 
   bool refitThreeProng(reco::PFTau&); 

--- a/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
@@ -8,7 +8,7 @@
  *
  * Base classes for plugins that construct and rank PFRecoTauChargedHadron
  * objects from a jet.  The builder plugin has an abstract function
- * that takes a PFJet and returns a list of reconstructed photons in
+ * that takes a Jet and returns a list of reconstructed photons in
  * the jet.
  *
  * The quality plugin has an abstract function that takes a reference
@@ -27,7 +27,7 @@
 namespace reco {
 
 // Forward declarations
-class PFJet;
+class Jet;
 class PFRecoTauChargedHadron;
 
 namespace tau {
@@ -45,7 +45,7 @@ class PFRecoTauChargedHadronBuilderPlugin : public RecoTauEventHolderPlugin
   {}
   ~PFRecoTauChargedHadronBuilderPlugin() override {}
   /// Build a collection of chargedHadrons from objects in the input jet
-  virtual return_type operator()(const PFJet&) const = 0;
+  virtual return_type operator()(const Jet&) const = 0;
   /// Hook called at the beginning of the event.
   void beginEvent() override {}
 };

--- a/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
@@ -35,7 +35,7 @@ class TauIdMVAAuxiliaries {
         else {
           const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(leadingPFCharged.get());
           if (patcand != nullptr && patcand->hasTrackDetails()) {
-            patcand->pseudoTrack().normalizedChi2();
+            LeadingTracknormalizedChi2 = patcand->pseudoTrack().normalizedChi2();
           }
         }
       }

--- a/RecoTauTag/RecoTau/interface/PFRecoTauTagInfoAlgorithm.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauTagInfoAlgorithm.h
@@ -17,7 +17,7 @@ class  PFRecoTauTagInfoAlgorithm  {
   PFRecoTauTagInfoAlgorithm(){}
   PFRecoTauTagInfoAlgorithm(const edm::ParameterSet&);
   ~PFRecoTauTagInfoAlgorithm(){}
-  reco::PFTauTagInfo buildPFTauTagInfo(const reco::PFJetRef&,const std::vector<reco::PFCandidatePtr>&,const reco::TrackRefVector&,const reco::Vertex&) const; 
+  reco::PFTauTagInfo buildPFTauTagInfo(const reco::JetBaseRef&,const std::vector<reco::CandidatePtr>&,const reco::TrackRefVector&,const reco::Vertex&) const; 
  private: 
   double ChargedHadrCand_tkminPt_;
   int ChargedHadrCand_tkminPixelHitsn_;

--- a/RecoTauTag/RecoTau/interface/RecoTauBinnedIsolationPlugin.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBinnedIsolationPlugin.h
@@ -17,7 +17,7 @@
  */
 
 #include "RecoTauTag/RecoTau/interface/RecoTauDiscriminantPlugins.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 namespace reco { namespace tau {
 
@@ -28,7 +28,7 @@ class RecoTauDiscriminationBinnedIsolation : public RecoTauDiscriminantPlugin {
     void beginEvent() override;
     std::vector<double> operator()(const reco::PFTauRef& tau) const override;
     // Pure abstract function to extract objects to isolate with
-    virtual std::vector<reco::PFCandidatePtr> extractIsoObjects(
+    virtual std::vector<reco::CandidatePtr> extractIsoObjects(
         const reco::PFTauRef& tau) const = 0;
 
   private:

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -76,7 +76,7 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
 	    const reco::PFJetRef&, const 
 	    std::vector<reco::PFRecoTauChargedHadron>&, 
 	    const std::vector<reco::RecoTauPiZero>&, 
-	    const std::vector<PFCandidatePtr>&) const = 0;
+	    const std::vector<CandidatePtr>&) const = 0;
 
   /// Hack to be able to convert Ptrs to Refs
   const edm::Handle<PFCandidateCollection>& getPFCands() const { return pfCands_; };

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -37,7 +37,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
@@ -51,7 +51,7 @@
 
 namespace reco { namespace tau {
 
-/* Class that constructs PFTau(s) from a PFJet and its associated PiZeros */
+/* Class that constructs PFTau(s) from a Jet and its associated PiZeros */
 class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin 
 {
  public:
@@ -73,7 +73,7 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
   /// reconstructed PiZeros and regional extras i.e. objects in a 0.8 cone
   /// about the jet
   virtual return_type operator()(
-	    const reco::PFJetRef&, const 
+	    const reco::JetBaseRef&, const 
 	    std::vector<reco::PFRecoTauChargedHadron>&, 
 	    const std::vector<reco::RecoTauPiZero>&, 
 	    const std::vector<CandidatePtr>&) const = 0;
@@ -82,7 +82,7 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
   const edm::Handle<PFCandidateCollection>& getPFCands() const { return pfCands_; };
 
   /// Get primary vertex associated to this jet
-  reco::VertexRef primaryVertex(const reco::PFJetRef& jet) const { return vertexAssociator_.associatedVertex(*jet); }
+  reco::VertexRef primaryVertex(const reco::JetBaseRef& jet) const { return vertexAssociator_.associatedVertex(*jet); }
   /// Get primary vertex associated to this tau
   reco::VertexRef primaryVertex(const reco::PFTau& tau, bool useJet=false) const { return vertexAssociator_.associatedVertex(tau, useJet); }
 

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -64,7 +64,7 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
     vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC))
   {
     pfCandSrc_ = pset.getParameter<edm::InputTag>("pfCandSrc");
-    pfCand_token = iC.consumes<PFCandidateCollection>(pfCandSrc_);
+    pfCand_token = iC.consumes<edm::View<reco::Candidate> >(pfCandSrc_);
   };
 
   ~RecoTauBuilderPlugin() override {}
@@ -79,7 +79,7 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
 	    const std::vector<CandidatePtr>&) const = 0;
 
   /// Hack to be able to convert Ptrs to Refs
-  const edm::Handle<PFCandidateCollection>& getPFCands() const { return pfCands_; };
+  const edm::Handle<edm::View<reco::Candidate> >& getPFCands() const { return pfCands_; };
 
   /// Get primary vertex associated to this jet
   reco::VertexRef primaryVertex(const reco::JetBaseRef& jet) const { return vertexAssociator_.associatedVertex(*jet); }
@@ -93,9 +93,9 @@ class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin
  private:
   edm::InputTag pfCandSrc_;
   // Handle to PFCandidates needed to build Refs
-  edm::Handle<PFCandidateCollection> pfCands_;
+  edm::Handle<edm::View<reco::Candidate> > pfCands_;
   reco::tau::RecoTauVertexAssociator vertexAssociator_;
-  edm::EDGetTokenT<PFCandidateCollection> pfCand_token;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > pfCand_token;
 };
 
 /* Class that updates a PFTau's members (i.e. electron variables) */

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -9,8 +9,8 @@
  *
  */
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include <vector>
@@ -29,20 +29,20 @@ namespace reco { namespace tau {
 
 class SortPFCandsDescendingPt {
   public:
-    bool operator()(const PFCandidatePtr& a, const PFCandidatePtr& b) const {
+    bool operator()(const CandidatePtr& a, const CandidatePtr& b) const {
       return a->pt() > b->pt();
     }
 };
 
-/// Filter a collection of objects that are convertible to PFCandidatePtrs
+/// Filter a collection of objects that are convertible to CandidatePtrs
 /// by PFCandidate ID
-template<typename Iterator> std::vector<PFCandidatePtr>
+template<typename Iterator> std::vector<CandidatePtr>
 filterPFCandidates(const Iterator& begin, const Iterator& end,
-    int particleId, bool sort=true) {
-  std::vector<PFCandidatePtr> output;
+    int pdgId, bool sort=true) {
+  std::vector<CandidatePtr> output;
   for(Iterator iter = begin; iter != end; ++iter) {
-    reco::PFCandidatePtr ptr(*iter);
-    if (ptr->particleId() == particleId)
+    reco::CandidatePtr ptr(*iter);
+    if (std::abs(ptr->pdgId()) == pdgId)
       output.push_back(ptr);
   }
   if (sort) std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
@@ -51,23 +51,23 @@ filterPFCandidates(const Iterator& begin, const Iterator& end,
 
 /// Extract pfCandidates of a given particle Id from a PFJet.  If sort is true,
 /// candidates will be sorted by descending PT
-std::vector<PFCandidatePtr> pfCandidates(const PFJet& jet,
-                                         int particleId, bool sort=true);
+std::vector<CandidatePtr> pfCandidates(const Jet& jet,
+                                         int pdgId, bool sort=true);
 
 /// Extract pfCandidates of a that match a list of particle Ids from a PFJet
-std::vector<PFCandidatePtr> pfCandidates(const PFJet& jet,
-                                         const std::vector<int>& particleIds,
+std::vector<CandidatePtr> pfCandidates(const Jet& jet,
+                                         const std::vector<int>& pdgIds,
                                          bool sort=true);
 
 /// Extract all non-neutral candidates from a PFJet
-std::vector<PFCandidatePtr> pfChargedCands(const PFJet& jet, bool sort=true);
+std::vector<CandidatePtr> pfChargedCands(const Jet& jet, bool sort=true);
 
 /// Extract all pfGammas from a PFJet
-std::vector<PFCandidatePtr> pfGammas(const PFJet& jet, bool sort=true);
+std::vector<CandidatePtr> pfGammas(const Jet& jet, bool sort=true);
 
 /// Flatten a list of pi zeros into a list of there constituent PFCandidates
-std::vector<PFCandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator&, const std::vector<RecoTauPiZero>::const_iterator&);
-std::vector<PFCandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>&);
+std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator&, const std::vector<RecoTauPiZero>::const_iterator&);
+std::vector<CandidatePtr> flattenPiZeros(const std::vector<RecoTauPiZero>&);
 
 /// Convert a BaseView (View<T>) to a TRefVector
 template<typename RefVectorType, typename BaseView>
@@ -87,6 +87,7 @@ RefVectorType castView(const edm::Handle<BaseView>& view) {
   }
   return output;
 }
+
 
 /*
  *Given a range over a container of type C, return a new 'end' iterator such
@@ -141,5 +142,25 @@ template<typename InputIterator> InputIterator leadPFCand(InputIterator begin,
     }
     return max_cand;
   }
+
+std::vector<PFCandidatePtr> convertPtrVector(const std::vector<CandidatePtr>& cands) {
+  std::vector<PFCandidatePtr> newSignalPFCands;
+  for (auto& cand : cands) {
+    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
+    newSignalPFCands.push_back(newPtr);
+  }
+  return newSignalPFCands;
+}
+
+std::vector<CandidatePtr> convertPtrVector(const std::vector<PFCandidatePtr>& cands) {
+  std::vector<CandidatePtr> newSignalCands;
+  for (auto& cand : cands) {
+    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::Candidate> >();
+    newSignalCands.push_back(newPtr);
+  }
+  return newSignalCands;
+}
+
+
 }}  // end namespace reco::tau
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -161,6 +161,7 @@ std::vector<CandidatePtr> convertPtrVector(const std::vector<PFCandidatePtr>& ca
   return newSignalCands;
 }
 
+math::XYZPoint atECALEntrance(const reco::Candidate* part);
 
 }}  // end namespace reco::tau
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -53,12 +53,22 @@ filterPFCandidates(const Iterator& begin, const Iterator& end,
 }
 
 /// Extract pfCandidates of a given particle Id from a PFJet.  If sort is true,
-/// candidates will be sorted by descending PT
+/// candidates will be sorted by descending PT. Internall translates to pdgId
 std::vector<CandidatePtr> pfCandidates(const Jet& jet,
-                                         int pdgId, bool sort=true);
+                                         int particleId, bool sort=true);
 
 /// Extract pfCandidates of a that match a list of particle Ids from a PFJet
 std::vector<CandidatePtr> pfCandidates(const Jet& jet,
+                                         const std::vector<int>& particleIds,
+                                         bool sort=true);
+
+/// Extract pfCandidates of a given PDG Id from a PFJet.  If sort is true,
+/// candidates will be sorted by descending PT
+std::vector<CandidatePtr> pfCandidatesByPdgId(const Jet& jet,
+                                         int pdgId, bool sort=true);
+
+/// Extract pfCandidates of a that match a list of PDG Ids from a PFJet
+std::vector<CandidatePtr> pfCandidatesByPdgId(const Jet& jet,
                                          const std::vector<int>& pdgIds,
                                          bool sort=true);
 

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -9,13 +9,16 @@
  *
  */
 
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
-#include "DataFormats/Candidate/interface/Candidate.h"
-#include "DataFormats/TauReco/interface/PFTau.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include <vector>
 #include <algorithm>
 #include <numeric>
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 // Boost helpers
 #include <boost/iterator/transform_iterator.hpp>
@@ -162,25 +165,11 @@ template<typename InputIterator> InputIterator leadPFCand(InputIterator begin,
     return max_cand;
   }
 
-std::vector<PFCandidatePtr> convertPtrVector(const std::vector<CandidatePtr>& cands) {
-  std::vector<PFCandidatePtr> newSignalPFCands;
-  for (auto& cand : cands) {
-    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
-    newSignalPFCands.push_back(newPtr);
-  }
-  return newSignalPFCands;
-}
+std::vector<PFCandidatePtr> convertPtrVectorToPF(const std::vector<CandidatePtr>& cands);
 
-std::vector<CandidatePtr> convertPtrVector(const std::vector<PFCandidatePtr>& cands) {
-  std::vector<CandidatePtr> newSignalCands;
-  for (auto& cand : cands) {
-    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::Candidate> >();
-    newSignalCands.push_back(newPtr);
-  }
-  return newSignalCands;
-}
+std::vector<CandidatePtr> convertPtrVector(const std::vector<PFCandidatePtr>& cands);
 
-math::XYZPoint atECALEntrance(const reco::Candidate* part);
+math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField);
 
 }}  // end namespace reco::tau
 #endif

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -89,6 +89,25 @@ RefVectorType castView(const edm::Handle<BaseView>& view) {
 }
 
 
+/// Convert a BaseView (View<T>) to a TRefToBaseVector
+template<typename RefVectorType, typename BaseView>
+RefVectorType castViewToOtherBase(const edm::Handle<BaseView>& view) {
+  typedef typename RefVectorType::value_type OutputRef;
+  // Double check at compile time that the inheritance is okay.  It can still
+  // fail at runtime if you pass it the wrong collection.
+  BOOST_STATIC_ASSERT(
+      (boost::is_base_of<typename BaseView::value_type,
+                         typename RefVectorType::member_type>::value));
+  RefVectorType output;
+  size_t nElements = view->size();
+  // output.reserve(nElements);
+  // Cast each of our Refs
+  for (size_t i = 0; i < nElements; ++i) {
+    output.push_back(view->refAt(i).template castTo<OutputRef>());
+  }
+  return output;
+}
+
 /*
  *Given a range over a container of type C, return a new 'end' iterator such
  *that at max <N> elements are taken.  If there are less than N elements in the

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -146,20 +146,20 @@ template<typename InputIterator, typename FunctionPtr, typename ReturnType>
 
 template<typename InputIterator> reco::Candidate::LorentzVector sumPFCandP4(
     InputIterator begin, InputIterator end) {
-  return sumPFVector(begin, end, &PFCandidate::p4,
+  return sumPFVector(begin, end, &Candidate::p4,
       reco::Candidate::LorentzVector());
 }
 
 /// Sum the pT of a collection of PFCandidates
 template<typename InputIterator> double sumPFCandPt(InputIterator begin,
     InputIterator end) {
-    return sumPFVector(begin, end, &PFCandidate::pt, 0.0);
+    return sumPFVector(begin, end, &Candidate::pt, 0.0);
   }
 
 /// Sum the charge of a collection of PFCandidates
 template<typename InputIterator> int sumPFCandCharge(InputIterator begin,
     InputIterator end) {
-    return sumPFVector(begin, end, &PFCandidate::charge, 0);
+    return sumPFVector(begin, end, &Candidate::charge, 0);
   }
 
 template<typename InputIterator> InputIterator leadPFCand(InputIterator begin,

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -175,10 +175,6 @@ template<typename InputIterator> InputIterator leadPFCand(InputIterator begin,
     return max_cand;
   }
 
-std::vector<PFCandidatePtr> convertPtrVectorToPF(const std::vector<CandidatePtr>& cands);
-
-std::vector<CandidatePtr> convertPtrVector(const std::vector<PFCandidatePtr>& cands);
-
 math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField);
 
 }}  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -53,7 +53,7 @@ filterPFCandidates(const Iterator& begin, const Iterator& end,
 }
 
 /// Extract pfCandidates of a given particle Id from a PFJet.  If sort is true,
-/// candidates will be sorted by descending PT. Internall translates to pdgId
+/// candidates will be sorted by descending PT. Internally translates to pdgId
 std::vector<CandidatePtr> pfCandidates(const Jet& jet,
                                          int particleId, bool sort=true);
 
@@ -101,25 +101,6 @@ RefVectorType castView(const edm::Handle<BaseView>& view) {
   return output;
 }
 
-
-/// Convert a BaseView (View<T>) to a TRefToBaseVector
-template<typename RefVectorType, typename BaseView>
-RefVectorType castViewToOtherBase(const edm::Handle<BaseView>& view) {
-  typedef typename RefVectorType::value_type OutputRef;
-  // Double check at compile time that the inheritance is okay.  It can still
-  // fail at runtime if you pass it the wrong collection.
-  BOOST_STATIC_ASSERT(
-      (boost::is_base_of<typename BaseView::value_type,
-                         typename RefVectorType::member_type>::value));
-  RefVectorType output;
-  size_t nElements = view->size();
-  // output.reserve(nElements);
-  // Cast each of our Refs
-  for (size_t i = 0; i < nElements; ++i) {
-    output.push_back(view->refAt(i).template castTo<OutputRef>());
-  }
-  return output;
-}
 
 /*
  *Given a range over a container of type C, return a new 'end' iterator such

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -27,7 +27,7 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
@@ -52,7 +52,7 @@ class RecoTauConstructor {
     };
 
     /// Constructor with PFCandidate Handle
-    RecoTauConstructor(const PFJetRef& jetRef,
+    RecoTauConstructor(const JetBaseRef& jetRef,
         const edm::Handle<PFCandidateCollection>& pfCands,
 	bool copyGammasFromPiZeros = false,
 	const StringObjectFunction<reco::PFTau>* signalConeSize = nullptr,

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -53,7 +53,7 @@ class RecoTauConstructor {
 
     /// Constructor with PFCandidate Handle
     RecoTauConstructor(const JetBaseRef& jetRef,
-        const edm::Handle<PFCandidateCollection>& pfCands,
+        const edm::Handle<edm::View<reco::Candidate> >& pfCands,
 	bool copyGammasFromPiZeros = false,
 	const StringObjectFunction<reco::PFTau>* signalConeSize = nullptr,
 	double minAbsPhotonSumPt_insideSignalCone = 2.5, double minRelPhotonSumPt_insideSignalCone = 0.,
@@ -81,8 +81,8 @@ class RecoTauConstructor {
     }
 
     /// Append a PFCandidateRef/Ptr to a given collection
-    void addPFCand(Region region, ParticleType type, const PFCandidateRef& ref, bool skipAddToP4 = false);
-    void addPFCand(Region region, ParticleType type, const PFCandidatePtr& ptr, bool skipAddToP4 = false);
+    // void addPFCand(Region region, ParticleType type, const CandidateRef& ref, bool skipAddToP4 = false);
+    void addPFCand(Region region, ParticleType type, const CandidatePtr& ptr, bool skipAddToP4 = false);
 
     /// Reserve a set amount of space for a given RefVector
     void reserve(Region region, ParticleType type, size_t size);
@@ -132,8 +132,8 @@ class RecoTauConstructor {
 
   private:
     typedef std::pair<Region, ParticleType> CollectionKey;
-    typedef std::map<CollectionKey, std::vector<PFCandidatePtr>*> CollectionMap;
-    typedef boost::shared_ptr<std::vector<PFCandidatePtr> > SortedListPtr;
+    typedef std::map<CollectionKey, std::vector<CandidatePtr>*> CollectionMap;
+    typedef boost::shared_ptr<std::vector<CandidatePtr> > SortedListPtr;
     typedef std::map<CollectionKey, SortedListPtr> SortedCollectionMap;
 
     bool copyGammas_;
@@ -145,18 +145,18 @@ class RecoTauConstructor {
     double minRelPhotonSumPt_outsideSignalCone_;
 
     // Retrieve collection associated to signal/iso and type
-    std::vector<PFCandidatePtr>* getCollection(Region region, ParticleType type);
+    std::vector<CandidatePtr>* getCollection(Region region, ParticleType type);
     SortedListPtr getSortedCollection(Region region, ParticleType type);
 
     // Sort all our collections by PT and copy them into the tau
     void sortAndCopyIntoTau();
 
     // Helper functions for dealing with refs
-    PFCandidatePtr convertToPtr(const PFCandidatePtr& pfPtr) const;
-    PFCandidatePtr convertToPtr(const CandidatePtr& candPtr) const;
-    PFCandidatePtr convertToPtr(const PFCandidateRef& pfRef) const;
+    CandidatePtr convertToPtr(const PFCandidatePtr& pfPtr) const;
+    CandidatePtr convertToPtr(const CandidatePtr& candPtr) const;
+    // CandidatePtr convertToPtr(const PFCandidateRef& pfRef) const;
 
-    const edm::Handle<PFCandidateCollection>& pfCands_;
+    const edm::Handle<edm::View<reco::Candidate> >& pfCands_;
     std::auto_ptr<reco::PFTau> tau_;
     CollectionMap collections_;
 

--- a/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
@@ -104,9 +104,23 @@ class FilterPFCandByParticleId {
   public:
     FilterPFCandByParticleId(int particleId):
       id_(particleId){};
-    template<typename PFCandCompatiblePtrType>
+      template<typename PFCandCompatiblePtrType>
       bool operator()(const PFCandCompatiblePtrType& ptr) const {
         return ptr->particleId() == id_;
+      }
+  private:
+    int id_;
+};
+
+// Predicate to filter CandPtrs by the abs(pdgId)
+class FilterCandByAbsPdgId {
+  public:
+    FilterCandByAbsPdgId(int pdgId):
+      id_(pdgId){};
+      template<typename CandCompatiblePtrType>
+      bool operator()(const CandCompatiblePtrType& ptr) const {
+        CandidatePtr pfptr(ptr);
+        return std::abs(ptr->pdgId()) == id_;
       }
   private:
     int id_;

--- a/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCrossCleaning.h
@@ -119,7 +119,6 @@ class FilterCandByAbsPdgId {
       id_(pdgId){};
       template<typename CandCompatiblePtrType>
       bool operator()(const CandCompatiblePtrType& ptr) const {
-        CandidatePtr pfptr(ptr);
         return std::abs(ptr->pdgId()) == id_;
       }
   private:

--- a/RecoTauTag/RecoTau/interface/RecoTauDiscriminantFunctions.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauDiscriminantFunctions.h
@@ -26,7 +26,7 @@ typedef std::vector<double> VDouble;
 
 /// For three prong events, take the track that has charge opposite to the
 /// composite charge.
-PFCandidatePtr mainTrack(const PFTau& tau);
+CandidatePtr mainTrack(const PFTau& tau);
 
 // HPStanc variables
 double JetPt(Tau tau);

--- a/RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauIsolationMasking.h
@@ -25,8 +25,8 @@ class RecoTauIsolationMasking {
   public:
     // Structure containing new, maksed isolation collections
     struct IsoMaskResult {
-      std::list<reco::PFCandidatePtr> gammas;
-      std::list<reco::PFCandidatePtr> h0s;
+      std::list<reco::CandidatePtr> gammas;
+      std::list<reco::CandidatePtr> h0s;
     };
     RecoTauIsolationMasking(const edm::ParameterSet& pset);
     ~RecoTauIsolationMasking();
@@ -36,10 +36,10 @@ class RecoTauIsolationMasking {
     void setMaxSigmas(double maxSigmas) {maxSigmas_ = maxSigmas;}
   private:
     // Get the energy resoltuion of a gamma or h0 candidate
-    double resolution(const reco::PFCandidate& cand) const;
+    double resolution(const reco::Candidate& cand) const;
     // Check if the candidate is in the correct cone
-    bool inCone(const reco::PFCandidate& track,
-        const reco::PFCandidate& cand) const;
+    bool inCone(const reco::Candidate& track,
+        const reco::Candidate& cand) const;
 
     double ecalCone_;
     double hcalCone_;

--- a/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
@@ -26,7 +26,7 @@
 
 namespace reco {
 // Forward declarations
-class PFJet;
+class Jet;
 class RecoTauPiZero;
 namespace tau {
 
@@ -41,7 +41,7 @@ class RecoTauPiZeroBuilderPlugin : public RecoTauEventHolderPlugin {
         RecoTauEventHolderPlugin(pset) {}
     ~RecoTauPiZeroBuilderPlugin() override {}
     /// Build a collection of piZeros from objects in the input jet
-    virtual return_type operator()(const PFJet&) const = 0;
+    virtual return_type operator()(const Jet&) const = 0;
     /// Hook called at the beginning of the event.
     void beginEvent() override {};
 };

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -6,10 +6,10 @@
  *
  * Author: Evan K. Friis
  *
- * Constructs a number of independent requirements on PFCandidates by building
+ * Constructs a number of independent requirements on Candidates by building
  * binary predicate functions.  These are held in a number of lists of
- * functions.  Each of these lists is mapped to a PFCandidate particle type
- * (like hadron, gamma, etc).  When a PFCandidate is passed to filter(),
+ * functions.  Each of these lists is mapped to a Candidate particle type
+ * (like hadron, gamma, etc).  When a Candidate is passed to filter(),
  * the correct list is looked up, and the result is the AND of all the predicate
  * functions.  See the .cc files for the QCut functions.
  *
@@ -23,8 +23,8 @@
 #include <boost/foreach.hpp>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -37,9 +37,9 @@ class RecoTauQualityCuts
   // Quality cut types
   typedef boost::function<bool (const TrackBaseRef&)> TrackQCutFunc;  
   typedef std::vector<TrackQCutFunc> TrackQCutFuncCollection;
-  typedef boost::function<bool (const PFCandidate&)> CandQCutFunc;  
+  typedef boost::function<bool (const Candidate&)> CandQCutFunc;  
   typedef std::vector<CandQCutFunc> CandQCutFuncCollection;
-  typedef std::map<PFCandidate::ParticleType, CandQCutFuncCollection> CandQCutFuncMap;
+  typedef std::map<int, CandQCutFuncCollection> CandQCutFuncMap;
   
   explicit RecoTauQualityCuts(const edm::ParameterSet& qcuts);
 
@@ -48,11 +48,11 @@ class RecoTauQualityCuts
     
   /// Update the leading track
   void setLeadTrack(const reco::TrackRef& leadTrack) const;
-  void setLeadTrack(const reco::PFCandidate& leadCand) const;
+  void setLeadTrack(const reco::Candidate& leadCand) const;
 
   /// Update the leading track (using reference)
   /// If null, this will set the lead track ref null.
-  void setLeadTrack(const reco::PFCandidateRef& leadCand) const;
+  void setLeadTrack(const reco::CandidateRef& leadCand) const;
 
   /// Filter a single Track
   bool filterTrack(const reco::TrackBaseRef& track) const;
@@ -69,14 +69,14 @@ class RecoTauQualityCuts
     return output;
   }
 
-  /// Filter a single PFCandidate
-  bool filterCand(const reco::PFCandidate& cand) const;
+  /// Filter a single Candidate
+  bool filterCand(const reco::Candidate& cand) const;
 
-  /// Filter a PFCandidate held by a smart pointer or Ref
-  template<typename PFCandRefType>
-  bool filterCandRef(const PFCandRefType& cand) const { return filterCand(*cand); }
+  /// Filter a Candidate held by a smart pointer or Ref
+  template<typename CandRefType>
+  bool filterCandRef(const CandRefType& cand) const { return filterCand(*cand); }
 
-  /// Filter a ref vector of PFCandidates
+  /// Filter a ref vector of Candidates
   template<typename Coll> 
   Coll filterCandRefs(const Coll& refcoll, bool invert = false) const 
   {
@@ -89,9 +89,9 @@ class RecoTauQualityCuts
 
  private:
   template <typename T> bool filterTrack_(const T& trackRef) const;
-  bool filterGammaCand(const reco::PFCandidate& cand) const;
-  bool filterNeutralHadronCand(const reco::PFCandidate& cand) const;
-  bool filterCandByType(const reco::PFCandidate& cand) const;
+  bool filterGammaCand(const reco::Candidate& cand) const;
+  bool filterNeutralHadronCand(const reco::Candidate& cand) const;
+  bool filterCandByType(const reco::Candidate& cand) const;
 
   // The current primary vertex
   mutable reco::VertexRef pv_;

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -57,6 +57,9 @@ class RecoTauQualityCuts
   /// Filter a single Track
   bool filterTrack(const reco::TrackBaseRef& track) const;
   bool filterTrack(const reco::TrackRef& track) const;
+  bool filterTrack(const reco::Track& track) const;
+  /// or a single charged candidate
+  bool filterChargedCand(const reco::Candidate& cand) const;
 
   /// Filter a collection of Tracks
   template<typename Coll> 

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -47,7 +47,7 @@ class RecoTauQualityCuts
   void setPV(const reco::VertexRef& vtx) const { pv_ = vtx; }
     
   /// Update the leading track
-  void setLeadTrack(const reco::TrackRef& leadTrack) const;
+  void setLeadTrack(const reco::Track& leadTrack) const;
   void setLeadTrack(const reco::Candidate& leadCand) const;
 
   /// Update the leading track (using reference)
@@ -91,7 +91,7 @@ class RecoTauQualityCuts
   }
 
  private:
-  template <typename T> bool filterTrack_(const T& trackRef) const;
+  bool filterTrack_(const reco::Track* track) const;
   bool filterGammaCand(const reco::Candidate& cand) const;
   bool filterNeutralHadronCand(const reco::Candidate& cand) const;
   bool filterCandByType(const reco::Candidate& cand) const;
@@ -99,7 +99,7 @@ class RecoTauQualityCuts
   // The current primary vertex
   mutable reco::VertexRef pv_;
   // The current lead track references
-  mutable reco::TrackBaseRef leadTrack_;
+  mutable const reco::Track* leadTrack_;
 
   double minTrackPt_;
   double maxTrackChi2_;

--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -25,7 +25,7 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
 
 #include "DataFormats/Common/interface/AssociationMap.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
@@ -41,7 +41,7 @@ namespace edm {
 
 namespace reco {
   class PFTau;
-  class PFJet;
+  class Jet;
 }
 
 namespace reco { namespace tau {
@@ -59,7 +59,7 @@ class RecoTauVertexAssociator {
     virtual ~RecoTauVertexAssociator(); 
     /// Get the primary vertex associated to a given jet. 
     /// Returns a null Ref if no vertex is found.
-    reco::VertexRef associatedVertex(const PFJet& jet) const;
+    reco::VertexRef associatedVertex(const Jet& jet) const;
     /// Convenience function to get the PV associated to the jet that
     /// seeded this tau (useJet=true, old behaviour) 
     /// or leaging charged hadron if set (useJet=false).
@@ -68,7 +68,7 @@ class RecoTauVertexAssociator {
 
     /// Load the vertices from the event.
     void setEvent(const edm::Event& evt);
-    reco::TrackBaseRef getLeadTrack(const PFJet& jet) const;
+    reco::TrackBaseRef getLeadTrack(const Jet& jet) const;
 
   private:
     edm::InputTag vertexTag_;
@@ -84,7 +84,7 @@ class RecoTauVertexAssociator {
     int leadingTrkOrPFCandOption_;
     edm::EDGetTokenT<reco::VertexCollection> vxToken_;
     // containers for holding vertices associated to jets
-    std::map<const reco::PFJet*, reco::VertexRef>* jetToVertexAssociation_;
+    std::map<const reco::Jet*, reco::VertexRef>* jetToVertexAssociation_;
     edm::EventNumber_t lastEvent_;    
     int verbosity_;
 };

--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -65,10 +65,13 @@ class RecoTauVertexAssociator {
     /// or leaging charged hadron if set (useJet=false).
     reco::VertexRef associatedVertex(const PFTau& tau, bool useJet=false) const;
     reco::VertexRef associatedVertex(const TrackBaseRef& track) const;
+    reco::VertexRef associatedVertex(const Track* track) const;
 
     /// Load the vertices from the event.
     void setEvent(const edm::Event& evt);
-    reco::TrackBaseRef getLeadTrack(const Jet& jet) const;
+    const Track* getLeadTrack(const Jet&) const;
+    const TrackBaseRef getLeadTrackRef(const Jet&) const;
+    const CandidatePtr getLeadCand(const Jet&) const;
 
   private:
     edm::InputTag vertexTag_;

--- a/RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h
+++ b/RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h
@@ -7,6 +7,7 @@
 
 namespace reco { namespace tau {
 
+    const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron);
     void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scaleFactor_neutralPFCands = 1.0);
     reco::Candidate::LorentzVector compChargedHadronP4fromPxPyPz(double, double, double);
     reco::Candidate::LorentzVector compChargedHadronP4fromPThetaPhi(double, double, double);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromLostTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromLostTrackPlugin.cc
@@ -1,0 +1,278 @@
+/*
+ * PFRecoTauChargedHadronFromLostTrackPlugin
+ *
+ * Build PFRecoTauChargedHadron objects
+ * using lostTracks, i.e. pat::PackedCandidates built for tracks not used 
+ * by PFlow algorithm as input
+ *
+ * Author: Michal Bluj, NCBJ, Poland
+ * based on PFRecoTauChargedHadronFromTrackPlugin by Christian Veelken
+ *
+ */
+
+#include "RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "FastSimulation/BaseParticlePropagator/interface/BaseParticlePropagator.h"
+#include "FastSimulation/Particle/interface/RawParticle.h"
+
+#include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
+#include "RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h"
+#include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
+#include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
+
+#include <TMath.h>
+
+#include <memory>
+#include <cmath>
+
+namespace reco { namespace tau {
+
+class PFRecoTauChargedHadronFromLostTrackPlugin : public PFRecoTauChargedHadronBuilderPlugin 
+{
+ public:
+  explicit PFRecoTauChargedHadronFromLostTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector && iC);
+  ~PFRecoTauChargedHadronFromLostTrackPlugin() override;
+  // Return type is auto_ptr<ChargedHadronVector>
+  return_type operator()(const reco::Jet&) const override;
+  // Hook to update PV information
+  void beginEvent() override;
+  
+ private:
+  typedef std::vector<reco::CandidatePtr> CandPtrs;
+
+  RecoTauVertexAssociator vertexAssociator_;
+
+  RecoTauQualityCuts* qcuts_;
+
+  edm::InputTag srcLostTracks_;
+  edm::EDGetTokenT<pat::PackedCandidateCollection> lostTracks_token;
+  double dRcone_;
+  bool dRconeLimitedToJetArea_;
+
+  double dRmergeNeutralHadron_;
+  double dRmergePhoton_;
+
+  math::XYZVector magneticFieldStrength_;
+
+  mutable int numWarnings_;
+  int maxWarnings_;
+
+  int verbosity_;
+};
+
+  PFRecoTauChargedHadronFromLostTrackPlugin::PFRecoTauChargedHadronFromLostTrackPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC)
+    : PFRecoTauChargedHadronBuilderPlugin(pset,std::move(iC)),
+      vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)),
+    qcuts_(nullptr)
+{
+  edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
+  qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+
+  srcLostTracks_ = pset.getParameter<edm::InputTag>("srcLostTracks");
+  lostTracks_token = iC.consumes<pat::PackedCandidateCollection>(srcLostTracks_);
+  dRcone_ = pset.getParameter<double>("dRcone");
+  dRconeLimitedToJetArea_ = pset.getParameter<bool>("dRconeLimitedToJetArea");
+
+  dRmergeNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadron");
+  dRmergePhoton_ = pset.getParameter<double>("dRmergePhoton");
+
+  numWarnings_ = 0;
+  maxWarnings_ = 3;
+
+  verbosity_ = ( pset.exists("verbosity") ) ?
+    pset.getParameter<int>("verbosity") : 0;
+}
+  
+PFRecoTauChargedHadronFromLostTrackPlugin::~PFRecoTauChargedHadronFromLostTrackPlugin()
+{
+  delete qcuts_;
+}
+
+// Update the primary vertex
+void PFRecoTauChargedHadronFromLostTrackPlugin::beginEvent() 
+{
+  vertexAssociator_.setEvent(*this->evt());
+
+  edm::ESHandle<MagneticField> magneticField;
+  evtSetup()->get<IdealMagneticFieldRecord>().get(magneticField);
+  magneticFieldStrength_ = magneticField->inTesla(GlobalPoint(0.,0.,0.));
+}
+
+namespace
+{
+  struct Candidate_withDistance 
+  {
+    reco::CandidatePtr pfCandidate_;
+    double distance_;
+  };
+
+  bool isSmallerDistance(const Candidate_withDistance& cand1, const Candidate_withDistance& cand2)
+  {
+    return (cand1.distance_ < cand2.distance_);
+  }
+}
+
+PFRecoTauChargedHadronFromLostTrackPlugin::return_type PFRecoTauChargedHadronFromLostTrackPlugin::operator()(const reco::Jet& jet) const 
+{
+  if ( verbosity_ ) {
+    edm::LogPrint("TauChHFromLostTrack") << "<PFRecoTauChargedHadronFromLostTrackPlugin::operator()>:" ;
+    edm::LogPrint("TauChHFromLostTrack") << " pluginName = " << name() ;
+  }
+
+  ChargedHadronVector output;
+
+  const edm::Event& evt = (*this->evt());
+
+  edm::Handle<pat::PackedCandidateCollection> lostTracks;
+  evt.getByToken(lostTracks_token, lostTracks);
+
+  qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
+  float jEta=jet.eta();
+  float jPhi=jet.phi();
+  size_t numTracks = lostTracks->size();
+  for ( size_t iTrack = 0; iTrack < numTracks; ++iTrack ) {
+    // ignore lostTracks without detailed information
+    if ( !(*lostTracks)[iTrack].hasTrackDetails() ) continue;
+    const reco::Track *track = &(*lostTracks)[iTrack].pseudoTrack();
+
+    // consider tracks in vicinity of tau-jet candidate only
+    double dR = deltaR((*lostTracks)[iTrack].eta(), (*lostTracks)[iTrack].phi(), jEta,jPhi);
+    double dRmatch = dRcone_;
+    if ( dRconeLimitedToJetArea_ ) {
+      double jetArea = jet.jetArea();
+      if ( jetArea > 0. ) {
+	dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea/TMath::Pi()));
+      } else {
+	if ( numWarnings_ < maxWarnings_ ) {
+	  edm::LogInfo("PFRecoTauChargedHadronFromLostTrackPlugin::operator()") 
+	    << "Jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << " has area = " << jetArea << " !!" << std::endl;
+	  ++numWarnings_;
+	}
+	dRmatch = 0.1;
+      }
+    }
+    if ( dR > dRmatch ) continue;
+
+    // ignore tracks which fail quality cuts
+    if ( (*lostTracks)[iTrack].charge() == 0 || !qcuts_->filterChargedCand((*lostTracks)[iTrack]) ) continue;
+
+    reco::Candidate::Charge trackCharge_int = 0;
+    if ( (*lostTracks)[iTrack].charge() > 0. ) trackCharge_int = +1;
+    else if ( (*lostTracks)[iTrack].charge() < 0. ) trackCharge_int = -1;
+
+    const double chargedPionMass = 0.13957; // GeV
+    double chargedPionP  = (*lostTracks)[iTrack].p();
+    double chargedPionEn = TMath::Sqrt(chargedPionP*chargedPionP + chargedPionMass*chargedPionMass);
+    reco::Candidate::LorentzVector chargedPionP4((*lostTracks)[iTrack].px(), (*lostTracks)[iTrack].py(),(*lostTracks)[iTrack].pz(), chargedPionEn);
+
+    reco::Vertex::Point vtx(0.,0.,0.);
+    if ( vertexAssociator_.associatedVertex(jet).isNonnull() ) vtx = vertexAssociator_.associatedVertex(jet)->position();
+
+    std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
+    // MB: Not possible to save track for a lostTrack(PackedCandidate)/miniAOD,
+    // need to get the track later using the pseudoTrack method (downstream)
+    //chargedHadron->track_ = edm::Ptr<reco::Track>(tracks, iTrack);
+    chargedHadron->lostTrackCandidate_ = edm::Ptr<pat::PackedCandidate>(lostTracks,iTrack);
+
+    // CV: Take code for propagating track to ECAL entrance 
+    //     from RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+    //     to make sure propagation is done in the same way as for charged PFCandidates.
+    //     
+    //     The following replacements need to be made
+    //       outerMomentum -> momentum
+    //       outerPosition -> referencePoint
+    //     in order to run on AOD input
+    //    (outerMomentum and outerPosition require access to reco::TrackExtra objects, which are available in RECO only)
+    //
+    XYZTLorentzVector chargedPionPos((*lostTracks)[iTrack].vertex().x(), (*lostTracks)[iTrack].vertex().y(), (*lostTracks)[iTrack].vertex().z(), 0.);
+    BaseParticlePropagator trackPropagator(RawParticle(chargedPionP4, chargedPionPos), 0., 0., magneticFieldStrength_.z());
+    trackPropagator.setCharge((*lostTracks)[iTrack].charge());
+    trackPropagator.propagateToEcalEntrance(false);
+    if ( trackPropagator.getSuccess() != 0 ) { 
+      chargedHadron->positionAtECALEntrance_ = trackPropagator.vertex();
+    } else {
+      if ( chargedPionP4.pt() > 2. ) {
+	edm::LogWarning("PFRecoTauChargedHadronFromLostTrackPlugin::operator()") 
+	  << "Failed to propagate track: Pt = " << track->pt() << ", eta = " << track->eta() << ", phi = " << track->phi() << " to ECAL entrance !!" << std::endl;
+      }
+      chargedHadron->positionAtECALEntrance_ = math::XYZPointF(0.,0.,0.);
+    }
+
+    std::vector<Candidate_withDistance> neutralJetConstituents_withDistance;
+    std::vector<reco::CandidatePtr> jetConstituents = jet.daughterPtrVector();
+    for ( const auto& jetConstituent : jetConstituents ) {
+      int pdgId = jetConstituent->pdgId();
+      if ( !(pdgId == 130 || pdgId == 22) ) continue;
+      double dR = deltaR(atECALEntrance(&*jetConstituent, magneticFieldStrength_.z()), chargedHadron->positionAtECALEntrance_);
+      double dRmerge = -1.;      
+      if      ( pdgId == 130 ) dRmerge = dRmergeNeutralHadron_;
+      else if ( pdgId == 22 ) dRmerge = dRmergePhoton_;
+      if ( dR < dRmerge ) {
+	Candidate_withDistance jetConstituent_withDistance;
+	jetConstituent_withDistance.pfCandidate_ = jetConstituent;
+	jetConstituent_withDistance.distance_ = dR;
+	neutralJetConstituents_withDistance.push_back(jetConstituent_withDistance);
+	chargedHadron->addDaughter(jetConstituent);
+      }
+    }
+    std::sort(neutralJetConstituents_withDistance.begin(), neutralJetConstituents_withDistance.end(), isSmallerDistance);
+
+    const double caloResolutionCoeff = 1.0; // CV: approximate ECAL + HCAL calorimeter resolution for hadrons by 100%*sqrt(E)
+    double trackPtError = 0.06; // MB: Approximate avarage track PtError by 2.5% (barrel), 4% (transition), 6% (endcaps) lostTracks w/o detailed track information available (after TRK-11-001)
+    if( std::abs((*lostTracks)[iTrack].eta()) < 0.9 )
+      trackPtError = 0.025;
+    else if( std::abs((*lostTracks)[iTrack].eta()) < 1.4 )
+      trackPtError = 0.04;
+    if(track != nullptr)
+      trackPtError = track->ptError();
+    double resolutionTrackP =(*lostTracks)[iTrack].p()*(trackPtError/(*lostTracks)[iTrack].pt());
+    double neutralEnSum = 0.;
+    for ( std::vector<Candidate_withDistance>::const_iterator nextNeutral = neutralJetConstituents_withDistance.begin();
+	  nextNeutral != neutralJetConstituents_withDistance.end(); ++nextNeutral ) {
+      double nextNeutralEn = nextNeutral->pfCandidate_->energy();      
+      double resolutionCaloEn = caloResolutionCoeff*sqrt(neutralEnSum + nextNeutralEn);
+      double resolution = sqrt(resolutionTrackP*resolutionTrackP + resolutionCaloEn*resolutionCaloEn);
+      if ( (neutralEnSum + nextNeutralEn) < ((*lostTracks)[iTrack].p() + 2.*resolution) ) {
+	chargedHadron->neutralPFCandidates_.push_back(nextNeutral->pfCandidate_);
+	neutralEnSum += nextNeutralEn;
+      } else {
+	break;
+      }
+    }
+
+    setChargedHadronP4(*chargedHadron);
+
+    if ( verbosity_ ) {
+      edm::LogPrint("TauChHFromLostTrack") << *chargedHadron;
+    }
+
+    output.push_back(chargedHadron);
+  }
+
+  return output.release();
+}
+
+}} // end namespace reco::tau
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_EDM_PLUGIN(PFRecoTauChargedHadronBuilderPluginFactory, reco::tau::PFRecoTauChargedHadronFromLostTrackPlugin, "PFRecoTauChargedHadronFromLostTrackPlugin");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -60,7 +60,7 @@ class PFRecoTauChargedHadronFromPFCandidatePlugin : public PFRecoTauChargedHadro
 
   RecoTauQualityCuts* qcuts_;
 
-  std::vector<int> inputPdgIds_;  // type of candidates to clusterize
+  std::vector<int> inputParticleIds_;  // type of candidates to clusterize
 
   double dRmergeNeutralHadronWrtChargedHadron_;
   double dRmergeNeutralHadronWrtNeutralHadron_;
@@ -91,7 +91,7 @@ class PFRecoTauChargedHadronFromPFCandidatePlugin : public PFRecoTauChargedHadro
   edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
   qcuts_ = new RecoTauQualityCuts(qcuts_pset);
 
-  inputPdgIds_ = pset.getParameter<std::vector<int> >("chargedHadronCandidatesParticleIds");
+  inputParticleIds_ = pset.getParameter<std::vector<int> >("chargedHadronCandidatesParticleIds");
 
   dRmergeNeutralHadronWrtChargedHadron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtChargedHadron");
   dRmergeNeutralHadronWrtNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadronWrtNeutralHadron");
@@ -185,7 +185,7 @@ PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronF
 
   // Get the candidates passing our quality cuts
   qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputPdgIds_));
+  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
 
   for ( CandPtrs::iterator cand = candsVector.begin();
 	cand != candsVector.end(); ++cand ) {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -130,19 +130,6 @@ void PFRecoTauChargedHadronFromPFCandidatePlugin::beginEvent()
 
 namespace
 {
-  // std::string getPFCandidateType(reco::PFCandidate::ParticleType pfCandidateType)
-  // {
-  //   if      ( pfCandidateType == reco::PFCandidate::X         ) return "undefined";
-  //   else if ( pfCandidateType == reco::PFCandidate::h         ) return "PFChargedHadron";
-  //   else if ( pfCandidateType == reco::PFCandidate::e         ) return "PFElectron";
-  //   else if ( pfCandidateType == reco::PFCandidate::mu        ) return "PFMuon";
-  //   else if ( pfCandidateType == reco::PFCandidate::gamma     ) return "PFGamma";
-  //   else if ( pfCandidateType == reco::PFCandidate::h0        ) return "PFNeutralHadron";
-  //   else if ( pfCandidateType == reco::PFCandidate::h_HF      ) return "HF_had";
-  //   else if ( pfCandidateType == reco::PFCandidate::egamma_HF ) return "HF_em";
-  //   else assert(0);
-  // }
-
   bool isMatchedByBlockElement(const reco::PFCandidate& pfCandidate1, const reco::PFCandidate& pfCandidate2, int minMatches1, int minMatches2, int maxUnmatchedBlockElements1plus2)
   {
     reco::PFCandidate::ElementsInBlocks blockElements1 = pfCandidate1.elementsInBlocks();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -21,7 +21,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
-#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/RefToPtr.h"
 
@@ -44,7 +44,7 @@ class PFRecoTauChargedHadronFromPFCandidatePlugin : public PFRecoTauChargedHadro
   explicit PFRecoTauChargedHadronFromPFCandidatePlugin(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
   ~PFRecoTauChargedHadronFromPFCandidatePlugin() override;
   // Return type is auto_ptr<ChargedHadronVector>
-  return_type operator()(const reco::PFJet&) const override;
+  return_type operator()(const reco::Jet&) const override;
   // Hook to update PV information
   void beginEvent() override;
   
@@ -163,7 +163,7 @@ namespace
   }
 }
 
-PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronFromPFCandidatePlugin::operator()(const reco::PFJet& jet) const 
+PFRecoTauChargedHadronFromPFCandidatePlugin::return_type PFRecoTauChargedHadronFromPFCandidatePlugin::operator()(const reco::Jet& jet) const 
 {
   if ( verbosity_ ) {
     edm::LogPrint("TauChHadronFromPF") << "<PFRecoTauChargedHadronFromPFCandidatePlugin::operator()>:";

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
@@ -50,6 +50,7 @@ class PFRecoTauChargedHadronFromTrackPlugin : public PFRecoTauChargedHadronBuild
   ~PFRecoTauChargedHadronFromTrackPlugin() override;
   // Return type is auto_ptr<ChargedHadronVector>
   return_type operator()(const reco::PFJet&) const override;
+  return_type operator()(const reco::Jet&) const override;
   // Hook to update PV information
   void beginEvent() override;
   
@@ -128,7 +129,7 @@ namespace
   }
 }
 
-PFRecoTauChargedHadronFromTrackPlugin::return_type PFRecoTauChargedHadronFromTrackPlugin::operator()(const reco::PFJet& jet) const 
+PFRecoTauChargedHadronFromTrackPlugin::return_type PFRecoTauChargedHadronFromTrackPlugin::operator()(const reco::Jet& jet) const 
 {
   if ( verbosity_ ) {
     edm::LogPrint("TauChHFromTrack") << "<PFRecoTauChargedHadronFromTrackPlugin::operator()>:" ;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromTrackPlugin.cc
@@ -49,7 +49,6 @@ class PFRecoTauChargedHadronFromTrackPlugin : public PFRecoTauChargedHadronBuild
   explicit PFRecoTauChargedHadronFromTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector && iC);
   ~PFRecoTauChargedHadronFromTrackPlugin() override;
   // Return type is auto_ptr<ChargedHadronVector>
-  return_type operator()(const reco::PFJet&) const override;
   return_type operator()(const reco::Jet&) const override;
   // Hook to update PV information
   void beginEvent() override;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -164,9 +164,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
 
 
   if ( !pfJets.empty() ) {
-    edm::Handle<reco::PFJetCollection> pfJetCollectionHandle;
-    evt.get(pfJets.id(), pfJetCollectionHandle);
-    pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>(reco::JetRefBaseProd(pfJetCollectionHandle));
+    pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>(reco::JetRefBaseProd(jets));
   } else {
     pfJetChargedHadronAssociations = std::make_unique<reco::PFJetChargedHadronAssociation>();
   }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -256,8 +256,6 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
       if ( nextChargedHadron->algoIs(reco::PFRecoTauChargedHadron::kPFNeutralHadron) ) {
 	for ( std::set<reco::CandidatePtr>::const_iterator neutralPFCandInCleanCollection = neutralPFCandsInCleanCollection.begin();
 	      neutralPFCandInCleanCollection != neutralPFCandsInCleanCollection.end(); ++neutralPFCandInCleanCollection ) {
-          // JAN - FIXME - this should be fine according to the documentation but need to double-check
-	  // if ( neutralPFCandInCleanCollection->id() == nextChargedHadron->getChargedPFCandidate().id() )
           if ( (*neutralPFCandInCleanCollection) == nextChargedHadron->getChargedPFCandidate() )  isNeutralPFCand_overlap = true;
 
 	}

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectron.cc
@@ -119,7 +119,7 @@ double PFRecoTauDiscriminationAgainstElectron::discriminate(const PFTauRef& theP
        if (pflch != nullptr) {
          TrackRef myleadTk;
          myleadTk = pflch->trackRef();
-         math::XYZPointF myleadTkEcalPos = pflch->positionAtECALEntrance();
+         const math::XYZPointF& myleadTkEcalPos = pflch->positionAtECALEntrance();
          if(myleadTk.isNonnull())
          {
             if (applyCut_ecalCrack_ && isInEcalCrack(myleadTkEcalPos.eta()))

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronMVA6.cc
@@ -97,11 +97,13 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
   float tauEtaAtEcalEntrance = -99.;
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
-  const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTauRef->signalPFCands();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumEtaTimesEnergy += ((*pfCandidate)->positionAtECALEntrance().eta()*(*pfCandidate)->energy());
-    sumEnergy += (*pfCandidate)->energy();
+  for (const auto& cand : thePFTauRef->signalPFCands()) {
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand.get());
+    if (pfcand != nullptr) {
+      sumEtaTimesEnergy += (pfcand->positionAtECALEntrance().eta()*pfcand->energy());
+      sumEnergy += pfcand->energy();
+    }
+    else throw cms::Exception("Type Mismatch") << "FIXME.\n";
   }
   if ( sumEnergy > 0. ) {
     tauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
@@ -109,28 +111,30 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
 
   float leadChargedPFCandEtaAtEcalEntrance = -99.;
   float leadChargedPFCandPt = -99.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
-	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    const reco::Track* track = nullptr;
-    if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-    else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
-    if ( track ) {
-      if ( track->pt() > leadChargedPFCandPt ) {
-	leadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
-	leadChargedPFCandPt = track->pt();
+  for (const auto& cand : thePFTauRef->signalPFCands()) {
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand.get());
+    if (pfcand != nullptr) {
+      const reco::Track* track = nullptr;
+      if ( pfcand->trackRef().isNonnull() ) track = pfcand->trackRef().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->innerTrack().isNonnull()  ) track = pfcand->muonRef()->innerTrack().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->globalTrack().isNonnull() ) track = pfcand->muonRef()->globalTrack().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->outerTrack().isNonnull()  ) track = pfcand->muonRef()->outerTrack().get();
+      else if ( pfcand->gsfTrackRef().isNonnull() ) track = pfcand->gsfTrackRef().get();
+      if ( track ) {
+        if ( track->pt() > leadChargedPFCandPt ) {
+	  leadChargedPFCandEtaAtEcalEntrance = pfcand->positionAtECALEntrance().eta();
+	  leadChargedPFCandPt = track->pt();
+        }
       }
-    }
+    } else throw cms::Exception("Type Mismatch") << "FIXME.\n";
   }
 
   if( (*thePFTauRef).leadPFChargedHadrCand().isNonnull()) {
 
     int numSignalPFGammaCandsInSigCone = 0;
-    const std::vector<reco::PFCandidatePtr>& signalPFGammaCands = thePFTauRef->signalPFGammaCands();
+    const std::vector<reco::CandidatePtr>& signalPFGammaCands = thePFTauRef->signalPFGammaCands();
     
-    for ( std::vector<reco::PFCandidatePtr>::const_iterator pfGamma = signalPFGammaCands.begin();
+    for ( std::vector<reco::CandidatePtr>::const_iterator pfGamma = signalPFGammaCands.begin();
 	  pfGamma != signalPFGammaCands.end(); ++pfGamma ) {
             
       double dR = deltaR((*pfGamma)->p4(), thePFTauRef->leadPFChargedHadrCand()->p4());
@@ -150,7 +154,12 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
 	deltaRDummy = deltaREleTau;
 	if ( deltaREleTau < 0.3 ) {
 	  double mva_match = mva_->MVAValue(*thePFTauRef, *theGsfElectron, usePhiAtEcalEntranceExtrapolation_);
-	  bool hasGsfTrack = thePFTauRef->leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
+	  const reco::PFCandidate* lpfch = dynamic_cast<const reco::PFCandidate*>(thePFTauRef->leadPFChargedHadrCand().get());
+	  bool hasGsfTrack = false;
+	  if (lpfch) {
+	    hasGsfTrack = lpfch->gsfTrackRef().isNonnull();
+	  } else throw cms::Exception("Type Mismatch") << "FIXME.\n";
+
 	  if ( !hasGsfTrack )
             hasGsfTrack = theGsfElectron->gsfTrack().isNonnull();
 
@@ -187,7 +196,11 @@ double PFRecoTauDiscriminationAgainstElectronMVA6::discriminate(const PFTauRef& 
 
     if ( !isGsfElectronMatched ) {
       mvaValue = mva_->MVAValue(*thePFTauRef, usePhiAtEcalEntranceExtrapolation_);
-      bool hasGsfTrack = thePFTauRef->leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
+      const reco::PFCandidate* lpfch = dynamic_cast<const reco::PFCandidate*>(thePFTauRef->leadPFChargedHadrCand().get());
+      bool hasGsfTrack = false;
+      if (lpfch) {
+	hasGsfTrack = lpfch->gsfTrackRef().isNonnull();
+      } else throw cms::Exception("Type Mismatch") << "FIXME.\n";
       
       //// Veto taus that go to Ecal crack
       if ( isInEcalCrack(tauEtaAtEcalEntrance) || isInEcalCrack(leadChargedPFCandEtaAtEcalEntrance) ) {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon.cc
@@ -9,6 +9,7 @@
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
 
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
@@ -51,45 +52,55 @@ double PFRecoTauDiscriminationAgainstMuon::discriminate(const PFTauRef& thePFTau
   bool decision = true;
 
   if ( thePFTauRef->hasMuonReference() ) {
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(thePFTauRef->leadPFChargedHadrCand().get());
+    if (pfcand != nullptr) {
+      MuonRef muonref = pfcand->muonRef();
+      if ( discriminatorOption_ == "noSegMatch" ) {
+        if ( muonref ->numberOfMatches() > maxNumberOfMatches_ ) decision = false;
+      } else if (discriminatorOption_ == "twoDCut") {
+        double seg = muon::segmentCompatibility(*muonref);
+        double calo= muonref->caloCompatibility(); 
+        double border = calo * a + seg * b +c;
+        if ( border > 0 ) decision = false; 
+      } else if ( discriminatorOption_ == "merePresence" ) {
+        decision = false;
+      } else if (discriminatorOption_ == "combined" ) { // testing purpose only
+        unsigned int muType = 0;
+        if      ( muonref->isGlobalMuon()  ) muType = 1;
+        else if ( muonref->isCaloMuon()    ) muType = 2;
+        else if ( muonref->isTrackerMuon() ) muType = 3;
+        float muonEnergyFraction = 0.;
+        const reco::PFJet* pfJetPtr = dynamic_cast<const reco::PFJet*>(thePFTauRef->pfTauTagInfoRef()->pfjetRef().get());
+        if (pfJetPtr) {
+          muonEnergyFraction = pfJetPtr->chargedMuEnergyFraction();
+        } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFJets, and this outdated algorithm was not updated to cope with PFTaus made from other Jets.\n";
 
-    MuonRef muonref = thePFTauRef->leadPFChargedHadrCand()->muonRef();
-    if ( discriminatorOption_ == "noSegMatch" ) {
-      if ( muonref ->numberOfMatches() > maxNumberOfMatches_ ) decision = false;
-    } else if (discriminatorOption_ == "twoDCut") {
-      double seg = muon::segmentCompatibility(*muonref);
-      double calo= muonref->caloCompatibility(); 
-      double border = calo * a + seg * b +c;
-      if ( border > 0 ) decision = false; 
-    } else if ( discriminatorOption_ == "merePresence" ) {
-      decision = false;
-    } else if (discriminatorOption_ == "combined" ) { // testing purpose only
-      unsigned int muType = 0;
-      if      ( muonref->isGlobalMuon()  ) muType = 1;
-      else if ( muonref->isCaloMuon()    ) muType = 2;
-      else if ( muonref->isTrackerMuon() ) muType = 3;
-      double muonEnergyFraction = thePFTauRef->pfTauTagInfoRef()->pfjetRef()->chargedMuEnergyFraction();
-      bool eta_veto = false;
-      bool phi_veto = false;
-      if ( fabs(muonref->eta()) > 2.3 || (fabs(muonref->eta()) > 1.4 && fabs(muonref->eta()) < 1.6)) eta_veto = true;
-      if ( muonref->phi() < 0.1 && muonref->phi() > -0.1) phi_veto = true;
-      if ( muType != 1 || muonref ->numberOfMatches() > 0 || eta_veto || phi_veto || muonEnergyFraction > 0.9 ) decision = false; // as place holder
-    } else if ( discriminatorOption_ == "noAllArbitrated" || discriminatorOption_ == "noAllArbitratedWithHOP" ) {
-      if(checkNumMatches_ && muonref ->numberOfMatches() > maxNumberOfMatches_) decision = false;
-      if ( muon::isGoodMuon(*muonref, muon::AllArbitrated) ) decision = false;      
-    } else if ( discriminatorOption_ == "HOP" ) { 
-      decision = true; // only calo. muon cut requested: keep all tau candidates, regardless of signals in muon system
-    } else {
-      throw edm::Exception(edm::errors::UnimplementedFeature) 
-	<< " Invalid Discriminator option = " << discriminatorOption_ << " --> please check cfi file !!\n";
-    }
+        bool eta_veto = false;
+        bool phi_veto = false;
+        if ( fabs(muonref->eta()) > 2.3 || (fabs(muonref->eta()) > 1.4 && fabs(muonref->eta()) < 1.6)) eta_veto = true;
+        if ( muonref->phi() < 0.1 && muonref->phi() > -0.1) phi_veto = true;
+        if ( muType != 1 || muonref ->numberOfMatches() > 0 || eta_veto || phi_veto || muonEnergyFraction > 0.9 ) decision = false; // as place holder
+      } else if ( discriminatorOption_ == "noAllArbitrated" || discriminatorOption_ == "noAllArbitratedWithHOP" ) {
+        if(checkNumMatches_ && muonref ->numberOfMatches() > maxNumberOfMatches_) decision = false;
+        if ( muon::isGoodMuon(*muonref, muon::AllArbitrated) ) decision = false;      
+      } else if ( discriminatorOption_ == "HOP" ) { 
+        decision = true; // only calo. muon cut requested: keep all tau candidates, regardless of signals in muon system
+      } else {
+        throw edm::Exception(edm::errors::UnimplementedFeature) 
+	  << " Invalid Discriminator option = " << discriminatorOption_ << " --> please check cfi file !!\n";
+      }
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   } // valid muon ref
 
   // Additional calo. muon cut: veto one prongs compatible with MIP signature
   if ( discriminatorOption_ == "HOP" || discriminatorOption_ == "noAllArbitratedWithHOP" ) {
     if ( thePFTauRef->leadPFChargedHadrCand().isNonnull() ) {
-      double muonCaloEn = thePFTauRef->leadPFChargedHadrCand()->hcalEnergy() + thePFTauRef->leadPFChargedHadrCand()->ecalEnergy();
-      if ( thePFTauRef->decayMode() == 0 && muonCaloEn < (hop_*thePFTauRef->leadPFChargedHadrCand()->p()) ) decision = false;
-    }
+      const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(thePFTauRef->leadPFChargedHadrCand().get());
+      if (pfcand != nullptr) {
+        double muonCaloEn = pfcand->hcalEnergy() + pfcand->ecalEnergy();
+        if ( thePFTauRef->decayMode() == 0 && muonCaloEn < (hop_*pfcand->p()) ) decision = false;
+      }
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
 
   return (decision ? 1. : 0.);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
@@ -174,14 +174,17 @@ double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& p
     numHitsRPC[iStation]    = 0;
   } 
 
-  const reco::PFCandidatePtr& pfLeadChargedHadron = pfTau->leadPFChargedHadrCand();
+  const reco::CandidatePtr& pfLeadChargedHadron = pfTau->leadPFChargedHadrCand();
   if ( pfLeadChargedHadron.isNonnull() ) {
-    reco::MuonRef muonRef = pfLeadChargedHadron->muonRef();      
-    if ( muonRef.isNonnull() ) {
-      if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuon2") << " has muonRef." ;
-      countMatches(*muonRef, numMatchesDT, numMatchesCSC, numMatchesRPC);
-      countHits(*muonRef, numHitsDT, numHitsCSC, numHitsRPC);
-    }
+    const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(pfLeadChargedHadron.get());
+    if (pflch != nullptr) {
+      reco::MuonRef muonRef = pflch->muonRef();      
+      if ( muonRef.isNonnull() ) {
+	if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuon2") << " has muonRef." ;
+	countMatches(*muonRef, numMatchesDT, numMatchesCSC, numMatchesRPC);
+	countHits(*muonRef, numHitsDT, numHitsCSC, numHitsRPC);
+      } 
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and PFRecoTauDiscriminationAgainstMuon2 only works with PFTaus made from PFCandidates. Please use PFRecoTauDiscriminationAgainstMuonSimple instead.\n";
   }
   
   if ( srcMuons_.label() != "" ) {
@@ -193,9 +196,14 @@ double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& p
 	if ( verbosity_ ){ edm::LogPrint("PFTauAgainstMuon2") << " fails Pt cut --> skipping it." ;}
 	continue;
        }
-      if ( pfLeadChargedHadron.isNonnull() && pfLeadChargedHadron->muonRef().isNonnull() && muon == pfLeadChargedHadron->muonRef() ) {	
-	if ( verbosity_ ){ edm::LogPrint("PFTauAgainstMuon2") << " matches muonRef of tau --> skipping it." ;}
-	continue;
+      if ( pfLeadChargedHadron.isNonnull()) {
+	const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(pfLeadChargedHadron.get());
+	if (pflch != nullptr) {
+	  reco::MuonRef muonRef = pflch->muonRef();      
+	  if (muonRef.isNonnull() && muon == pflch->muonRef() )
+	  if ( verbosity_ ) { edm::LogPrint("PFTauAgainstMuon2") << " matches muonRef of tau --> skipping it."; }
+	  continue;
+	} else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and PFRecoTauDiscriminationAgainstMuon2 only works with PFTaus made from PFCandidates. Please use PFRecoTauDiscriminationAgainstMuonSimple instead.\n";
       }
       double dR = deltaR(muon->p4(), pfTau->p4());
       double dRmatch = dRmuonMatch_;
@@ -248,18 +256,21 @@ double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& p
   
   bool passesCaloMuonVeto = true;
   if ( pfLeadChargedHadron.isNonnull() ) {
-    double energyECALplusHCAL = pfLeadChargedHadron->ecalEnergy() + pfLeadChargedHadron->hcalEnergy();    
-    if ( verbosity_ ) {
-      if ( pfLeadChargedHadron->trackRef().isNonnull() ) {
-	edm::LogPrint("PFTauAgainstMuon2") << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL << ", leadPFChargedHadronP = " << pfLeadChargedHadron->trackRef()->p() ;
-      } else if ( pfLeadChargedHadron->gsfTrackRef().isNonnull() ) {
-	edm::LogPrint("PFTauAgainstMuon2") << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL << ", leadPFChargedHadronP = " << pfLeadChargedHadron->gsfTrackRef()->p() ;
+    const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(pfLeadChargedHadron.get());
+    if (pflch != nullptr) {
+      double energyECALplusHCAL = pflch->ecalEnergy() + pflch->hcalEnergy();    
+      if ( verbosity_ ) {
+	if ( pflch->trackRef().isNonnull() ) {
+	  edm::LogPrint("PFTauAgainstMuon2") << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL << ", leadPFChargedHadronP = " << pflch->trackRef()->p() ;
+	} else if ( pflch->gsfTrackRef().isNonnull() ) {
+	  edm::LogPrint("PFTauAgainstMuon2") << "decayMode = " << pfTau->decayMode() << ", energy(ECAL+HCAL) = " << energyECALplusHCAL << ", leadPFChargedHadronP = " << pflch->gsfTrackRef()->p() ;
+	}
       }
-    }
-    const reco::Track* leadTrack = nullptr;
-    if ( pfLeadChargedHadron->trackRef().isNonnull() ) leadTrack = pfLeadChargedHadron->trackRef().get();
-    else if ( pfLeadChargedHadron->gsfTrackRef().isNonnull() ) leadTrack = pfLeadChargedHadron->gsfTrackRef().get();
-    if ( pfTau->decayMode() == 0 && leadTrack && energyECALplusHCAL < (hop_*leadTrack->p()) ) passesCaloMuonVeto = false;
+      const reco::Track* leadTrack = nullptr;
+      if ( pflch->trackRef().isNonnull() ) leadTrack = pflch->trackRef().get();
+      else if ( pflch->gsfTrackRef().isNonnull() ) leadTrack = pflch->gsfTrackRef().get();
+      if ( pfTau->decayMode() == 0 && leadTrack && energyECALplusHCAL < (hop_*leadTrack->p()) ) passesCaloMuonVeto = false;
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and PFRecoTauDiscriminationAgainstMuon2 only works with PFTaus made from PFCandidates. Please use PFRecoTauDiscriminationAgainstMuonSimple instead.\n";
   }
   
   double discriminatorValue = 0.;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
@@ -1,0 +1,311 @@
+/** \class PFRecoTauDiscriminationAgainstMuonSimple
+ *
+ * Compute tau Id. discriminator against muons for MiniAOD.
+ * 
+ * \author Michal Bluj, NCBJ Warsaw
+ * based on PFRecoTauDiscriminationAgainstMuon2 by Christian Veelken
+ *
+ * Note: it is not granted that information on muon track is/will be always 
+ * accesible with MiniAOD, if not one can consider to veto muons which are 
+ * not only Trk by also STA or RPC muons, i.e. have many (>=2) good muon segments 
+ */
+
+#include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <vector>
+#include <string>
+#include <iostream>
+
+namespace {
+
+class PFRecoTauDiscriminationAgainstMuonSimple final : public PFTauDiscriminationProducerBase
+{
+ public:
+  explicit PFRecoTauDiscriminationAgainstMuonSimple(const edm::ParameterSet& cfg)
+    : PFTauDiscriminationProducerBase(cfg),
+      moduleLabel_(cfg.getParameter<std::string>("@module_label"))
+  {   
+    hop_ = cfg.getParameter<double>("HoPMin");
+    doCaloMuonVeto_ = cfg.getParameter<bool>("doCaloMuonVeto");
+    srcPatMuons_ = cfg.getParameter<edm::InputTag>("srcPatMuons");
+    Muons_token = consumes<pat::MuonCollection>(srcPatMuons_);
+    dRmuonMatch_ = cfg.getParameter<double>("dRmuonMatch");
+    dRmuonMatchLimitedToJetArea_ = cfg.getParameter<bool>("dRmuonMatchLimitedToJetArea");
+    minPtMatchedMuon_ = cfg.getParameter<double>("minPtMatchedMuon");
+    maxNumberOfMatches_ = cfg.getParameter<int>("maxNumberOfMatches");
+    maxNumberOfHitsLast2Stations_ = cfg.getParameter<int>("maxNumberOfHitsLast2Stations");
+    typedef std::vector<int> vint;
+    maskMatchesDT_  = cfg.getParameter<vint>("maskMatchesDT");
+    maskMatchesCSC_ = cfg.getParameter<vint>("maskMatchesCSC");
+    maskMatchesRPC_ = cfg.getParameter<vint>("maskMatchesRPC");
+    maskHitsDT_     = cfg.getParameter<vint>("maskHitsDT");
+    maskHitsCSC_    = cfg.getParameter<vint>("maskHitsCSC");
+    maskHitsRPC_    = cfg.getParameter<vint>("maskHitsRPC");
+    maxNumberOfSTAMuons_ = cfg.getParameter<int>("maxNumberOfSTAMuons");
+    maxNumberOfRPCMuons_ = cfg.getParameter<int>("maxNumberOfRPCMuons");
+
+    numWarnings_ = 0;
+    maxWarnings_ = 3;
+    verbosity_ = cfg.exists("verbosity") ? cfg.getParameter<int>("verbosity") : 0;
+   }
+  ~PFRecoTauDiscriminationAgainstMuonSimple() override {} 
+
+  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+
+  double discriminate(const reco::PFTauRef&) const override;
+
+ private:  
+  std::string moduleLabel_;
+  int discriminatorOption_;
+  double hop_;
+  bool doCaloMuonVeto_;
+  edm::InputTag srcPatMuons_;
+  edm::Handle<pat::MuonCollection> muons_;
+  edm::EDGetTokenT<pat::MuonCollection> Muons_token;
+  double dRmuonMatch_;
+  bool dRmuonMatchLimitedToJetArea_;
+  double minPtMatchedMuon_;
+  int maxNumberOfMatches_;
+  std::vector<int> maskMatchesDT_;
+  std::vector<int> maskMatchesCSC_;
+  std::vector<int> maskMatchesRPC_;
+  int maxNumberOfHitsLast2Stations_;
+  std::vector<int> maskHitsDT_;
+  std::vector<int> maskHitsCSC_;
+  std::vector<int> maskHitsRPC_;
+  int maxNumberOfSTAMuons_, maxNumberOfRPCMuons_;
+
+  mutable int numWarnings_;
+  int maxWarnings_;
+  int verbosity_;
+};
+
+void PFRecoTauDiscriminationAgainstMuonSimple::beginEvent(const edm::Event& evt, const edm::EventSetup& es) 
+{
+  evt.getByToken(Muons_token, muons_);
+}
+
+namespace
+{
+  /* MB: not used in current implementation, but keep it if needed in future
+  const reco::Track* getTrack(const reco::Candidate& cand) {
+    const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if ( pCand != nullptr && pCand->hasTrackDetails() )
+      return &pCand->pseudoTrack();
+    return nullptr;
+  }
+  */
+  void countHits(const pat::Muon& muon, std::vector<int>& numHitsDT, std::vector<int>& numHitsCSC, std::vector<int>& numHitsRPC)
+  {
+    if ( muon.outerTrack().isNonnull() ) {
+      const reco::HitPattern &muonHitPattern = muon.outerTrack()->hitPattern();
+      for (int iHit = 0; iHit < muonHitPattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++iHit) {
+          uint32_t hit = muonHitPattern.getHitPattern(reco::HitPattern::TRACK_HITS, iHit);
+	if ( hit == 0 ) break;	    
+	if ( muonHitPattern.muonHitFilter(hit) && (muonHitPattern.getHitType(hit) == TrackingRecHit::valid || muonHitPattern.getHitType(hit) == TrackingRecHit::bad) ) {
+	  int muonStation = muonHitPattern.getMuonStation(hit) - 1; // CV: map into range 0..3
+	  if ( muonStation >= 0 && muonStation < 4 ) {
+	    if      ( muonHitPattern.muonDTHitFilter(hit)  ) ++numHitsDT[muonStation];
+	    else if ( muonHitPattern.muonCSCHitFilter(hit) ) ++numHitsCSC[muonStation];
+	    else if ( muonHitPattern.muonRPCHitFilter(hit) ) ++numHitsRPC[muonStation];
+	  }
+	}
+      }
+    }
+  }
+
+  void countMatches(const pat::Muon& muon, std::vector<int>& numMatchesDT, std::vector<int>& numMatchesCSC, std::vector<int>& numMatchesRPC)
+  {
+    const std::vector<reco::MuonChamberMatch>& muonSegments = muon.matches();
+    for ( std::vector<reco::MuonChamberMatch>::const_iterator muonSegment = muonSegments.begin();
+	  muonSegment != muonSegments.end(); ++muonSegment ) {
+      if ( muonSegment->segmentMatches.empty() ) continue;
+      int muonDetector = muonSegment->detector();
+      int muonStation = muonSegment->station() - 1;
+      assert(muonStation >= 0 && muonStation <= 3);
+      if      ( muonDetector == MuonSubdetId::DT  ) ++numMatchesDT[muonStation];
+      else if ( muonDetector == MuonSubdetId::CSC ) ++numMatchesCSC[muonStation];
+      else if ( muonDetector == MuonSubdetId::RPC ) ++numMatchesRPC[muonStation];      
+    }
+  }
+
+  std::string format_vint(const std::vector<int>& vi)
+  {
+    std::ostringstream os;    
+    os << "{ ";
+    unsigned numEntries = vi.size();
+    for ( unsigned iEntry = 0; iEntry < numEntries; ++iEntry ) {
+      os << vi[iEntry];
+      if ( iEntry < (numEntries - 1) ) os << ", ";
+    }
+    os << " }";
+    return os.str();
+  }
+  
+}
+
+double PFRecoTauDiscriminationAgainstMuonSimple::discriminate(const reco::PFTauRef& pfTau) const
+{
+  if ( verbosity_ ) {
+    edm::LogPrint("PFTauAgainstMuonSimple") << "<PFRecoTauDiscriminationAgainstMuonSimple::discriminate>:" ;
+    edm::LogPrint("PFTauAgainstMuonSimple") << " moduleLabel = " << moduleLabel_ ;
+    edm::LogPrint("PFTauAgainstMuonSimple") << "tau #" << pfTau.key() << ": Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() << ", decay mode = " << pfTau->decayMode() ;   
+  }
+
+  //if (pfTau->decayMode() >= 5) return true; //MB: accept all multi-prongs??
+
+  const reco::CandidatePtr& pfLeadChargedHadron = pfTau->leadPFChargedHadrCand();
+  bool passesCaloMuonVeto = true;
+  if ( pfLeadChargedHadron.isNonnull() ) {
+    const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(pfLeadChargedHadron.get());
+    if ( pCand != nullptr ) {
+      double rawCaloEnergyFraction = pCand->rawCaloFraction();
+      //if ( !(rawCaloEnergyFraction > 0.) ) rawCaloEnergyFraction = 99; //MB: hack against cases when rawCaloEnergyFraction is not stored; it makes performance of the H/P cut rather poor
+      if ( verbosity_ ) {
+	edm::LogPrint("PFTauAgainstMuonSimple") << "decayMode = " << pfTau->decayMode() << ", rawCaloEnergy(ECAL+HCAL)Fraction = " << rawCaloEnergyFraction << ", leadPFChargedHadronP = " << pCand->p() << ", leadPFChargedHadron pdgId = " << pCand->pdgId();
+      }
+      if ( pfTau->decayMode() == 0 && rawCaloEnergyFraction < hop_ ) passesCaloMuonVeto = false;
+    }
+  }
+  if ( doCaloMuonVeto_ && !passesCaloMuonVeto ) {
+    if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << "--> CaloMuonVeto failed, returning 0";
+    return 0.;
+  }
+
+  //iterate over muons to find ones to use for discrimination
+  std::vector<const pat::Muon*> muonsToCheck;
+  size_t numMuons = muons_->size();
+  for ( size_t idxMuon = 0; idxMuon < numMuons; ++idxMuon ) {
+    bool matched = false;
+    const pat::MuonRef muon(muons_, idxMuon);
+    if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << "muon #" << muon.key() << ": Pt = " << muon->pt() << ", eta = " << muon->eta() << ", phi = " << muon->phi() ;
+    //firsty check if the muon corrsponds with the leading tau particle
+    for ( size_t iCand = 0; iCand < muon->numberOfSourceCandidatePtrs(); ++iCand) {
+      const reco::CandidatePtr& srcCand = muon->sourceCandidatePtr(iCand);
+      if (srcCand.isNonnull() && pfLeadChargedHadron.isNonnull() &&
+	  srcCand.id()==pfLeadChargedHadron.id() &&
+	  srcCand.key()==pfLeadChargedHadron.key() ) {
+	muonsToCheck.push_back(muon.get());
+	matched = true;
+	if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << " tau has muonRef." ;
+	break;
+      }
+    }
+    if (matched) continue;
+    //check dR matching
+    if ( !(muon->pt() > minPtMatchedMuon_) ) {
+      if ( verbosity_ ){ edm::LogPrint("PFTauAgainstMuonSimple") << " fails Pt cut --> skipping it." ;}
+      continue;
+    }
+    double dR = deltaR(muon->p4(), pfTau->p4());
+    double dRmatch = dRmuonMatch_;
+    if ( dRmuonMatchLimitedToJetArea_ ) {
+      double jetArea = 0.;
+      if ( pfTau->jetRef().isNonnull() ) jetArea = pfTau->jetRef()->jetArea();
+      if ( jetArea > 0. ) {
+	dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea/TMath::Pi()));
+      } else {
+	if ( numWarnings_ < maxWarnings_ ) {
+	  edm::LogInfo("PFRecoTauDiscriminationAgainstMuonSimple::discriminate") 
+	    << "Jet associated to Tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() << " has area = " << jetArea << " !!" ;
+	  ++numWarnings_;
+	}
+	dRmatch = pfTau->signalConeSize();
+      }
+      dRmatch = TMath::Max(dRmatch,pfTau->signalConeSize());
+      if ( dR < dRmatch ) {
+	if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << " overlaps with tau, dR = " << dR ;
+	muonsToCheck.push_back(muon.get());
+      }
+    }
+  }
+  //now examine selected muons
+  bool pass = true;
+  std::vector<int> numMatchesDT(4);
+  std::vector<int> numMatchesCSC(4);
+  std::vector<int> numMatchesRPC(4);
+  std::vector<int> numHitsDT(4);
+  std::vector<int> numHitsCSC(4);
+  std::vector<int> numHitsRPC(4);
+  //MB: clear counters of matched segments and hits globally as in the AgainstMuon2 discriminant, but note that they will sum for all matched muons. However it is not likely that there is more than one matched muon.
+  for ( int iStation = 0; iStation < 4; ++iStation ) {
+    numMatchesDT[iStation]  = 0;
+    numMatchesCSC[iStation] = 0;
+    numMatchesRPC[iStation] = 0;
+    numHitsDT[iStation]  = 0;
+    numHitsCSC[iStation] = 0;
+    numHitsRPC[iStation] = 0;
+  } 
+  int numSTAMuons=0, numRPCMuons=0;
+  if ( verbosity_ && !muonsToCheck.empty() ) edm::LogPrint("PFTauAgainstMuonSimple") << "Muons to check (" << muonsToCheck.size() << "):";
+  size_t iMu = 0;
+  for (const auto &mu: muonsToCheck) {
+    if ( mu->isStandAloneMuon() ) numSTAMuons++;
+    if ( mu->muonID("RPCMuLoose") ) numRPCMuons++;
+    countMatches(*mu, numMatchesDT, numMatchesCSC, numMatchesRPC);
+    int numStationsWithMatches = 0;
+    for ( int iStation = 0; iStation < 4; ++iStation ) {
+      if ( numMatchesDT[iStation]  > 0 && !maskMatchesDT_[iStation]  ) ++numStationsWithMatches;
+      if ( numMatchesCSC[iStation] > 0 && !maskMatchesCSC_[iStation] ) ++numStationsWithMatches;
+      if ( numMatchesRPC[iStation] > 0 && !maskMatchesRPC_[iStation] ) ++numStationsWithMatches;
+    }
+    countHits(*mu, numHitsDT, numHitsCSC, numHitsRPC);
+    int numLast2StationsWithHits = 0;
+    for ( int iStation = 2; iStation < 4; ++iStation ) {
+      if ( numHitsDT[iStation]  > 0 && !maskHitsDT_[iStation]  ) ++numLast2StationsWithHits;
+      if ( numHitsCSC[iStation] > 0 && !maskHitsCSC_[iStation] ) ++numLast2StationsWithHits;
+      if ( numHitsRPC[iStation] > 0 && !maskHitsRPC_[iStation] ) ++numLast2StationsWithHits;
+    }
+    if ( verbosity_ )
+      edm::LogPrint("PFTauAgainstMuonSimple") 
+	<< "\t" << iMu << ": Pt = " << mu->pt() << ", eta = " << mu->eta() << ", phi = " << mu->phi() 
+	<< "\n\t" 
+	<< "   isSTA: "<<mu->isStandAloneMuon()
+	<< ", isRPCLoose: "<<mu->muonID("RPCMuLoose")
+	<< "\n\t   numMatchesDT  = " << format_vint(numMatchesDT)
+	<< "\n\t   numMatchesCSC = " << format_vint(numMatchesCSC)
+	<< "\n\t   numMatchesRPC = " << format_vint(numMatchesRPC)
+	<< "\n\t   --> numStationsWithMatches = " << numStationsWithMatches
+	<< "\n\t   numHitsDT  = " << format_vint(numHitsDT)
+	<< "\n\t   numHitsCSC = " << format_vint(numHitsCSC)
+	<< "\n\t   numHitsRPC = " << format_vint(numHitsRPC)
+	<< "\n\t   --> numLast2StationsWithHits = " << numLast2StationsWithHits ;
+    if ( maxNumberOfMatches_ >= 0 && numStationsWithMatches > maxNumberOfMatches_ ) {
+      pass = false;
+      break;
+    }
+    if ( maxNumberOfHitsLast2Stations_ >= 0 && numLast2StationsWithHits > maxNumberOfHitsLast2Stations_ ) {
+      pass = false;
+      break;
+    }
+    if ( maxNumberOfSTAMuons_ >= 0 && numSTAMuons > maxNumberOfSTAMuons_ ) {
+      pass = false;
+      break;
+    }
+    if ( maxNumberOfRPCMuons_ >= 0 && numRPCMuons > maxNumberOfRPCMuons_ ) {
+      pass = false;
+      break;
+    }
+    iMu++;
+  }
+
+  double discriminatorValue = pass ? 1.: 0.;
+  if ( verbosity_ ) edm::LogPrint("PFTauAgainstMuonSimple") << "--> returning discriminatorValue = " << discriminatorValue ;
+
+  return discriminatorValue;
+} 
+
+}
+
+DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstMuonSimple);
+

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByDeltaE.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByDeltaE.cc
@@ -48,7 +48,7 @@ double PFRecoTauDiscriminationByDeltaE::discriminate(const PFTauRef& tau) const{
 
 double PFRecoTauDiscriminationByDeltaE::DeltaE(const PFTauRef& tau) const {
 	double tracksE = 0;
-	const std::vector<PFCandidatePtr>& signalTracks = tau->signalPFChargedHadrCands();
+	const std::vector<CandidatePtr>& signalTracks = tau->signalPFChargedHadrCands();
 	for(size_t i = 0; i < signalTracks.size(); ++i){
 		TLorentzVector p4;
 		p4.SetXYZM(signalTracks[i]->px(),

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByFlightPathSignificance.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByFlightPathSignificance.cc
@@ -82,19 +82,22 @@ double PFRecoTauDiscriminationByFlightPathSignificance::threeProngFlightPathSig(
   }
 
   //Secondary vertex
-  const vector<PFCandidatePtr>& pfSignalCandidates = tau->signalPFChargedHadrCands();
+  const vector<CandidatePtr>& pfSignalCandidates = tau->signalPFChargedHadrCands();
   vector<TransientTrack> transientTracks;
-  vector<PFCandidatePtr>::const_iterator iTrack;
-  for(iTrack = pfSignalCandidates.begin(); iTrack!= pfSignalCandidates.end(); iTrack++){
-    const PFCandidate& pfCand = *(iTrack->get());
-    if(pfCand.trackRef().isNonnull()){
-      const TransientTrack transientTrack = transientTrackBuilder->build(pfCand.trackRef());
-      transientTracks.push_back(transientTrack);
+  for(const auto& pfSignalCand : pfSignalCandidates){
+    const PFCandidate* pfCand = dynamic_cast<const PFCandidate*>(pfSignalCand.get());
+    if (pfCand) {
+      if(pfCand->trackRef().isNonnull()){
+        const TransientTrack transientTrack = transientTrackBuilder->build(pfCand->trackRef());
+        transientTracks.push_back(transientTrack);
+      }
+      else if(pfCand->gsfTrackRef().isNonnull()){
+        const TransientTrack transientTrack = transientTrackBuilder->build(pfCand->gsfTrackRef());
+        transientTracks.push_back(transientTrack);
+      }
     }
-    else if(pfCand.gsfTrackRef().isNonnull()){
-      const TransientTrack transientTrack = transientTrackBuilder->build(pfCand.gsfTrackRef());
-      transientTracks.push_back(transientTrack);
-    }
+    else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+
   }
   if(transientTracks.size() > 1){
     KalmanVertexFitter kvf(true);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
@@ -8,6 +8,7 @@
 
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadronFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 namespace {
   // Apply a hypothesis on the mass of the strips.
@@ -122,6 +123,23 @@ PFRecoTauDiscriminationByHPSSelection::~PFRecoTauDiscriminationByHPSSelection()
   for ( DecayModeCutMap::iterator it = decayModeCuts_.begin();
 	it != decayModeCuts_.end(); ++it ) {
     delete it->second.maxMass_;
+  }
+}
+
+namespace {
+  inline const reco::Track* getTrack(const reco::Candidate& cand)
+  {
+    const reco::PFCandidate* pfCandPtr = dynamic_cast<const reco::PFCandidate*>(&cand);
+    if (pfCandPtr) {
+      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
+      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
+      else return nullptr;
+    }
+    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (packedCand && packedCand->hasTrackDetails())
+    	return &packedCand->pseudoTrack();
+
+    return nullptr;
   }
 }
 
@@ -317,13 +335,9 @@ PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef& tau) c
 
   if ( minPixelHits_ > 0 ) {
     int numPixelHits = 0;
-    const std::vector<reco::PFCandidatePtr>& chargedHadrCands = tau->signalPFChargedHadrCands();
-    for ( std::vector<reco::PFCandidatePtr>::const_iterator chargedHadrCand = chargedHadrCands.begin();
-	  chargedHadrCand != chargedHadrCands.end(); ++chargedHadrCand ) {
-      const reco::Track* track = nullptr;
-      if ( (*chargedHadrCand)->trackRef().isNonnull() ) track = (*chargedHadrCand)->trackRef().get();
-      else if ( (*chargedHadrCand)->gsfTrackRef().isNonnull() ) track = (*chargedHadrCand)->gsfTrackRef().get();
-      if ( track ) {
+    for (const auto& chargedHadrCand : tau->signalPFChargedHadrCands()) {
+      const reco::Track* track = getTrack(*chargedHadrCand);
+      if (track != nullptr) {
 	numPixelHits += track->hitPattern().numberOfValidPixelHits();
       }
     }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -374,13 +374,13 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   if ( !(pv.isNonnull() && pfTau->leadPFChargedHadrCand().isNonnull()) ) return 0.;
 
   qcuts_->setPV(pv);
-  qcuts_->setLeadTrack(pfTau->leadPFChargedHadrCand());
+  qcuts_->setLeadTrack(*pfTau->leadPFChargedHadrCand());
 
   if ( applyDeltaBeta_ || calculateWeights_) {
     pileupQcutsGeneralQCuts_->setPV(pv);
-    pileupQcutsGeneralQCuts_->setLeadTrack(pfTau->leadPFChargedHadrCand());
+    pileupQcutsGeneralQCuts_->setLeadTrack(*pfTau->leadPFChargedHadrCand());
     pileupQcutsPUTrackSelection_->setPV(pv);
-    pileupQcutsPUTrackSelection_->setLeadTrack(pfTau->leadPFChargedHadrCand());
+    pileupQcutsPUTrackSelection_->setLeadTrack(*pfTau->leadPFChargedHadrCand());
   }
 
   // Load the tracks if they are being used.

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -167,7 +167,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
         puFactorizedIsoQCuts.second));
 
       pfCandSrc_ = pset.getParameter<edm::InputTag>("particleFlowSrc");
-      pfCand_token = consumes<reco::PFCandidateCollection>(pfCandSrc_);
+      pfCand_token = consumes<edm::View<reco::Candidate> >(pfCandSrc_);
       vertexSrc_ = pset.getParameter<edm::InputTag>("vertexSrc");
       vertex_token = consumes<reco::VertexCollection>(vertexSrc_);
       deltaBetaCollectionCone_ = pset.getParameter<double>(
@@ -201,7 +201,7 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   void beginEvent(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   double discriminate(const PFTauRef& pfTau) const override;
 
-  inline  double weightedSum(const std::vector<PFCandidatePtr>& inColl_, double eta, double phi) const {
+  inline  double weightedSum(const std::vector<CandidatePtr>& inColl_, double eta, double phi) const {
     double out = 1.0;
     for (auto const & inObj_ : inColl_){
       double sum = (inObj_->pt()*inObj_->pt())/(deltaR2(eta,phi,inObj_->eta(),inObj_->phi()));
@@ -268,11 +268,11 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   // Delta Beta correction
   bool applyDeltaBeta_;
   edm::InputTag pfCandSrc_;
-  edm::EDGetTokenT<reco::PFCandidateCollection> pfCand_token;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > pfCand_token;
   // Keep track of how many vertices are in the event
   edm::InputTag vertexSrc_;
   edm::EDGetTokenT<reco::VertexCollection> vertex_token;
-  std::vector<reco::PFCandidatePtr> chargedPFCandidatesInEvent_;
+  std::vector<reco::CandidatePtr> chargedPFCandidatesInEvent_;
   // Size of cone used to collect PU tracks
   double deltaBetaCollectionCone_;
   std::auto_ptr<TFormula> deltaBetaFormula_;
@@ -304,13 +304,13 @@ void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, con
   // candidates from the event so we can find the PU tracks.
   if ( applyDeltaBeta_ || calculateWeights_ ) {
     // Collect all the PF pile up tracks
-    edm::Handle<reco::PFCandidateCollection> pfCandidates;
+    edm::Handle<edm::View<reco::Candidate> > pfCandidates;
     event.getByToken(pfCand_token, pfCandidates);
     chargedPFCandidatesInEvent_.clear();
     chargedPFCandidatesInEvent_.reserve(pfCandidates->size());
     size_t numPFCandidates = pfCandidates->size();
     for ( size_t i = 0; i < numPFCandidates; ++i ) {
-      reco::PFCandidatePtr pfCandidate(pfCandidates, i);
+      reco::CandidatePtr pfCandidate(pfCandidates, i);
       if ( pfCandidate->charge() != 0 ) {
         chargedPFCandidatesInEvent_.push_back(pfCandidate);
       }
@@ -338,11 +338,11 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
     LogDebug("discriminate") << *pfTau ;
 
   // collect the objects we are working with (ie tracks, tracks+gammas, etc)
-  std::vector<PFCandidatePtr> isoCharged_;
-  std::vector<PFCandidatePtr> isoNeutral_;
-  std::vector<PFCandidatePtr> isoPU_;
-  PFCandidateCollection isoNeutralWeight_;
-  std::vector<PFCandidatePtr> chPV_;
+  std::vector<CandidatePtr> isoCharged_;
+  std::vector<CandidatePtr> isoNeutral_;
+  std::vector<CandidatePtr> isoPU_;
+  CandidateCollection isoNeutralWeight_;
+  std::vector<CandidatePtr> chPV_;
   isoCharged_.reserve(pfTau->isolationPFChargedHadrCands().size());
   isoNeutral_.reserve(pfTau->isolationPFGammaCands().size());
   isoPU_.reserve(std::min(100UL, chargedPFCandidatesInEvent_.size()));
@@ -401,8 +401,8 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
     }
   }
 
-  typedef reco::tau::cone::DeltaRPtrFilter<PFCandidatePtr> DRFilter;
-  typedef reco::tau::cone::DeltaRFilter<PFCandidate> DRFilter2;
+  typedef reco::tau::cone::DeltaRPtrFilter<CandidatePtr> DRFilter;
+  typedef reco::tau::cone::DeltaRFilter<Candidate> DRFilter2;
 
   // If desired, get PU tracks.
   if ( applyDeltaBeta_ || calculateWeights_) {
@@ -411,21 +411,21 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
       std::cout << "Initial PFCands: " << chargedPFCandidatesInEvent_.size() << std::endl;
     }
 
-    std::vector<PFCandidatePtr> allPU =
+    std::vector<CandidatePtr> allPU =
       pileupQcutsPUTrackSelection_->filterCandRefs(
           chargedPFCandidatesInEvent_, true);
 
-    std::vector<PFCandidatePtr> allNPU =
+    std::vector<CandidatePtr> allNPU =
       pileupQcutsPUTrackSelection_->filterCandRefs(
 	  chargedPFCandidatesInEvent_);
       LogTrace("discriminate") << "After track cuts: " << allPU.size() ;
 
     // Now apply the rest of the cuts, like pt, and TIP, tracker hits, etc
     if ( !useAllPFCands_ ) {
-      std::vector<PFCandidatePtr> cleanPU =
+      std::vector<CandidatePtr> cleanPU =
         pileupQcutsGeneralQCuts_->filterCandRefs(allPU);
 
-      std::vector<PFCandidatePtr> cleanNPU =
+      std::vector<CandidatePtr> cleanNPU =
         pileupQcutsGeneralQCuts_->filterCandRefs(allNPU);
 
       LogTrace("discriminate") << "After cleaning cuts: " << cleanPU.size() ;
@@ -459,7 +459,7 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
       double sumNPU = 0.5*log(weightedSum(chPV_, eta, phi));
       
       double sumPU = 0.5*log(weightedSum(isoPU_, eta, phi));
-      PFCandidate neutral = (*isoObject);
+      LeafCandidate neutral(*isoObject);
       if ( (sumNPU + sumPU) > 0 ) neutral.setP4(((sumNPU)/(sumNPU + sumPU))*neutral.p4());
       
       isoNeutralWeight_.push_back(neutral);
@@ -470,9 +470,9 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   if ( customIsoCone_ >= 0. ) {
     DRFilter filter(pfTau->p4(), 0, customIsoCone_);
     DRFilter2 filter2(pfTau->p4(), 0, customIsoCone_);
-    std::vector<PFCandidatePtr> isoCharged_filter;
-    std::vector<PFCandidatePtr> isoNeutral_filter;
-    PFCandidateCollection isoNeutralWeight_filter;
+    std::vector<CandidatePtr> isoCharged_filter;
+    std::vector<CandidatePtr> isoNeutral_filter;
+    CandidateCollection isoNeutralWeight_filter;
     // Remove all the objects not in our iso cone
     for( auto const & isoObject : isoCharged_ ) {
       if ( filter(isoObject) ) isoCharged_filter.push_back(isoObject);
@@ -578,8 +578,8 @@ PFRecoTauDiscriminationByIsolation::discriminate(const PFTauRef& pfTau) const
   bool failsPhotonPtSumOutsideSignalConeCut = false;
   double photonSumPt_outsideSignalCone = 0.;
   if ( applyPhotonPtSumOutsideSignalConeCut_ || storeRawPhotonSumPt_outsideSignalCone_ ) {
-    const std::vector<reco::PFCandidatePtr>& signalPFGammas = pfTau->signalPFGammaCands();
-    for ( std::vector<reco::PFCandidatePtr>::const_iterator signalPFGamma = signalPFGammas.begin();
+    const std::vector<reco::CandidatePtr>& signalPFGammas = pfTau->signalPFGammaCands();
+    for ( std::vector<reco::CandidatePtr>::const_iterator signalPFGamma = signalPFGammas.begin();
 	  signalPFGamma != signalPFGammas.end(); ++signalPFGamma ) {
       double dR = deltaR(pfTau->eta(), pfTau->phi(), (*signalPFGamma)->eta(), (*signalPFGamma)->phi());
       if ( dR > pfTau->signalConeSize() ) photonSumPt_outsideSignalCone += (*signalPFGamma)->pt();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByNProngs.cc
@@ -52,14 +52,14 @@ void PFRecoTauDiscriminationByNProngs::beginEvent(const Event& iEvent, const Eve
 double PFRecoTauDiscriminationByNProngs::discriminate(const PFTauRef& tau) const{
 
 	reco::VertexRef pv = vertexAssociator_->associatedVertex(*tau);
-	const PFCandidatePtr leadingTrack = tau->leadPFChargedHadrCand();
+	const CandidatePtr leadingTrack = tau->leadPFChargedHadrCand();
 
 	uint np = 0;
 	if(leadingTrack.isNonnull() && pv.isNonnull()){
 	    qcuts_->setPV(pv);
-	    qcuts_->setLeadTrack(tau->leadPFChargedHadrCand());
+	    qcuts_->setLeadTrack(*tau->leadPFChargedHadrCand());
 
-	    BOOST_FOREACH( const reco::PFCandidatePtr& cand, tau->signalPFChargedHadrCands() ) {
+	    BOOST_FOREACH( const reco::CandidatePtr& cand, tau->signalPFChargedHadrCands() ) {
 	        if ( qcuts_->filterCandRef(cand) ) np++;
  	    }
 	}

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -187,13 +187,13 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 
     // Determine which neutral PFCandidates are close to PFChargedHadrons
     // and have been merged into ChargedHadrons
-    std::vector<reco::PFCandidatePtr> mergedNeutrals;
+    std::vector<reco::CandidatePtr> mergedNeutrals;
     reco::Candidate::LorentzVector mergedNeutralsSumP4;
     for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
 	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
       if ( chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) ) {
-	const std::vector<reco::PFCandidatePtr>& neutralPFCands = chargedHadron->getNeutralPFCandidates();
-	for ( std::vector<reco::PFCandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
+	const std::vector<reco::CandidatePtr>& neutralPFCands = chargedHadron->getNeutralPFCandidates();
+	for ( std::vector<reco::CandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
 	      neutralPFCand != neutralPFCands.end(); ++neutralPFCand ) {
 	  mergedNeutrals.push_back(*neutralPFCand);
 	  mergedNeutralsSumP4 += (*neutralPFCand)->p4();
@@ -234,7 +234,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 
     // Determine energy sum of all PFNeutralHadrons interpreted as ChargedHadrons with missing track
     unsigned numChargedHadronNeutrals = 0;
-    std::vector<reco::PFCandidatePtr> chargedHadronNeutrals;
+    std::vector<reco::CandidatePtr> chargedHadronNeutrals;
     reco::Candidate::LorentzVector chargedHadronNeutralsSumP4;
     for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
 	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
@@ -266,7 +266,7 @@ void PFRecoTauEnergyAlgorithmPlugin::operator()(PFTau& tau) const
 	if ( chargedHadron.algoIs(PFRecoTauChargedHadron::kPFNeutralHadron) ) {
 	  PFRecoTauChargedHadron chargedHadron_modified = chargedHadron;
 	  chargedHadron_modified.neutralPFCandidates_.clear();
-	  const PFCandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
+	  const CandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
 	  double chargedHadronPx_modified = scaleFactor*chargedPFCand->px();
 	  double chargedHadronPy_modified = scaleFactor*chargedPFCand->py();
 	  double chargedHadronPz_modified = scaleFactor*chargedPFCand->pz();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -97,27 +97,6 @@ namespace
     tau.setP4(tauP4_modified);
     tau.setStatus(-1);
   }
-
-  const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron) {
-    // Charged hadron made from track (reco::Track) - RECO/AOD only
-    if ( chargedHadron.getTrack().isNonnull()) {
-      return chargedHadron.getTrack().get();
-    }
-    // Get track from chargedPackedCandidate - MINIAOD
-    const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getChargedPFCandidate());
-    if (chargedPFPCand) {
-        if (chargedPFPCand->hasTrackDetails())
-          return &chargedPFPCand->pseudoTrack();
-    }
-    // Get track from lostTrackPackedCandidate - MINIAOD for charged hadron made from lostTtrack (pat::PackedCandidate)
-    const pat::PackedCandidate* lostTrackPCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getLostTrackCandidate());
-    if (lostTrackPCand) {
-        if (lostTrackPCand->hasTrackDetails())
-          return &lostTrackPCand->pseudoTrack();
-    }
-
-    return nullptr;
-  }
 }
 
 template<class Base, class Der>

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauTagInfoProducer.cc
@@ -74,9 +74,9 @@ void PFRecoTauTagInfoProducer::produce(edm::StreamID, edm::Event& iEvent, const 
   // *** access the PFCandidateCollection in the event in order to retrieve the PFCandidateRefVector which constitutes each PFJet
   edm::Handle<PFCandidateCollection> thePFCandidateCollection;
   iEvent.getByToken(PFCandidate_token,thePFCandidateCollection);
-  vector<PFCandidatePtr> thePFCandsInTheEvent;
+  vector<CandidatePtr> thePFCandsInTheEvent;
   for(unsigned int i_PFCand=0;i_PFCand!=thePFCandidateCollection->size();i_PFCand++) { 
-        thePFCandsInTheEvent.push_back(PFCandidatePtr(thePFCandidateCollection,i_PFCand));
+        thePFCandsInTheEvent.push_back(CandidatePtr(thePFCandidateCollection,i_PFCand));
   }
   // ***
   // query a rec/sim PV
@@ -98,7 +98,8 @@ else{
   
   auto resultExt = std::make_unique<PFTauTagInfoCollection>();  
   for(JetTracksAssociationCollection::const_iterator iAssoc=thePFJetTracksAssociatorCollection->begin();iAssoc!=thePFJetTracksAssociatorCollection->end();iAssoc++){
-    PFTauTagInfo myPFTauTagInfo=PFRecoTauTagInfoAlgo_->buildPFTauTagInfo((*iAssoc).first.castTo<PFJetRef>(),thePFCandsInTheEvent,(*iAssoc).second,thePV);
+    // PFTauTagInfo myPFTauTagInfo=PFRecoTauTagInfoAlgo_->buildPFTauTagInfo((*iAssoc).first.castTo<JetBaseRef>(),thePFCandsInTheEvent,(*iAssoc).second,thePV);
+  	PFTauTagInfo myPFTauTagInfo=PFRecoTauTagInfoAlgo_->buildPFTauTagInfo(JetBaseRef((*iAssoc).first),thePFCandsInTheEvent,(*iAssoc).second,thePV);
     resultExt->push_back(myPFTauTagInfo);
   }
   

--- a/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
@@ -1,0 +1,334 @@
+/* class PFTauMiniAODPrimaryVertexProducer
+ * EDProducer of the 
+ * authors: Ian M. Nugent
+ * This work is based on the impact parameter work by Rosamaria Venditti and reconstructing the 3 prong taus.
+ * The idea of the fully reconstructing the tau using a kinematic fit comes from
+ * Lars Perchalla and Philip Sauerland Theses under Achim Stahl supervision. This
+ * work was continued by Ian M. Nugent and Vladimir Cherepanov.
+ * Thanks goes to Christian Veelken and Evan Klose Friis for their help and suggestions.
+ */
+
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
+#include "RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h"
+
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h" 
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h" 
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/AssociationVector.h"
+#include "DataFormats/Common/interface/RefProd.h"
+
+#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include <memory>
+#include <boost/foreach.hpp>
+#include <TFormula.h>
+
+#include <memory>
+
+using namespace reco;
+using namespace edm;
+using namespace std;
+
+class PFTauMiniAODPrimaryVertexProducer final : public edm::stream::EDProducer<> {
+ public:
+  enum Alg{useInputPV=0, useFontPV};
+
+  struct DiscCutPair{
+    DiscCutPair():discr_(nullptr),cutFormula_(nullptr){}
+    ~DiscCutPair(){delete cutFormula_;}
+    const reco::PFTauDiscriminator* discr_;
+    edm::EDGetTokenT<reco::PFTauDiscriminator> inputToken_;
+    double cut_;
+    TFormula* cutFormula_;
+  };
+  typedef std::vector<DiscCutPair*> DiscCutPairVec;
+
+  explicit PFTauMiniAODPrimaryVertexProducer(const edm::ParameterSet& iConfig);
+  ~PFTauMiniAODPrimaryVertexProducer() override;
+  void produce(edm::Event&,const edm::EventSetup&) override;
+
+ private:
+  edm::EDGetTokenT<std::vector<reco::PFTau> > PFTauToken_;
+  edm::EDGetTokenT<std::vector<pat::Electron> > ElectronToken_;
+  edm::EDGetTokenT<std::vector<pat::Muon> > MuonToken_;
+  edm::EDGetTokenT<reco::VertexCollection> PVToken_;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  edm::EDGetTokenT<edm::View<pat::PackedCandidate> > packedCandsToken_, lostCandsToken_;
+  int Algorithm_;
+  edm::ParameterSet qualityCutsPSet_;
+  bool useBeamSpot_;
+  bool useSelectedTaus_;
+  bool removeMuonTracks_;
+  bool removeElectronTracks_;
+  DiscCutPairVec discriminators_;
+  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
+  std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+};
+
+PFTauMiniAODPrimaryVertexProducer::PFTauMiniAODPrimaryVertexProducer(const edm::ParameterSet& iConfig):
+  PFTauToken_(consumes<std::vector<reco::PFTau> >(iConfig.getParameter<edm::InputTag>("PFTauTag"))),
+  ElectronToken_(consumes<std::vector<pat::Electron> >(iConfig.getParameter<edm::InputTag>("ElectronTag"))),
+  MuonToken_(consumes<std::vector<pat::Muon> >(iConfig.getParameter<edm::InputTag>("MuonTag"))),
+  PVToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PVTag"))),
+  beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+  packedCandsToken_(consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("packedCandidatesTag"))),
+  lostCandsToken_(consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("lostCandidatesTag"))),
+  Algorithm_(iConfig.getParameter<int>("Algorithm")),
+  qualityCutsPSet_(iConfig.getParameter<edm::ParameterSet>("qualityCuts")),
+  useBeamSpot_(iConfig.getParameter<bool>("useBeamSpot")),
+  useSelectedTaus_(iConfig.getParameter<bool>("useSelectedTaus")),
+  removeMuonTracks_(iConfig.getParameter<bool>("RemoveMuonTracks")),
+  removeElectronTracks_(iConfig.getParameter<bool>("RemoveElectronTracks"))
+{
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  std::vector<edm::ParameterSet> discriminators =iConfig.getParameter<std::vector<edm::ParameterSet> >("discriminators");
+  // Build each of our cuts
+  BOOST_FOREACH(const edm::ParameterSet &pset, discriminators) {
+    DiscCutPair* newCut = new DiscCutPair();
+    newCut->inputToken_ =consumes<reco::PFTauDiscriminator>(pset.getParameter<edm::InputTag>("discriminator"));
+
+    if ( pset.existsAs<std::string>("selectionCut") ) newCut->cutFormula_ = new TFormula("selectionCut", pset.getParameter<std::string>("selectionCut").data());
+    else newCut->cut_ = pset.getParameter<double>("selectionCut");
+    discriminators_.push_back(newCut);
+  }
+  // Build a string cut if desired
+  if (iConfig.exists("cut")) cut_.reset(new StringCutObjectSelector<reco::PFTau>(iConfig.getParameter<std::string>( "cut" )));
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  produces<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef> > >();
+  produces<VertexCollection>("PFTauPrimaryVertices"); 
+
+  vertexAssociator_.reset(new tau::RecoTauVertexAssociator(qualityCutsPSet_,consumesCollector()));
+}
+
+PFTauMiniAODPrimaryVertexProducer::~PFTauMiniAODPrimaryVertexProducer(){}
+
+namespace {
+  const reco::Track* getTrack(const reco::Candidate& cand) {
+    const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (pCand && pCand->hasTrackDetails())
+      return &pCand->pseudoTrack();
+    return nullptr;
+  }
+}
+
+void PFTauMiniAODPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
+  // Obtain Collections
+  edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",transTrackBuilder);
+  
+  edm::Handle<std::vector<reco::PFTau> > Tau;
+  iEvent.getByToken(PFTauToken_,Tau);
+
+  edm::Handle<std::vector<pat::Electron> > Electron;
+  iEvent.getByToken(ElectronToken_,Electron);
+
+  edm::Handle<std::vector<pat::Muon> > Mu;
+  iEvent.getByToken(MuonToken_,Mu);
+
+  edm::Handle<reco::VertexCollection > PV;
+  iEvent.getByToken(PVToken_,PV);
+
+  edm::Handle<reco::BeamSpot> beamSpot;
+  iEvent.getByToken(beamSpotToken_,beamSpot);
+
+  edm::Handle<edm::View<pat::PackedCandidate> >  packedCands;
+  iEvent.getByToken(packedCandsToken_, packedCands);
+
+  edm::Handle<edm::View<pat::PackedCandidate> >  lostCands;
+  iEvent.getByToken(lostCandsToken_, lostCands);
+
+  // Set Association Map
+  auto AVPFTauPV = std::make_unique<edm::AssociationVector<PFTauRefProd, std::vector<reco::VertexRef>>>(PFTauRefProd(Tau));
+  auto VertexCollection_out = std::make_unique<VertexCollection>();
+  reco::VertexRefProd VertexRefProd_out = iEvent.getRefBeforePut<reco::VertexCollection>("PFTauPrimaryVertices");
+
+  // Load each discriminator
+  BOOST_FOREACH(DiscCutPair *disc, discriminators_) {
+    edm::Handle<reco::PFTauDiscriminator> discr;
+    iEvent.getByToken(disc->inputToken_, discr);
+    disc->discr_ = &(*discr);
+  }
+
+  // Set event for VerexAssociator if needed
+  if(useInputPV==Algorithm_)
+    vertexAssociator_->setEvent(iEvent);
+
+  // For each Tau Run Algorithim 
+  if(Tau.isValid()){
+    for(reco::PFTauCollection::size_type iPFTau = 0; iPFTau < Tau->size(); iPFTau++) {
+      reco::PFTauRef tau(Tau, iPFTau);
+      reco::Vertex thePV;
+      size_t thePVkey = 0;
+      if(useInputPV==Algorithm_){
+	reco::VertexRef thePVRef = vertexAssociator_->associatedVertex(*tau); 
+	thePV = *thePVRef;
+	thePVkey = thePVRef.key();
+      }
+      else if(useFontPV==Algorithm_){
+	thePV=PV->front();
+	thePVkey = 0;
+      }
+      ///////////////////////
+      // Check if it passed all the discrimiantors
+      bool passed(true); 
+      BOOST_FOREACH(const DiscCutPair* disc, discriminators_) {
+        // Check this discriminator passes
+	bool passedDisc = true;
+	if ( disc->cutFormula_ )passedDisc = (disc->cutFormula_->Eval((*disc->discr_)[tau]) > 0.5);
+	else passedDisc = ((*disc->discr_)[tau] > disc->cut_);
+        if ( !passedDisc ){passed = false; break;}
+      }
+      if (passed && cut_.get()){passed = (*cut_)(*tau);}
+      if (passed){
+	std::vector<const reco::Track*> SignalTracks;
+	for(reco::PFTauCollection::size_type jPFTau = 0; jPFTau < Tau->size(); jPFTau++) {
+	  if(useSelectedTaus_ || iPFTau==jPFTau){
+	    reco::PFTauRef RefPFTau(Tau, jPFTau);
+	    ///////////////////////////////////////////////////////////////////////////////////////////////
+	    // Get tracks from PFTau daugthers
+	    const std::vector<reco::CandidatePtr> cands = RefPFTau->signalPFChargedHadrCands(); 
+	    for(std::vector<reco::CandidatePtr>::const_iterator iter = cands.begin(); iter!=cands.end(); ++iter){
+	      if((*iter).isNull()) continue;
+	      const reco::Track* track = getTrack(**iter);
+	      if(track == nullptr) continue;
+	      SignalTracks.push_back(track);
+	    }
+	  }
+	}
+	// Get Muon tracks
+	if(removeMuonTracks_){
+
+	  if(Mu.isValid()) {
+	    for(pat::MuonCollection::size_type iMuon = 0; iMuon< Mu->size(); iMuon++){
+	      pat::MuonRef RefMuon(Mu, iMuon);
+	      if(RefMuon->track().isNonnull()) SignalTracks.push_back(RefMuon->track().get());
+	    }
+	  }
+	}
+	// Get Electron Tracks
+	if(removeElectronTracks_){
+	  if(Electron.isValid()) {
+	    for(pat::ElectronCollection::size_type iElectron = 0; iElectron<Electron->size(); iElectron++){
+	      pat::ElectronRef RefElectron(Electron, iElectron);
+	      if(RefElectron->gsfTrack().isNonnull()) SignalTracks.push_back(RefElectron->gsfTrack().get());
+	    }
+	  }
+	}
+	///////////////////////////////////////////////////////////////////////////////////////////////
+	// Get Non-Tau tracks
+	std::vector<const reco::Track*> nonTauTracks;
+	//PackedCandidates first...
+ 	if(packedCands.isValid()) {
+	  //Find candidates/tracks associated to thePV
+	  for(size_t iCand=0; iCand<packedCands->size(); ++iCand){
+	    if((*packedCands)[iCand].vertexRef().isNull()) continue;
+	    int quality = (*packedCands)[iCand].pvAssociationQuality();
+	    if((*packedCands)[iCand].vertexRef().key()!=thePVkey ||
+	       (quality!=pat::PackedCandidate::UsedInFitTight &&
+		quality!=pat::PackedCandidate::UsedInFitLoose)) continue;
+	    const reco::Track* track = getTrack((*packedCands)[iCand]);
+	    if(track == nullptr) continue;
+	    //Remove signal (tau) tracks
+	    //MB: Only deltaR deltaPt overlap removal possible (?)
+	    //MB: It should be fine as pat objects stores same track info with same presision 
+	    bool skipTrack = false;
+	    for(size_t iSigTrk=0 ; iSigTrk<SignalTracks.size(); ++iSigTrk){
+	      if(deltaR2(SignalTracks[iSigTrk]->eta(),SignalTracks[iSigTrk]->phi(),
+			 track->eta(),track->phi())<0.005*0.005
+		 && std::abs(SignalTracks[iSigTrk]->pt()/track->pt()-1.)<0.005
+		 ){
+		skipTrack = true;
+		break;
+	      }
+	    }
+	    if(skipTrack) continue;
+	    nonTauTracks.push_back(track);
+	  } 
+	}
+	//then lostCandidates
+ 	if(lostCands.isValid()) {
+	  //Find candidates/tracks associated to thePV
+	  for(size_t iCand=0; iCand<lostCands->size(); ++iCand){
+	    if((*lostCands)[iCand].vertexRef().isNull()) continue;
+	    int quality = (*lostCands)[iCand].pvAssociationQuality();
+	    if((*lostCands)[iCand].vertexRef().key()!=thePVkey ||
+	       (quality!=pat::PackedCandidate::UsedInFitTight &&
+		quality!=pat::PackedCandidate::UsedInFitLoose)) continue;
+	    const reco::Track* track = getTrack((*lostCands)[iCand]);
+	    if(track == nullptr) continue;
+	    //Remove signal (tau) tracks
+	    //MB: Only deltaR deltaPt overlap removal possible (?)
+	    //MB: It should be fine as pat objects stores same track info with same presision 
+	    bool skipTrack = false;
+	    for(size_t iSigTrk=0 ; iSigTrk<SignalTracks.size(); ++iSigTrk){
+	      if(deltaR2(SignalTracks[iSigTrk]->eta(),SignalTracks[iSigTrk]->phi(),
+			 track->eta(),track->phi())<0.005*0.005
+		 && std::abs(SignalTracks[iSigTrk]->pt()/track->pt()-1.)<0.005
+		 ){
+		skipTrack = true;
+		break;
+	      }
+	    }
+	    if(skipTrack) continue;
+	    nonTauTracks.push_back(track);
+	  } 
+	}
+	///////////////////////////////////////////////////////////////////////////////////////////////
+	// Refit the vertex
+	TransientVertex transVtx;
+	std::vector<reco::TransientTrack> transTracks;
+	for(size_t iTrk=0 ; iTrk<nonTauTracks.size(); ++iTrk){
+	  transTracks.push_back(transTrackBuilder->build(*(nonTauTracks[iTrk])));
+	}
+	bool FitOk(true);
+	if ( transTracks.size() >= 2 ) {
+	  AdaptiveVertexFitter avf;
+	  avf.setWeightThreshold(0.1); //weight per track. allow almost every fit, else --> exception
+	  try {
+	    if ( !useBeamSpot_ ){
+	      transVtx = avf.vertex(transTracks);
+	    } else {
+	      transVtx = avf.vertex(transTracks, *beamSpot);
+	    }
+	  } catch (...) {
+	    FitOk = false;
+	  }
+	} else FitOk = false;
+	if ( FitOk ) thePV = transVtx;
+      }
+      VertexRef VRef = reco::VertexRef(VertexRefProd_out, VertexCollection_out->size());
+      VertexCollection_out->push_back(thePV);
+      AVPFTauPV->setValue(iPFTau, VRef);
+    }
+  }
+  iEvent.put(std::move(VertexCollection_out),"PFTauPrimaryVertices");
+  iEvent.put(std::move(AVPFTauPV));
+}
+  
+DEFINE_FWK_MODULE(PFTauMiniAODPrimaryVertexProducer);

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -195,16 +195,23 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
       }
       if (passed && cut_.get()){passed = (*cut_)(*tau);}
       if (passed){
+      	// Use two signal track collections: One with Refs for taus made from PFCandidates,
+      	// and one with pointers for taus made from PackedCandidates
 	std::vector<reco::TrackBaseRef> SignalTracks;
+	// std::vector<reco::Track*> SignalTrackPtrs;
+	// JAN - FIXME - THIS NEEDS TO BE CHANGED WITH MICHAL'S ADAPTIONS
+
 	for(reco::PFTauCollection::size_type jPFTau = 0; jPFTau < Tau->size(); jPFTau++) {
 	  if(useSelectedTaus_ || iPFTau==jPFTau){
 	    reco::PFTauRef RefPFTau(Tau, jPFTau);
 	    ///////////////////////////////////////////////////////////////////////////////////////////////
-	    // Get tracks from PFTau daugthers
-	    const std::vector<edm::Ptr<reco::PFCandidate> > cands = RefPFTau->signalPFChargedHadrCands(); 
-	    for (std::vector<edm::Ptr<reco::PFCandidate> >::const_iterator iter = cands.begin(); iter!=cands.end(); iter++){
-	      if(iter->get()->trackRef().isNonnull()) SignalTracks.push_back(reco::TrackBaseRef(iter->get()->trackRef()));
-	      else if(iter->get()->gsfTrackRef().isNonnull()){SignalTracks.push_back(reco::TrackBaseRef(((iter)->get()->gsfTrackRef())));}
+	    // Get tracks from PFTau daughters
+	    for (const auto& cand : RefPFTau->signalPFChargedHadrCands()){
+	      const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand.get());
+	      if (pfcand != nullptr) {
+		if (pfcand->trackRef().isNonnull()) {SignalTracks.push_back(reco::TrackBaseRef(pfcand->trackRef()));}
+		else if (pfcand->gsfTrackRef().isNonnull()) {SignalTracks.push_back(reco::TrackBaseRef((pfcand->gsfTrackRef())));}
+	      }
 	    }
 	  }
 	}

--- a/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauPrimaryVertexProducer.cc
@@ -195,12 +195,7 @@ void PFTauPrimaryVertexProducer::produce(edm::Event& iEvent,const edm::EventSetu
       }
       if (passed && cut_.get()){passed = (*cut_)(*tau);}
       if (passed){
-      	// Use two signal track collections: One with Refs for taus made from PFCandidates,
-      	// and one with pointers for taus made from PackedCandidates
 	std::vector<reco::TrackBaseRef> SignalTracks;
-	// std::vector<reco::Track*> SignalTrackPtrs;
-	// JAN - FIXME - THIS NEEDS TO BE CHANGED WITH MICHAL'S ADAPTIONS
-
 	for(reco::PFTauCollection::size_type jPFTau = 0; jPFTau < Tau->size(); jPFTau++) {
 	  if(useSelectedTaus_ || iPFTau==jPFTau){
 	    reco::PFTauRef RefPFTau(Tau, jPFTau);

--- a/RecoTauTag/RecoTau/plugins/PFTauSecondaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauSecondaryVertexProducer.cc
@@ -36,6 +36,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
@@ -71,6 +72,21 @@ PFTauSecondaryVertexProducer::~PFTauSecondaryVertexProducer(){
 
 }
 
+namespace {
+  const reco::Track* getTrack(const reco::Candidate& cand) {
+  	const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(&cand);
+  	if (pfCand != nullptr) {
+ 	  if (pfCand->trackRef().isNonnull())
+ 	  	return &*pfCand->trackRef();
+	  else if (pfCand->gsfTrackRef().isNonnull())
+	  	return &*pfCand->gsfTrackRef();
+	}
+    const pat::PackedCandidate* pCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (pCand != nullptr && pCand->hasTrackDetails())
+    	return &pCand->pseudoTrack();
+    return nullptr;
+  }
+}
 void PFTauSecondaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent,const edm::EventSetup& iSetup) const {
   // Obtain 
   edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
@@ -94,10 +110,12 @@ void PFTauSecondaryVertexProducer::produce(edm::StreamID, edm::Event& iEvent,con
 	// Get tracks form PFTau daugthers
 	std::vector<reco::TransientTrack> transTrk;
 	TransientVertex transVtx;
-	const std::vector<edm::Ptr<reco::PFCandidate> > cands = RefPFTau->signalPFChargedHadrCands(); 
-	for (std::vector<edm::Ptr<reco::PFCandidate> >::const_iterator iter = cands.begin(); iter!=cands.end(); ++iter) {
-	  if(iter->get()->trackRef().isNonnull())transTrk.push_back(transTrackBuilder->build(iter->get()->trackRef()));
-	  else if(iter->get()->gsfTrackRef().isNonnull())transTrk.push_back(transTrackBuilder->build(iter->get()->gsfTrackRef()));
+	const std::vector<edm::Ptr<reco::Candidate> > cands = RefPFTau->signalPFChargedHadrCands(); 
+	for (const auto& cand : cands) {
+	  if (cand.isNull()) continue;
+	  const reco::Track* track = getTrack(*cand);
+	  if (track != nullptr)
+	    transTrk.push_back(transTrackBuilder->build(*track));
 	}
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// Fit the secondary vertex

--- a/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
@@ -36,6 +36,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
@@ -75,6 +76,23 @@ PFTauTransverseImpactParameters::~PFTauTransverseImpactParameters(){
 
 }
 
+namespace {
+  inline const reco::Track* getTrack(const Candidate& cand)
+  {
+    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+    if (pfCandPtr != nullptr) {
+      if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
+      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
+      else return nullptr;
+    }
+    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (packedCand != nullptr && packedCand->hasTrackDetails())
+        return &packedCand->pseudoTrack();
+
+   return nullptr;
+  }
+}
+
 void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::EventSetup& iSetup){
   // Obtain Collections
   edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
@@ -105,11 +123,7 @@ void PFTauTransverseImpactParameters::produce(edm::Event& iEvent,const edm::Even
       double ip3d(-999), ip3d_err(-999);
       reco::Vertex::Point ip3d_poca(0,0,0);
       if(RefPFTau->leadPFChargedHadrCand().isNonnull()){
-	const reco::Track* track = nullptr;
-	if(RefPFTau->leadPFChargedHadrCand()->trackRef().isNonnull())
-	  track = RefPFTau->leadPFChargedHadrCand()->trackRef().get();
-	else if(RefPFTau->leadPFChargedHadrCand()->gsfTrackRef().isNonnull())
-	  track = RefPFTau->leadPFChargedHadrCand()->gsfTrackRef().get();
+	const reco::Track* track = getTrack(*RefPFTau->leadPFChargedHadrCand());
 	if(track != nullptr){
 	  if(useFullCalculation_){
 	    reco::TransientTrack transTrk=transTrackBuilder->build(*track);

--- a/RecoTauTag/RecoTau/plugins/RecoPatTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoPatTauJetRegionProducer.cc
@@ -1,0 +1,210 @@
+/*
+ * RecoTauPatJetRegionProducer
+ *
+ * Given a set of PFJets, make new jets with the same p4 but collect all the
+ * PFCandidates from a cone of a given size into the constituents.
+ *
+ * Author: Evan K. Friis, UC Davis
+ *
+ */
+
+#include <boost/bind.hpp>
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+
+#include "RecoTauTag/RecoTau/interface/ConeTools.h"
+#include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <string>
+#include <iostream>
+
+class RecoTauPatJetRegionProducer : public edm::stream::EDProducer<> 
+{
+ public:
+  typedef edm::Association<pat::JetCollection> PatJetMatchMap;
+  typedef edm::AssociationMap<edm::OneToMany<std::vector<pat::Jet>, std::vector<pat::PackedCandidate>, unsigned int> > JetToPackedCandidateAssociation;
+  explicit RecoTauPatJetRegionProducer(const edm::ParameterSet& pset);
+  ~RecoTauPatJetRegionProducer() override {}
+
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
+
+ private:
+  std::string moduleLabel_;
+
+  edm::InputTag inputJets_;
+  edm::InputTag pfCandSrc_;
+  edm::InputTag pfCandAssocMapSrc_;
+
+  edm::EDGetTokenT<pat::PackedCandidateCollection> pf_token;
+  edm::EDGetTokenT<reco::CandidateView> Jets_token;
+  edm::EDGetTokenT<JetToPackedCandidateAssociation> pfCandAssocMap_token;
+
+  double minJetPt_;
+  double maxJetAbsEta_;
+  double deltaR2_;
+
+  int verbosity_;
+};
+
+RecoTauPatJetRegionProducer::RecoTauPatJetRegionProducer(const edm::ParameterSet& cfg) 
+  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
+{
+  inputJets_ = cfg.getParameter<edm::InputTag>("src");
+  pfCandSrc_ = cfg.getParameter<edm::InputTag>("pfCandSrc");
+  pfCandAssocMapSrc_ = cfg.getParameter<edm::InputTag>("pfCandAssocMapSrc");
+
+  pf_token = consumes<pat::PackedCandidateCollection>(pfCandSrc_); 
+  Jets_token = consumes<reco::CandidateView>(inputJets_);
+  pfCandAssocMap_token =  consumes<JetToPackedCandidateAssociation>(pfCandAssocMapSrc_);
+  
+  double deltaR = cfg.getParameter<double>("deltaR"); 
+  deltaR2_ = deltaR*deltaR;
+  minJetPt_ = ( cfg.exists("minJetPt") ) ? cfg.getParameter<double>("minJetPt") : -1.0;
+  maxJetAbsEta_ = ( cfg.exists("maxJetAbsEta") ) ? cfg.getParameter<double>("maxJetAbsEta") : 99.0;
+  
+  verbosity_ = ( cfg.exists("verbosity") ) ?
+    cfg.getParameter<int>("verbosity") : 0;
+  
+  produces<pat::JetCollection>("jets");
+  produces<PatJetMatchMap>();
+}
+
+void RecoTauPatJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
+{
+  if ( verbosity_ ) {
+    std::cout << "<RecoTauPatJetRegionProducer::produce (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
+    std::cout << " inputJets = " << inputJets_ << std::endl;
+    std::cout << " pfCandSrc = " << pfCandSrc_ << std::endl;
+    std::cout << " pfCandAssocMapSrc_ = " << pfCandAssocMapSrc_ << std::endl;
+  }
+
+  edm::Handle<pat::PackedCandidateCollection> pfCandsHandle;
+  evt.getByToken(pf_token, pfCandsHandle);
+
+  // Build Ptrs for all the PFCandidates
+  typedef edm::Ptr<pat::PackedCandidate> PackedCandPtr;
+  std::vector<PackedCandPtr> pfCands;
+  pfCands.reserve(pfCandsHandle->size());
+  for ( size_t icand = 0; icand < pfCandsHandle->size(); ++icand ) {
+    pfCands.push_back(PackedCandPtr(pfCandsHandle, icand));
+  }
+
+  // Get the jets
+  edm::Handle<reco::CandidateView> jetView;
+  evt.getByToken(Jets_token, jetView);
+  // Convert to a vector of PFJetRefs
+  pat::JetRefVector jets = reco::tau::castView<pat::JetRefVector>(jetView);
+  size_t nJets = jets.size();
+
+  // Get the association map matching jets to PFCandidates
+  // (needed for recinstruction of boosted taus)
+  edm::Handle<JetToPackedCandidateAssociation> jetToPFCandMap;
+  std::vector<std::unordered_set<unsigned> > fastJetToPFCandMap;
+  if ( pfCandAssocMapSrc_.label() != "" ) {
+    evt.getByToken(pfCandAssocMap_token, jetToPFCandMap);
+    fastJetToPFCandMap.resize(nJets);
+    for ( size_t ijet = 0; ijet < nJets; ++ijet ) {
+      // Get a ref to jet
+      const pat::JetRef& jetRef = jets[ijet];
+      const auto& pfCandsMappedToJet = (*jetToPFCandMap)[jetRef];
+      for ( const auto& pfCandMappedToJet : pfCandsMappedToJet ) {
+	fastJetToPFCandMap[ijet].emplace(pfCandMappedToJet.key());
+      }
+    }
+  }
+
+  // Get the original product, so we can match against it - otherwise the
+  // indices don't match up.
+  edm::ProductID originalId = jets.id();
+  edm::Handle<pat::JetCollection> originalJets;
+  size_t nOriginalJets = 0;
+  // We have to make sure that we have some selected jets, otherwise we don't
+  // actually have a valid product ID to the original jets.
+  if ( nJets ) {
+    try {
+      evt.get(originalId, originalJets);
+    } catch(const cms::Exception &e) {
+      edm::LogError("MissingOriginalCollection")
+        << "Can't get the original jets that made: " << inputJets_
+        << " that have product ID: " << originalId
+        << " from the event!!";
+      throw e;
+    }
+    nOriginalJets = originalJets->size();
+  }
+
+  auto newJets = std::make_unique<pat::JetCollection>();
+
+  // Keep track of the indices of the current jet and the old (original) jet
+  // -1 indicates no match.
+  std::vector<int> matchInfo(nOriginalJets, -1);
+  newJets->reserve(nJets);
+  size_t nNewJets = 0;
+  for ( size_t ijet = 0; ijet < nJets; ++ijet ) {
+    // Get a ref to jet
+    const pat::JetRef& jetRef = jets[ijet];
+    if(jetRef->pt() - minJetPt_ < 1e-5) continue;
+    if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
+    // Make an initial copy.
+    newJets->emplace_back(*jetRef);
+    pat::Jet& newJet = newJets->back();
+    // Clear out all the constituents
+    newJet.clearDaughters();
+    // Loop over all the PFCands
+    for ( const auto& pfCand : pfCands ) {
+      bool isMappedToJet = false;
+      if ( jetToPFCandMap.isValid() ) {
+	auto temp = jetToPFCandMap->find(jetRef);
+	if( temp == jetToPFCandMap->end() ) {
+	  edm::LogWarning("WeirdCandidateMap") << "Candidate map for jet " << jetRef.key() << " is empty!";
+	  continue;
+	}
+	isMappedToJet = fastJetToPFCandMap[ijet].count(pfCand.key());
+      } else {
+	isMappedToJet = true;
+      }
+      if ( reco::deltaR2(*jetRef, *pfCand) < deltaR2_ && isMappedToJet ) newJet.addDaughter(pfCand);
+    }
+    if ( verbosity_ ) {
+      std::cout << "jet #" << ijet << ": Pt = " << jetRef->pt() << ", eta = " << jetRef->eta() << ", phi = " << jetRef->eta() << ","
+		<< " mass = " << jetRef->mass() << ", area = " << jetRef->jetArea() << std::endl;
+      auto jetConstituents = newJet.daughterPtrVector();
+      int idx = 0;
+      for ( const auto& jetConstituent : jetConstituents) {
+	std::cout << " constituent #" << idx << ": Pt = " << jetConstituent->pt() << ", eta = " << jetConstituent->eta() << ", phi = " << jetConstituent->phi() << std::endl;
+        ++idx;
+      }
+    }
+    // Match the index of the jet we just made to the index into the original
+    // collection.
+    //matchInfo[jetRef.key()] = ijet;
+    matchInfo[jetRef.key()] = nNewJets;
+    nNewJets++;
+  }
+
+  // Put our new jets into the event
+  edm::OrphanHandle<pat::JetCollection> newJetsInEvent = evt.put(std::move(newJets), "jets");
+
+  // Create a matching between original jets -> extra collection
+  auto matching = std::make_unique<PatJetMatchMap>(newJetsInEvent);
+  if ( nJets ) {
+    PatJetMatchMap::Filler filler(*matching);
+    filler.insert(originalJets, matchInfo.begin(), matchInfo.end());
+    filler.fill();
+  }
+  evt.put(std::move(matching));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(RecoTauPatJetRegionProducer);
+

--- a/RecoTauTag/RecoTau/plugins/RecoPatTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoPatTauJetRegionProducer.cc
@@ -200,11 +200,7 @@ void RecoTauPatJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup
   // Create a matching between original jets -> extra collection
   auto matching = (nJets !=0) ? std::make_unique<PatJetMatchMap>(edm::makeRefToBaseProdFrom(edm::RefToBase<reco::Jet>(jets[0]), evt), newJetsInEvent) : std::make_unique<PatJetMatchMap>();
   for (size_t ijet = 0; ijet < nJets; ++ijet) {
-    // JAN - FIXME - this doesn't look very elegant...
     matching->insert(edm::RefToBase<reco::Jet>(jets[ijet]), edm::RefToBase<reco::Jet>(edm::Ref<pat::JetCollection>(newJetsInEvent, matchInfo[ijet])));
-    // PFJetMatchMap::Filler filler(*matching);
-    // filler.insert(originalJets, matchInfo.begin(), matchInfo.end());
-    // filler.fill();
   }
   evt.put(std::move(matching));
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -207,8 +207,8 @@ RecoTauBuilderCombinatoricPlugin::operator()(
   }
 
   CandPtrs pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
-  CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidates(*jet, 130));
-  CandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidates(*jet, 22));
+  CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 130));
+  CandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 22));
 
   /// Apply quality cuts to the regional junk around the jet.  Note that the
   /// particle contents of the junk is exclusive to the jet content.

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -32,10 +32,10 @@ class RecoTauBuilderCombinatoricPlugin : public RecoTauBuilderPlugin
   ~RecoTauBuilderCombinatoricPlugin() override {}
 
   return_type operator()(
-      const reco::PFJetRef&, 
+      const reco::JetBaseRef&, 
       const std::vector<reco::PFRecoTauChargedHadron>&, 
       const std::vector<RecoTauPiZero>&, 
-      const std::vector<PFCandidatePtr>&) const override;
+      const std::vector<CandidatePtr>&) const override;
 
  private:
   RecoTauQualityCuts qcuts_;
@@ -113,7 +113,7 @@ namespace xclean
   template<>
   inline void CrossCleanPtrs<PiZeroList::const_iterator>::initialize(const PiZeroList::const_iterator& piZerosBegin, const PiZeroList::const_iterator& piZerosEnd) 
   {
-    BOOST_FOREACH( const PFCandidatePtr &ptr, flattenPiZeros(piZerosBegin, piZerosEnd) ) {
+    BOOST_FOREACH( const CandidatePtr &ptr, flattenPiZeros(piZerosBegin, piZerosEnd) ) {
       toRemove_.insert(CandidatePtr(ptr));
     }
   }
@@ -167,10 +167,10 @@ namespace
 
 RecoTauBuilderCombinatoricPlugin::return_type
 RecoTauBuilderCombinatoricPlugin::operator()(
-    const reco::PFJetRef& jet, 
+    const reco::JetBaseRef& jet, 
     const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons, 
     const std::vector<RecoTauPiZero>& piZeros, 
-    const std::vector<PFCandidatePtr>& regionalExtras) const 
+    const std::vector<CandidatePtr>& regionalExtras) const 
 {
   if ( verbosity_ ) {
     std::cout << "<RecoTauBuilderCombinatoricPlugin::operator()>:" << std::endl;
@@ -185,7 +185,7 @@ RecoTauBuilderCombinatoricPlugin::operator()(
   // the base class.
   qcuts_.setPV( primaryVertex(jet) );
   
-  typedef std::vector<PFCandidatePtr> PFCandPtrs;
+  typedef std::vector<CandidatePtr> CandPtrs;
   
   if ( verbosity_ ) {
     std::cout << "#chargedHadrons = " << chargedHadrons.size() << std::endl;
@@ -206,13 +206,13 @@ RecoTauBuilderCombinatoricPlugin::operator()(
     }
   }
 
-  PFCandPtrs pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
-  PFCandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidates(*jet, reco::PFCandidate::h0));
-  PFCandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidates(*jet, reco::PFCandidate::gamma));
+  CandPtrs pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
+  CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidates(*jet, 130));
+  CandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidates(*jet, 22));
 
   /// Apply quality cuts to the regional junk around the jet.  Note that the
   /// particle contents of the junk is exclusive to the jet content.
-  PFCandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
+  CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
     
   // Loop over the decay modes we want to build
   for ( std::vector<decayModeInfo>::const_iterator decayMode = decayModesToBuild_.begin();
@@ -239,7 +239,7 @@ RecoTauBuilderCombinatoricPlugin::operator()(
     // Build our track combo generator
     ChargedHadronCombo trackCombos(chargedHadron_begin, chargedHadron_end, tracksToBuild);
 
-    PFCandPtrs::iterator pfch_end = pfchs.end();
+    CandPtrs::iterator pfch_end = pfchs.end();
     pfch_end = takeNElements(pfchs.begin(), pfch_end, decayMode->maxPFCHs_);
 
     //-------------------------------------------------------
@@ -349,7 +349,7 @@ RecoTauBuilderCombinatoricPlugin::operator()(
         // Now build isolation collections
         // Load our isolation tools
         using namespace reco::tau::cone;
-        PFCandPtrDRFilter isolationConeFilter(tau.p4(), -0.1, isolationConeSize_);
+        CandPtrDRFilter isolationConeFilter(tau.p4(), -0.1, isolationConeSize_);
 
         // Cross cleaning predicate: Remove any PFCandidatePtrs that are contained within existing ChargedHadrons or PiZeros.  
 	// The predicate will return false for any object that overlaps with chargedHadrons or cleanPiZeros.
@@ -357,29 +357,29 @@ RecoTauBuilderCombinatoricPlugin::operator()(
 	typedef xclean::CrossCleanPtrs<ChargedHadronCombo::combo_iterator> pfChargedHadronXCleanerType;
 	pfChargedHadronXCleanerType pfChargedHadronXCleaner_comboChargedHadrons(trackCombo->combo_begin(), trackCombo->combo_end());
 	// And this cleaning filter predicate with our Iso cone filter
-        xclean::PredicateAND<PFCandPtrDRFilter, pfChargedHadronXCleanerType> pfCandFilter_comboChargedHadrons(isolationConeFilter, pfChargedHadronXCleaner_comboChargedHadrons);
+        xclean::PredicateAND<CandPtrDRFilter, pfChargedHadronXCleanerType> pfCandFilter_comboChargedHadrons(isolationConeFilter, pfChargedHadronXCleaner_comboChargedHadrons);
 	//  2.) to select neutral PFCandidates within jet
 	xclean::CrossCleanPtrs<ChargedHadronList::const_iterator> pfChargedHadronXCleaner_allChargedHadrons(chargedHadrons.begin(), chargedHadrons.end());
 	xclean::CrossCleanPtrs<PiZeroList::const_iterator> piZeroXCleaner(piZeros.begin(), piZeros.end());
 	typedef xclean::PredicateAND<xclean::CrossCleanPtrs<ChargedHadronList::const_iterator>, xclean::CrossCleanPtrs<PiZeroList::const_iterator> > pfCandXCleanerType;
         pfCandXCleanerType pfCandXCleaner_allChargedHadrons(pfChargedHadronXCleaner_allChargedHadrons, piZeroXCleaner);
         // And this cleaning filter predicate with our Iso cone filter
-        xclean::PredicateAND<PFCandPtrDRFilter, pfCandXCleanerType> pfCandFilter_allChargedHadrons(isolationConeFilter, pfCandXCleaner_allChargedHadrons);
+        xclean::PredicateAND<CandPtrDRFilter, pfCandXCleanerType> pfCandFilter_allChargedHadrons(isolationConeFilter, pfCandXCleaner_allChargedHadrons);
 
 	ChargedHadronDRFilter isolationConeFilterChargedHadron(tau.p4(), -0.1, isolationConeSize_);
         PiZeroDRFilter isolationConeFilterPiZero(tau.p4(), -0.1, isolationConeSize_);
 
         // Additionally make predicates to select the different PF object types
         // of the regional junk objects to add
-        typedef xclean::PredicateAND<xclean::FilterPFCandByParticleId,
-	    PFCandPtrDRFilter> RegionalJunkConeAndIdFilter;
+        typedef xclean::PredicateAND<xclean::FilterCandByAbsPdgId,
+	    CandPtrDRFilter> RegionalJunkConeAndIdFilter;
 
-        xclean::FilterPFCandByParticleId
-          pfchCandSelector(reco::PFCandidate::h);
-        xclean::FilterPFCandByParticleId
-          pfgammaCandSelector(reco::PFCandidate::gamma);
-        xclean::FilterPFCandByParticleId
-          pfnhCandSelector(reco::PFCandidate::h0);
+        xclean::FilterCandByAbsPdgId
+          pfchCandSelector(211);
+        xclean::FilterCandByAbsPdgId
+          pfgammaCandSelector(22);
+        xclean::FilterCandByAbsPdgId
+          pfnhCandSelector(130);
 
         RegionalJunkConeAndIdFilter pfChargedJunk(
             pfchCandSelector, // select charged stuff from junk

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -211,7 +211,7 @@ RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
   // Get the PF Charged hadrons + quality cuts
   CandPtrs pfchs;
   if (!usePFLeptonsAsChargedHadrons_) {
-    pfchs = qcuts_.filterCandRefs(pfCandidates(*jet, 211));
+    pfchs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 211));
   } else {
     // Check if we want to include electrons in muons in "charged hadron"
     // collection.  This is the preferred behavior, as the PF lepton selections
@@ -224,10 +224,10 @@ RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
 
   // Get the PF gammas
   CandPtrs pfGammas = qcuts_.filterCandRefs(
-      pfCandidates(*jet, 22));
+      pfCandidatesByPdgId(*jet, 22));
   // Neutral hadrons
   CandPtrs pfnhs = qcuts_.filterCandRefs(
-      pfCandidates(*jet, 130));
+      pfCandidatesByPdgId(*jet, 130));
 
   // All the extra junk
   CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -36,7 +36,7 @@ class RecoTauBuilderConePlugin : public RecoTauBuilderPlugin {
   explicit RecoTauBuilderConePlugin(const edm::ParameterSet& pset,edm::ConsumesCollector &&iC);
     ~RecoTauBuilderConePlugin() override {}
     // Build a tau from a jet
-    return_type operator()(const reco::PFJetRef& jet,
+    return_type operator()(const reco::JetBaseRef& jet,
 	const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons,
         const std::vector<RecoTauPiZero>& piZeros,
         const std::vector<CandidatePtr>& regionalExtras) const override;
@@ -48,7 +48,7 @@ class RecoTauBuilderConePlugin : public RecoTauBuilderPlugin {
     double leadObjecPtThreshold_;
 
     /* String function to extract values from PFJets */
-    typedef StringObjectFunction<reco::PFJet> JetFunc;
+    typedef StringObjectFunction<reco::Jet> JetFunc;
 
     // Cone defintions
     JetFunc matchingCone_;
@@ -185,7 +185,7 @@ void RecoTauBuilderConePlugin::setTauQuantities(reco::PFTau& aTau,
 }
 
 RecoTauBuilderConePlugin::return_type RecoTauBuilderConePlugin::operator()(
-    const reco::PFJetRef& jet,
+    const reco::JetBaseRef& jet,
     const std::vector<reco::PFRecoTauChargedHadron>& chargedHadrons, 
     const std::vector<RecoTauPiZero>& piZeros,
     const std::vector<CandidatePtr>& regionalExtras) const {

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -135,8 +135,8 @@ void RecoTauBuilderConePlugin::setTauQuantities(reco::PFTau& aTau,
   // Set charge
   int charge = 0;
   int leadCharge = aTau.leadPFChargedHadrCand().isNonnull() ? aTau.leadPFChargedHadrCand()->charge() : 0;
-  const std::vector<reco::PFCandidatePtr>& pfChs = aTau.signalPFChargedHadrCands();
-  for(const reco::PFCandidatePtr& pfCh : pfChs){
+  const std::vector<reco::CandidatePtr>& pfChs = aTau.signalPFChargedHadrCands();
+  for(const reco::CandidatePtr& pfCh : pfChs){
     charge += pfCh->charge();
   }
   charge = charge==0 ? leadCharge : charge;

--- a/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauCleaner.cc
@@ -179,11 +179,11 @@ namespace
 	const reco::RecoTauPiZero& piZero = signalPiZeroCandidates.at(iPiZero);
 	std::cout << " piZero #" << iPiZero << ": Pt = " << piZero.pt() << ", eta = " << piZero.eta() << ", phi = " << piZero.phi() << ", mass = " << piZero.mass() << std::endl;
       }
-      const std::vector<reco::PFCandidatePtr>& isolationPFCands = tauRef_->isolationPFCands();
+      const auto& isolationPFCands = tauRef_->isolationPFCands();
       size_t numPFCands = isolationPFCands.size();
       std::cout << "isolationPFCands = " << numPFCands << std::endl;
       for ( size_t iPFCand = 0; iPFCand < numPFCands; ++iPFCand ) {
-	const reco::PFCandidatePtr& pfCand = isolationPFCands.at(iPFCand);
+	const auto& pfCand = isolationPFCands.at(iPFCand);
 	std::cout << " pfCand #" << iPFCand << " (" << pfCand.id() << ":" << pfCand.key() << "):" 
 		  << " Pt = " << pfCand->pt() << ", eta = " << pfCand->eta() << ", phi = " << pfCand->phi() << std::endl;
       }

--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminationByFlight.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminationByFlight.cc
@@ -54,16 +54,19 @@ double PFRecoTauDiscriminationByFlight::discriminate(
     const reco::PFTauRef& tau) const {
 
   KalmanVertexFitter kvf(true);
-  const std::vector<reco::PFCandidatePtr>& signalTracks =
+  const std::vector<reco::CandidatePtr>& signalTracks =
     tau->signalPFChargedHadrCands();
   std::vector<reco::TransientTrack> signalTransTracks;
   std::vector<reco::TrackRef> signalTrackPtrs;
-  BOOST_FOREACH(const reco::PFCandidatePtr& pftrack, signalTracks) {
-    if (pftrack->trackRef().isNonnull()) {
-      signalTransTracks.push_back(
-          builder_->build(pftrack->trackRef()));
-      signalTrackPtrs.push_back(pftrack->trackRef());
-    }
+  BOOST_FOREACH(const reco::CandidatePtr& signalTrack, signalTracks) {
+    const reco::PFCandidate* pftrack = dynamic_cast<const reco::PFCandidate*>(signalTrack.get());
+    if (pftrack != nullptr) {
+      if (pftrack->trackRef().isNonnull()) {
+        signalTransTracks.push_back(
+            builder_->build(pftrack->trackRef()));
+        signalTrackPtrs.push_back(pftrack->trackRef());
+      }
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
 
   reco::Vertex pv = (*vertices_)[0];

--- a/RecoTauTag/RecoTau/plugins/RecoTauElectronRejectionPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauElectronRejectionPlugin.cc
@@ -83,9 +83,9 @@ void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
   typedef std::pair<reco::PFBlockRef, unsigned> ElementInBlock;
   typedef std::vector< ElementInBlock > ElementsInBlocks;
 
-  PFCandidatePtr myleadPFChargedCand = tau.leadPFChargedHadrCand();
+  CandidatePtr myleadChargedCand = tau.leadPFChargedHadrCand();
   // Build list of PFCands in tau
-  std::vector<PFCandidatePtr> myPFCands;
+  std::vector<CandidatePtr> myPFCands;
   myPFCands.reserve(tau.isolationPFCands().size()+tau.signalPFCands().size());
 
   std::copy(tau.isolationPFCands().begin(), tau.isolationPFCands().end(),
@@ -94,7 +94,10 @@ void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
       std::back_inserter(myPFCands));
 
   //Use the electron rejection only in case there is a charged leading pion
-  if(myleadPFChargedCand.isNonnull()){
+  if(myleadChargedCand.isNonnull()){
+    const reco::PFCandidate* myleadPFChargedCand = dynamic_cast<const reco::PFCandidate*>(myleadChargedCand.get());
+    if (myleadPFChargedCand == nullptr)
+    	throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
     myElectronPreIDOutput = myleadPFChargedCand->mva_e_pi();
 
     math::XYZPointF myElecTrkEcalPos = myleadPFChargedCand->positionAtECALEntrance();
@@ -104,33 +107,37 @@ void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
       //FROM AOD
       if(DataType_ == "AOD"){
         // Corrected Cluster energies
-        for(int i=0;i<(int)myPFCands.size();i++){
-          myHCALenergy += myPFCands[i]->hcalEnergy();
-          myECALenergy += myPFCands[i]->ecalEnergy();
+        for(const auto& cand : myPFCands){
+          const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand.get());
+          if (pfcand == nullptr) {
+            throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+          }
+          myHCALenergy += pfcand->hcalEnergy();
+          myECALenergy += pfcand->ecalEnergy();
 
           math::XYZPointF candPos;
-          if (myPFCands[i]->particleId()==1 || myPFCands[i]->particleId()==2)//if charged hadron or electron
-            candPos = myPFCands[i]->positionAtECALEntrance();
+          if (pfcand->particleId()==1 || pfcand->particleId()==2)//if charged hadron or electron
+            candPos = pfcand->positionAtECALEntrance();
           else
-            candPos = math::XYZPointF(myPFCands[i]->px(),myPFCands[i]->py(),myPFCands[i]->pz());
+            candPos = math::XYZPointF(pfcand->px(),pfcand->py(),pfcand->pz());
 
           double deltaR   = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos,candPos);
           double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos,candPos);
           double deltaEta = std::abs(myElecTrkEcalPos.eta()-candPos.eta());
           double deltaPhiOverQ = deltaPhi/(double)myElecTrk->charge();
 
-          if (myPFCands[i]->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
+          if (pfcand->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
               deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_  && deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
-            myStripClusterE += myPFCands[i]->ecalEnergy();
+            myStripClusterE += pfcand->ecalEnergy();
           }
           if (deltaR<0.184) {
-            myHCALenergy3x3 += myPFCands[i]->hcalEnergy();
+            myHCALenergy3x3 += pfcand->hcalEnergy();
           }
-          if (myPFCands[i]->hcalEnergy()>myMaximumHCALPFClusterE) {
-            myMaximumHCALPFClusterE = myPFCands[i]->hcalEnergy();
+          if (pfcand->hcalEnergy()>myMaximumHCALPFClusterE) {
+            myMaximumHCALPFClusterE = pfcand->hcalEnergy();
           }
-          if ((myPFCands[i]->hcalEnergy()*fabs(sin(candPos.Theta())))>myMaximumHCALPFClusterEt) {
-            myMaximumHCALPFClusterEt = (myPFCands[i]->hcalEnergy()*fabs(sin(candPos.Theta())));
+          if ((pfcand->hcalEnergy()*fabs(sin(candPos.Theta())))>myMaximumHCALPFClusterEt) {
+            myMaximumHCALPFClusterEt = (pfcand->hcalEnergy()*fabs(sin(candPos.Theta())));
           }
         }
 
@@ -138,8 +145,12 @@ void RecoTauElectronRejectionPlugin::operator()(PFTau& tau) const {
         // Against double counting of clusters
         std::vector<math::XYZPoint> hcalPosV; hcalPosV.clear();
         std::vector<math::XYZPoint> ecalPosV; ecalPosV.clear();
-        for(int i=0;i<(int)myPFCands.size();i++){
-          const ElementsInBlocks& elts = myPFCands[i]->elementsInBlocks();
+        for(const auto& cand : myPFCands){
+          const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(cand.get());
+          if (pfcand == nullptr) {
+            throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+          }
+          const ElementsInBlocks& elts = pfcand->elementsInBlocks();
           for(ElementsInBlocks::const_iterator it=elts.begin(); it!=elts.end(); ++it) {
             const reco::PFBlock& block = *(it->first);
             unsigned indexOfElementInBlock = it->second;

--- a/RecoTauTag/RecoTau/plugins/RecoTauEnergyRecoveryPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauEnergyRecoveryPlugin2.cc
@@ -1,4 +1,4 @@
-/*
+  /*
  * =============================================================================
  *       Filename:  RecoTauEnergyRecoveryPlugin2.cc
  *
@@ -63,8 +63,8 @@ void RecoTauEnergyRecoveryPlugin2::operator()(PFTau& tau) const
 {
   reco::Candidate::LorentzVector tauAltP4(0.,0.,0.,0.);
   
-  std::vector<reco::PFCandidatePtr> pfJetConstituents = tau.jetRef()->getPFConstituents();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfJetConstituent = pfJetConstituents.begin();
+  std::vector<reco::CandidatePtr> pfJetConstituents = tau.jetRef()->getJetConstituents();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfJetConstituent = pfJetConstituents.begin();
 	pfJetConstituent != pfJetConstituents.end(); ++pfJetConstituent ) {
     double dR = deltaR((*pfJetConstituent)->p4(), tau.p4());
     if ( dR < dRcone_ ) tauAltP4 += (*pfJetConstituent)->p4();

--- a/RecoTauTag/RecoTau/plugins/RecoTauImpactParameterSignificancePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauImpactParameterSignificancePlugin.cc
@@ -14,6 +14,7 @@
 
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
@@ -52,11 +53,31 @@ void RecoTauImpactParameterSignificancePlugin::beginEvent() {
   builder_= myTransientTrackBuilder.product();
 }
 
+namespace 
+{
+  inline const reco::Track* getTrack(const Candidate& cand)
+  {
+    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+    if (pfCandPtr) {
+      if (pfCandPtr->trackRef().isNonnull())
+        return pfCandPtr->trackRef().get();
+      else
+        return nullptr;
+    }
+    
+    const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&cand);
+    if (packedCand && packedCand->hasTrackDetails())
+      return &packedCand->pseudoTrack();
+
+    return nullptr;
+  }
+}
+
 void RecoTauImpactParameterSignificancePlugin::operator()(PFTau& tau) const {
   // Get the transient lead track
   if (tau.leadPFChargedHadrCand().isNonnull()) {
-    TrackRef leadTrack = tau.leadPFChargedHadrCand()->trackRef();
-    if (leadTrack.isNonnull()) {
+    const reco::Track* leadTrack = getTrack(*tau.leadPFChargedHadrCand());
+    if (leadTrack != nullptr) {
       const TransientTrack track = builder_->build(leadTrack);
       GlobalVector direction(tau.jetRef()->px(), tau.jetRef()->py(),
                              tau.jetRef()->pz());

--- a/RecoTauTag/RecoTau/plugins/RecoTauIsolationDiscriminantPlugins.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauIsolationDiscriminantPlugins.cc
@@ -10,7 +10,7 @@ class RecoTauDiscriminationBinnedIsolationImpl
   public:
     RecoTauDiscriminationBinnedIsolationImpl(const edm::ParameterSet& pset)
       :RecoTauDiscriminationBinnedIsolation(pset),extractor_(pset) {}
-  std::vector<reco::PFCandidatePtr> extractIsoObjects(
+  std::vector<reco::CandidatePtr> extractIsoObjects(
         const reco::PFTauRef& tau) const override {
       return extractor_(tau);
     }
@@ -27,7 +27,7 @@ namespace {
 class TrackExtractor {
   public:
     TrackExtractor(const edm::ParameterSet& pset){};
-    std::vector<reco::PFCandidatePtr> operator()(const reco::PFTauRef& tau) const {
+    std::vector<reco::CandidatePtr> operator()(const reco::PFTauRef& tau) const {
       return tau->isolationPFChargedHadrCands();
     }
 };
@@ -35,7 +35,7 @@ class TrackExtractor {
 class ECALExtractor {
   public:
     ECALExtractor(const edm::ParameterSet& pset){};
-    std::vector<reco::PFCandidatePtr> operator()(const reco::PFTauRef& tau) const {
+    std::vector<reco::CandidatePtr> operator()(const reco::PFTauRef& tau) const {
       return tau->isolationPFGammaCands();
     }
 };
@@ -44,12 +44,12 @@ class MaskedECALExtractor {
   public:
     MaskedECALExtractor(const edm::ParameterSet& pset)
       :mask_(pset.getParameter<edm::ParameterSet>("mask")){};
-    std::vector<reco::PFCandidatePtr> operator()(const reco::PFTauRef& tau) const {
-      std::vector<reco::PFCandidatePtr> output;
+    std::vector<reco::CandidatePtr> operator()(const reco::PFTauRef& tau) const {
+      std::vector<reco::CandidatePtr> output;
       reco::tau::RecoTauIsolationMasking::IsoMaskResult
         result = mask_.mask(*tau);
       output.reserve(result.gammas.size());
-      BOOST_FOREACH(const reco::PFCandidatePtr gamma, result.gammas) {
+      BOOST_FOREACH(const reco::CandidatePtr gamma, result.gammas) {
         output.push_back(gamma);
       }
       return output;
@@ -61,7 +61,7 @@ class MaskedECALExtractor {
 class HCALExtractor {
   public:
     HCALExtractor(const edm::ParameterSet& pset){};
-    std::vector<reco::PFCandidatePtr> operator()(const reco::PFTauRef& tau) const {
+    std::vector<reco::CandidatePtr> operator()(const reco::PFTauRef& tau) const {
       return tau->isolationPFNeutrHadrCands();
     }
 };
@@ -70,12 +70,12 @@ class MaskedHCALExtractor {
   public:
     MaskedHCALExtractor(const edm::ParameterSet& pset)
       :mask_(pset.getParameter<edm::ParameterSet>("mask")){};
-    std::vector<reco::PFCandidatePtr> operator()(const reco::PFTauRef& tau) const {
-      std::vector<reco::PFCandidatePtr> output;
+    std::vector<reco::CandidatePtr> operator()(const reco::PFTauRef& tau) const {
+      std::vector<reco::CandidatePtr> output;
       reco::tau::RecoTauIsolationMasking::IsoMaskResult
         result = mask_.mask(*tau);
       output.reserve(result.h0s.size());
-      BOOST_FOREACH(const reco::PFCandidatePtr h0, result.h0s) {
+      BOOST_FOREACH(const reco::CandidatePtr h0, result.h0s) {
         output.push_back(h0);
       }
       return output;

--- a/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -194,11 +195,11 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
     nNewJets++;
   }
 
-  // Put our new jets into the event
+    // Put our new jets into the event
   edm::OrphanHandle<reco::PFJetCollection> newJetsInEvent = evt.put(std::move(newJets), "jets");
-
+  
   // Create a matching between original jets -> extra collection
-  auto matching = std::make_unique<PFJetMatchMap>();
+  auto matching = (nJets !=0) ? std::make_unique<PFJetMatchMap>(edm::makeRefToBaseProdFrom(edm::RefToBase<reco::Jet>(jets[0]), evt), newJetsInEvent) : std::make_unique<PFJetMatchMap>();
   for (size_t ijet = 0; ijet < nJets; ++ijet) {
     // JAN - FIXME - this doesn't look very elegant...
     matching->insert(edm::RefToBase<reco::Jet>(jets[ijet]), edm::RefToBase<reco::Jet>(edm::Ref<reco::PFJetCollection>(newJetsInEvent, matchInfo[ijet])));

--- a/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
@@ -201,11 +201,7 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
   // Create a matching between original jets -> extra collection
   auto matching = (nJets !=0) ? std::make_unique<PFJetMatchMap>(edm::makeRefToBaseProdFrom(edm::RefToBase<reco::Jet>(jets[0]), evt), newJetsInEvent) : std::make_unique<PFJetMatchMap>();
   for (size_t ijet = 0; ijet < nJets; ++ijet) {
-    // JAN - FIXME - this doesn't look very elegant...
     matching->insert(edm::RefToBase<reco::Jet>(jets[ijet]), edm::RefToBase<reco::Jet>(edm::Ref<reco::PFJetCollection>(newJetsInEvent, matchInfo[ijet])));
-    // PFJetMatchMap::Filler filler(*matching);
-    // filler.insert(originalJets, matchInfo.begin(), matchInfo.end());
-    // filler.fill();
   }
   evt.put(std::move(matching));
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
@@ -132,10 +132,10 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
         newSignalPFGammas.push_back(ptr);
     }
 
-    tau.setsignalPFCands(convertPtrVector(newSignalPFCands));
-    tau.setsignalPFCands(convertPtrVector(newSignalPFGammas));
-    tau.setisolationPFGammaCands(convertPtrVector(newIsolationPFGammas));
-    tau.setisolationPFCands(convertPtrVector(newIsolationPFCands));
+    tau.setsignalPFCands(convertPtrVectorToPF(newSignalPFCands));
+    tau.setsignalPFCands(convertPtrVectorToPF(newSignalPFGammas));
+    tau.setisolationPFGammaCands(convertPtrVectorToPF(newIsolationPFGammas));
+    tau.setisolationPFCands(convertPtrVectorToPF(newIsolationPFCands));
   }
 }
 }}  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
@@ -54,6 +54,7 @@ bool RecoTauPhotonFilter::filter( const RecoTauPiZero* piZero,
   return piZero->pt()/total.pt() < minPtFractionSinglePhotons_;
 }
 
+
 void RecoTauPhotonFilter::operator()(PFTau& tau) const {
   std::vector<const RecoTauPiZero*> signalPiZeros;
   BOOST_FOREACH(const RecoTauPiZero& piZero, tau.signalPiZeroCandidates()) {
@@ -103,38 +104,38 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
     tau.setisolationPiZeroCandidates(newIsolation);
 
     // Now we need to deal with the gamma candidates underlying moved pizeros.
-    std::vector<PFCandidatePtr> pfcandsToMove = flattenPiZeros(toMove);
+    std::vector<CandidatePtr> pfcandsToMove = flattenPiZeros(toMove);
 
     // Copy the keys to move
     std::set<size_t> keysToMove;
-    BOOST_FOREACH(const PFCandidatePtr& ptr, pfcandsToMove) {
+    BOOST_FOREACH(const CandidatePtr& ptr, pfcandsToMove) {
       keysToMove.insert(ptr.key());
     }
 
-    std::vector<PFCandidatePtr> newSignalPFGammas;
-    std::vector<PFCandidatePtr> newSignalPFCands;
-    std::vector<PFCandidatePtr> newIsolationPFGammas = tau.isolationPFGammaCands();
-    std::vector<PFCandidatePtr> newIsolationPFCands = tau.isolationPFCands();
+    std::vector<CandidatePtr> newSignalPFGammas;
+    std::vector<CandidatePtr> newSignalPFCands;
+    std::vector<CandidatePtr> newIsolationPFGammas = convertPtrVector(tau.isolationPFGammaCands());
+    std::vector<CandidatePtr> newIsolationPFCands = convertPtrVector(tau.isolationPFCands());
 
     // Move the necessary signal pizeros - what a mess!
-    BOOST_FOREACH(const PFCandidatePtr& ptr, tau.signalPFCands()) {
+    BOOST_FOREACH(const CandidatePtr& ptr, tau.signalPFCands()) {
       if (keysToMove.count(ptr.key()))
         newIsolationPFCands.push_back(ptr);
       else
         newSignalPFCands.push_back(ptr);
     }
 
-    BOOST_FOREACH(const PFCandidatePtr& ptr, tau.signalPFGammaCands()) {
+    BOOST_FOREACH(const CandidatePtr& ptr, tau.signalPFGammaCands()) {
       if (keysToMove.count(ptr.key()))
         newIsolationPFGammas.push_back(ptr);
       else
         newSignalPFGammas.push_back(ptr);
     }
 
-    tau.setsignalPFCands(newSignalPFCands);
-    tau.setsignalPFCands(newSignalPFGammas);
-    tau.setisolationPFGammaCands(newIsolationPFGammas);
-    tau.setisolationPFCands(newIsolationPFCands);
+    tau.setsignalPFCands(convertPtrVector(newSignalPFCands));
+    tau.setsignalPFCands(convertPtrVector(newSignalPFGammas));
+    tau.setisolationPFGammaCands(convertPtrVector(newIsolationPFGammas));
+    tau.setisolationPFCands(convertPtrVector(newIsolationPFCands));
   }
 }
 }}  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPhotonFilter.cc
@@ -114,8 +114,8 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
 
     std::vector<CandidatePtr> newSignalPFGammas;
     std::vector<CandidatePtr> newSignalPFCands;
-    std::vector<CandidatePtr> newIsolationPFGammas = convertPtrVector(tau.isolationPFGammaCands());
-    std::vector<CandidatePtr> newIsolationPFCands = convertPtrVector(tau.isolationPFCands());
+    std::vector<CandidatePtr> newIsolationPFGammas = tau.isolationPFGammaCands();
+    std::vector<CandidatePtr> newIsolationPFCands = tau.isolationPFCands();
 
     // Move the necessary signal pizeros - what a mess!
     BOOST_FOREACH(const CandidatePtr& ptr, tau.signalPFCands()) {
@@ -132,10 +132,10 @@ void RecoTauPhotonFilter::operator()(PFTau& tau) const {
         newSignalPFGammas.push_back(ptr);
     }
 
-    tau.setsignalPFCands(convertPtrVectorToPF(newSignalPFCands));
-    tau.setsignalPFCands(convertPtrVectorToPF(newSignalPFGammas));
-    tau.setisolationPFGammaCands(convertPtrVectorToPF(newIsolationPFGammas));
-    tau.setisolationPFCands(convertPtrVectorToPF(newIsolationPFCands));
+    tau.setsignalPFCands(newSignalPFCands);
+    tau.setsignalPFCands(newSignalPFGammas);
+    tau.setisolationPFGammaCands(newIsolationPFGammas);
+    tau.setisolationPFCands(newIsolationPFCands);
   }
 }
 }}  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -13,8 +13,8 @@
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
@@ -55,24 +55,24 @@ RecoTauPiZeroCombinatoricPlugin::return_type
 RecoTauPiZeroCombinatoricPlugin::operator()(
     const reco::PFJet& jet) const {
   // Get list of gamma candidates
-  typedef std::vector<reco::PFCandidatePtr> PFCandPtrs;
-  typedef PFCandPtrs::const_iterator PFCandIter;
+  typedef std::vector<reco::CandidatePtr> CandPtrs;
+  typedef CandPtrs::const_iterator CandIter;
   PiZeroVector output;
 
-  PFCandPtrs pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
+  CandPtrs pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
   // Check if we have anything to do...
   if (pfGammaCands.size() < choose_)
     return output.release();
 
   // Define the valid range of gammas to use
-  PFCandIter start_iter = pfGammaCands.begin();
-  PFCandIter end_iter = pfGammaCands.end();
+  CandIter start_iter = pfGammaCands.begin();
+  CandIter end_iter = pfGammaCands.end();
 
   // Only take the desired number of piZeros
   end_iter = takeNElements(start_iter, end_iter, maxInputGammas_);
 
   // Build the combinatoric generator
-  typedef CombinatoricGenerator<PFCandPtrs> ComboGenerator;
+  typedef CombinatoricGenerator<CandPtrs> ComboGenerator;
   ComboGenerator generator(start_iter, end_iter, choose_);
 
   // Find all possible combinations

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -30,7 +30,7 @@ class RecoTauPiZeroCombinatoricPlugin : public RecoTauPiZeroBuilderPlugin {
   explicit RecoTauPiZeroCombinatoricPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
     ~RecoTauPiZeroCombinatoricPlugin() override {}
     // Return type is auto_ptr<PiZeroVector>
-    return_type operator()(const reco::PFJet& jet) const override;
+    return_type operator()(const reco::Jet& jet) const override;
 
   private:
     RecoTauQualityCuts qcuts_;
@@ -53,7 +53,7 @@ RecoTauPiZeroCombinatoricPlugin::RecoTauPiZeroCombinatoricPlugin(
 
 RecoTauPiZeroCombinatoricPlugin::return_type
 RecoTauPiZeroCombinatoricPlugin::operator()(
-    const reco::PFJet& jet) const {
+    const reco::Jet& jet) const {
   // Get list of gamma candidates
   typedef std::vector<reco::CandidatePtr> CandPtrs;
   typedef CandPtrs::const_iterator CandIter;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -67,7 +67,7 @@ class RecoTauPiZeroProducer : public edm::stream::EDProducer<> {
       outputSelector_;
 
     //consumes interface
-    edm::EDGetTokenT<reco::CandidateView> cand_token;
+    edm::EDGetTokenT<reco::JetView> cand_token;
 
     double minJetPt_;
     double maxJetAbsEta_;
@@ -77,7 +77,7 @@ class RecoTauPiZeroProducer : public edm::stream::EDProducer<> {
 
 RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) 
 {
-  cand_token = consumes<reco::CandidateView>( pset.getParameter<edm::InputTag>("jetSrc"));
+  cand_token = consumes<reco::JetView>( pset.getParameter<edm::InputTag>("jetSrc"));
   minJetPt_ = ( pset.exists("minJetPt") ) ? pset.getParameter<double>("minJetPt") : -1.0;
   maxJetAbsEta_ = ( pset.exists("maxJetAbsEta") ) ? pset.getParameter<double>("maxJetAbsEta") : 99.0;
 
@@ -129,7 +129,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset)
 void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
 {
   // Get a view of our jets via the base candidates
-  edm::Handle<reco::CandidateView> jetView;
+  edm::Handle<reco::JetView> jetView;
   evt.getByToken(cand_token, jetView);
 
   // Give each of our plugins a chance at doing something with the edm::Event
@@ -144,9 +144,9 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   std::unique_ptr<reco::JetPiZeroAssociation> association;
 
   if (!jetRefs.empty()) {
-    edm::Handle<reco::PFJetCollection> pfJetCollectionHandle;
-    evt.get(jetRefs.id(), pfJetCollectionHandle);
-    association = std::make_unique<reco::JetPiZeroAssociation>(reco::PFJetRefProd(pfJetCollectionHandle));
+    // edm::Handle<reco::PFJetCollection> pfJetCollectionHandle;
+    // evt.get(jetRefs.id(), pfJetCollectionHandle);
+    association = std::make_unique<reco::JetPiZeroAssociation>(reco::JetRefBaseProd(jetView));
   } else {
     association = std::make_unique<reco::JetPiZeroAssociation>();
   }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -137,22 +137,15 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     builder.setup(evt, es);
   }
 
-  // Convert the view to a RefVector of actual PFJets
-  reco::PFJetRefVector jetRefs =
-      reco::tau::castView<reco::PFJetRefVector>(jetView);
   // Make our association
   std::unique_ptr<reco::JetPiZeroAssociation> association;
 
-  if (!jetRefs.empty()) {
-    // edm::Handle<reco::PFJetCollection> pfJetCollectionHandle;
-    // evt.get(jetRefs.id(), pfJetCollectionHandle);
-    association = std::make_unique<reco::JetPiZeroAssociation>(reco::JetRefBaseProd(jetView));
-  } else {
-    association = std::make_unique<reco::JetPiZeroAssociation>();
-  }
+  association = std::make_unique<reco::JetPiZeroAssociation>(reco::JetRefBaseProd(jetView));
 
   // Loop over our jets
-  BOOST_FOREACH(const reco::PFJetRef& jet, jetRefs) {
+  size_t nJets = jetView->size();
+  for (size_t i = 0; i < nJets; ++i) {
+    const reco::JetBaseRef jet(jetView->refAt(i));
 
     if(jet->pt() - minJetPt_ < 1e-5) continue;
     if(std::abs(jet->eta()) - maxJetAbsEta_ > -1e-5) continue;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -56,7 +56,7 @@ class RecoTauPiZeroStripPlugin : public RecoTauPiZeroBuilderPlugin {
     RecoTauQualityCuts qcuts_;
     RecoTauVertexAssociator vertexAssociator_;
 
-    std::vector<int> inputPdgIds_; //type of candidates to clusterize
+    std::vector<int> inputParticleIds_; //type of candidates to clusterize
     double etaAssociationDistance_;//eta Clustering Association Distance
     double phiAssociationDistance_;//phi Clustering Association Distance
 
@@ -74,7 +74,7 @@ RecoTauPiZeroStripPlugin::RecoTauPiZeroStripPlugin(
     qcuts_(pset.getParameterSet(
           "qualityCuts").getParameterSet("signalQualityCuts")),
     vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"),std::move(iC)) {
-  inputPdgIds_ = pset.getParameter<std::vector<int> >(
+  inputParticleIds_ = pset.getParameter<std::vector<int> >(
       "stripCandidatesParticleIds");
   etaAssociationDistance_ = pset.getParameter<double>(
       "stripEtaAssociationDistance");
@@ -102,7 +102,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
 
   // Get the candidates passing our quality cuts
   qcuts_.setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputPdgIds_));
+  CandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputParticleIds_));
   //PFCandPtrs candsVector = qcuts_.filterCandRefs(pfGammas(jet));
 
   // Convert to stl::list to allow fast deletions

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -16,8 +16,8 @@
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
@@ -96,24 +96,24 @@ void RecoTauPiZeroStripPlugin::beginEvent() {
 RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
     const reco::PFJet& jet) const {
   // Get list of gamma candidates
-  typedef std::vector<reco::PFCandidatePtr> PFCandPtrs;
-  typedef PFCandPtrs::iterator PFCandIter;
+  typedef std::vector<reco::CandidatePtr> CandPtrs;
+  typedef CandPtrs::iterator CandIter;
   PiZeroVector output;
 
   // Get the candidates passing our quality cuts
   qcuts_.setPV(vertexAssociator_.associatedVertex(jet));
-  PFCandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputPdgIds_));
+  CandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputPdgIds_));
   //PFCandPtrs candsVector = qcuts_.filterCandRefs(pfGammas(jet));
 
   // Convert to stl::list to allow fast deletions
-  typedef std::list<reco::PFCandidatePtr> PFCandPtrList;
-  typedef std::list<reco::PFCandidatePtr>::iterator PFCandPtrListIter;
-  PFCandPtrList cands;
+  typedef std::list<reco::CandidatePtr> CandPtrList;
+  typedef std::list<reco::CandidatePtr>::iterator CandPtrListIter;
+  CandPtrList cands;
   cands.insert(cands.end(), candsVector.begin(), candsVector.end());
 
   while (!cands.empty()) {
     // Seed this new strip, and delete it from future strips
-    PFCandidatePtr seed = cands.front();
+    CandidatePtr seed = cands.front();
     cands.pop_front();
 
     // Add a new candidate to our collection using this seed
@@ -122,7 +122,7 @@ RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
     strip->addDaughter(seed);
 
     // Find all other objects in the strip
-    PFCandPtrListIter stripCand = cands.begin();
+    CandPtrListIter stripCand = cands.begin();
     while(stripCand != cands.end()) {
       if( fabs(strip->eta() - (*stripCand)->eta()) < etaAssociationDistance_
           && fabs(deltaPhi(*strip, **stripCand)) < phiAssociationDistance_ ) {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -48,7 +48,7 @@ class RecoTauPiZeroStripPlugin : public RecoTauPiZeroBuilderPlugin {
   explicit RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector && iC);
     ~RecoTauPiZeroStripPlugin() override {}
     // Return type is auto_ptr<PiZeroVector>
-    return_type operator()(const reco::PFJet& jet) const override;
+    return_type operator()(const reco::Jet& jet) const override;
     // Hook to update PV information
     void beginEvent() override;
 
@@ -94,7 +94,7 @@ void RecoTauPiZeroStripPlugin::beginEvent() {
 }
 
 RecoTauPiZeroStripPlugin::return_type RecoTauPiZeroStripPlugin::operator()(
-    const reco::PFJet& jet) const {
+    const reco::Jet& jet) const {
   // Get list of gamma candidates
   typedef std::vector<reco::CandidatePtr> CandPtrs;
   typedef CandPtrs::iterator CandIter;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -73,7 +73,7 @@ class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin
 
   double minStripEt_;
 
-  std::vector<int> inputPdgIds_;  // type of candidates to clusterize
+  std::vector<int> inputParticleIds_;  // type of candidates to clusterize
   double etaAssociationDistance_; // size of strip clustering window in eta direction
   double phiAssociationDistance_; // size of strip clustering window in phi direction
 
@@ -118,7 +118,7 @@ RecoTauPiZeroStripPlugin2::RecoTauPiZeroStripPlugin2(const edm::ParameterSet& ps
   qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
   qcuts_ = new RecoTauQualityCuts(qcuts_pset);
 
-  inputPdgIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
+  inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
   etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");
   phiAssociationDistance_ = pset.getParameter<double>("stripPhiAssociationDistance");
 
@@ -208,7 +208,7 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
 
   // Get the candidates passing our quality cuts
   qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputPdgIds_));
+  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
 
   // Convert to stl::list to allow fast deletions
   CandPtrs seedCands;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -56,7 +56,7 @@ class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin
   explicit RecoTauPiZeroStripPlugin2(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
   ~RecoTauPiZeroStripPlugin2() override;
   // Return type is auto_ptr<PiZeroVector>
-  return_type operator()(const reco::PFJet&) const override;
+  return_type operator()(const reco::Jet&) const override;
   // Hook to update PV information
   void beginEvent() override;
   
@@ -195,7 +195,7 @@ namespace
   }
 }
 
-RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(const reco::PFJet& jet) const 
+RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(const reco::Jet& jet) const 
 {
   if ( verbosity_ >= 1 ) {
     edm::LogPrint("RecoTauPiZeroStripPlugin2") << "<RecoTauPiZeroStripPlugin2::operator()>:" ;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -18,8 +18,8 @@
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
@@ -61,8 +61,8 @@ class RecoTauPiZeroStripPlugin2 : public RecoTauPiZeroBuilderPlugin
   void beginEvent() override;
   
  private:
-  typedef std::vector<reco::PFCandidatePtr> PFCandPtrs;
-  void addCandsToStrip(RecoTauPiZero&, PFCandPtrs&, const std::vector<bool>&, std::set<size_t>&, bool&) const;
+  typedef std::vector<reco::CandidatePtr> CandPtrs;
+  void addCandsToStrip(RecoTauPiZero&, CandPtrs&, const std::vector<bool>&, std::set<size_t>&, bool&) const;
 
   RecoTauVertexAssociator vertexAssociator_;
 
@@ -146,7 +146,7 @@ void RecoTauPiZeroStripPlugin2::beginEvent()
   vertexAssociator_.setEvent(*evt());
 }
 
-void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, PFCandPtrs& cands, const std::vector<bool>& candFlags, 
+void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, CandPtrs& cands, const std::vector<bool>& candFlags, 
 						std::set<size_t>& candIdsCurrentStrip, bool& isCandAdded) const
 {
   if ( verbosity_ >= 1 ) {
@@ -155,7 +155,7 @@ void RecoTauPiZeroStripPlugin2::addCandsToStrip(RecoTauPiZero& strip, PFCandPtrs
   size_t numCands = cands.size();
   for ( size_t candId = 0; candId < numCands; ++candId ) {
     if ( (!candFlags[candId]) && candIdsCurrentStrip.find(candId) == candIdsCurrentStrip.end() ) { // do not include same cand twice
-      reco::PFCandidatePtr cand = cands[candId];
+      reco::CandidatePtr cand = cands[candId];
       if ( fabs(strip.eta() - cand->eta()) < etaAssociationDistance_ && // check if cand is within eta-phi window centered on strip 
 	   fabs(strip.phi() - cand->phi()) < phiAssociationDistance_ ) {
 	if ( verbosity_ >= 2 ) {
@@ -180,11 +180,18 @@ namespace
     }
   }
   
-  inline const reco::TrackBaseRef getTrack(const PFCandidate& cand)
+  // JAN - FIXME - this method is needed multiple times
+
+  inline const reco::TrackBaseRef getTrack(const Candidate& cand)
   {
-    if      ( cand.trackRef().isNonnull()    ) return reco::TrackBaseRef(cand.trackRef());
-    else if ( cand.gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(cand.gsfTrackRef());
-    else return reco::TrackBaseRef();
+    const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
+    if (pfCandPtr) {
+      if      ( pfCandPtr->trackRef().isNonnull()    ) return reco::TrackBaseRef(pfCandPtr->trackRef());
+      else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
+      else return reco::TrackBaseRef();
+    }
+    // JAN - FIXME: Add method for miniAOD PackedCandidate
+    return reco::TrackBaseRef();
   }
 }
 
@@ -201,13 +208,13 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
 
   // Get the candidates passing our quality cuts
   qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  PFCandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputPdgIds_));
+  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputPdgIds_));
 
   // Convert to stl::list to allow fast deletions
-  PFCandPtrs seedCands;
-  PFCandPtrs addCands;
+  CandPtrs seedCands;
+  CandPtrs addCands;
   int idx = 0;
-  for ( PFCandPtrs::iterator cand = candsVector.begin();
+  for ( CandPtrs::iterator cand = candsVector.begin();
 	cand != candsVector.end(); ++cand ) {
     if ( verbosity_ >= 1 ) {
       edm::LogPrint("RecoTauPiZeroStripPlugin2") << "PFGamma #" << idx << " (" << cand->id() << ":" << cand->key() << "): Et = " << (*cand)->et() << ", eta = " << (*cand)->eta() << ", phi = " << (*cand)->phi() ;
@@ -215,17 +222,17 @@ RecoTauPiZeroStripPlugin2::return_type RecoTauPiZeroStripPlugin2::operator()(con
     if ( (*cand)->et() > minGammaEtStripSeed_ ) {
       if ( verbosity_ >= 2 ) {
 	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "--> assigning seedCandId = " << seedCands.size() ;
-        const reco::TrackBaseRef candTrack = getTrack(*cand);
+        const reco::TrackBaseRef candTrack = getTrack(**cand);
         if ( candTrack.isNonnull() ) {
 	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << "track: Pt = " << candTrack->pt() << " eta = " << candTrack->eta() << ", phi = " << candTrack->phi() << ", charge = " << candTrack->charge() ;
 	  edm::LogPrint("RecoTauPiZeroStripPlugin2") << " (dZ = " << candTrack->dz(vertexAssociator_.associatedVertex(jet)->position()) << ", dXY = " << candTrack->dxy(vertexAssociator_.associatedVertex(jet)->position()) << "," 
 		    << " numHits = " << candTrack->hitPattern().numberOfValidTrackerHits() << ", numPxlHits = " << candTrack->hitPattern().numberOfValidPixelHits() << "," 
 		    << " chi2 = " << candTrack->normalizedChi2() << ", dPt/Pt = " << (candTrack->ptError()/candTrack->pt()) << ")" ;
 	}
-	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "ECAL Et: calibrated = " << (*cand)->ecalEnergy()*sin((*cand)->theta()) << "," 
-		  << " raw = " << (*cand)->rawEcalEnergy()*sin((*cand)->theta()) ;
-	edm::LogPrint("RecoTauPiZeroStripPlugin2") << "HCAL Et: calibrated = " << (*cand)->hcalEnergy()*sin((*cand)->theta()) << "," 
-		  << " raw = " << (*cand)->rawHcalEnergy()*sin((*cand)->theta()) ;
+	// edm::LogPrint("RecoTauPiZeroStripPlugin2") << "ECAL Et: calibrated = " << (*cand)->ecalEnergy()*sin((*cand)->theta()) << "," 
+		  // << " raw = " << (*cand)->rawEcalEnergy()*sin((*cand)->theta()) ;
+	// edm::LogPrint("RecoTauPiZeroStripPlugin2") << "HCAL Et: calibrated = " << (*cand)->hcalEnergy()*sin((*cand)->theta()) << "," 
+		  // << " raw = " << (*cand)->rawHcalEnergy()*sin((*cand)->theta()) ;
       }
       seedCands.push_back(*cand);
     } else if ( (*cand)->et() > minGammaEtStripAdd_  ) {

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -179,8 +179,6 @@ namespace
       candFlags[*candId] = true;
     }
   }
-  
-  // JAN - FIXME - this method is needed multiple times
 
   inline const reco::TrackBaseRef getTrack(const Candidate& cand)
   {
@@ -190,7 +188,7 @@ namespace
       else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
       else return reco::TrackBaseRef();
     }
-    // JAN - FIXME: Add method for miniAOD PackedCandidate
+
     return reco::TrackBaseRef();
   }
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -76,7 +76,7 @@ class RecoTauPiZeroStripPlugin3 : public RecoTauPiZeroBuilderPlugin
 
   double minStripEt_;
 
-  std::vector<int> inputPdgIds_;  // type of candidates to clusterize
+  std::vector<int> inputParticleIds_;  // type of candidates to clusterize
   std::unique_ptr<const TFormula> etaAssociationDistance_; // size of strip clustering window in eta direction
   std::unique_ptr<const TFormula> phiAssociationDistance_; // size of strip clustering window in phi direction
 
@@ -140,7 +140,7 @@ RecoTauPiZeroStripPlugin3::RecoTauPiZeroStripPlugin3(const edm::ParameterSet& ps
 
   qcuts_.reset(new RecoTauQualityCuts(qcuts_pset));
 
-  inputPdgIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
+  inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
   const edm::ParameterSet& stripSize_eta_pset = pset.getParameterSet("stripEtaAssociationDistance");
   etaAssociationDistance_ = makeFunction("etaAssociationDistance", stripSize_eta_pset);
   const edm::ParameterSet& stripSize_phi_pset = pset.getParameterSet("stripPhiAssociationDistance");
@@ -232,7 +232,7 @@ RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(con
 
   // Get the candidates passing our quality cuts
   qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
-  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputPdgIds_));
+  CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
 
   // Convert to stl::list to allow fast deletions
   CandPtrs seedCands;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -59,7 +59,7 @@ class RecoTauPiZeroStripPlugin3 : public RecoTauPiZeroBuilderPlugin
   explicit RecoTauPiZeroStripPlugin3(const edm::ParameterSet&, edm::ConsumesCollector &&iC);
   ~RecoTauPiZeroStripPlugin3() override;
   // Return type is auto_ptr<PiZeroVector>
-  return_type operator()(const reco::PFJet&) const override;
+  return_type operator()(const reco::Jet&) const override;
   // Hook to update PV information
   void beginEvent() override;
   
@@ -219,7 +219,7 @@ namespace
   }
 }
 
-RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(const reco::PFJet& jet) const 
+RecoTauPiZeroStripPlugin3::return_type RecoTauPiZeroStripPlugin3::operator()(const reco::Jet& jet) const 
 {
   if ( verbosity_ >= 1 ) {
     edm::LogPrint("RecoTauPiZeroStripPlugin3") << "<RecoTauPiZeroStripPlugin3::operator()>:" ;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -204,8 +204,9 @@ namespace
     }
   }
 
-  // JAN - FIXME - this method is needed multiple times
-
+  // The following method has not been adapted to work with PackedCandidates,
+  // however, it is only used for printing/debugging and can be adapted when
+  // needed.
   inline const reco::TrackBaseRef getTrack(const Candidate& cand)
   {
     const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
@@ -214,7 +215,7 @@ namespace
       else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(pfCandPtr->gsfTrackRef());
       else return reco::TrackBaseRef();
     }
-    // JAN - FIXME: Add method for miniAOD PackedCandidate
+    
     return reco::TrackBaseRef();
   }
 }

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -11,8 +11,8 @@
  */
 
 #include "RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 
@@ -39,11 +39,11 @@ RecoTauPiZeroTrivialPlugin::RecoTauPiZeroTrivialPlugin(
 
 RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(
     const reco::PFJet& jet) const {
-  std::vector<PFCandidatePtr> pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
+  std::vector<CandidatePtr> pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
   PiZeroVector output;
   output.reserve(pfGammaCands.size());
 
-  BOOST_FOREACH(const PFCandidatePtr& gamma, pfGammaCands) {
+  BOOST_FOREACH(const CandidatePtr& gamma, pfGammaCands) {
     std::auto_ptr<RecoTauPiZero> piZero(new RecoTauPiZero(
             0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true,
             RecoTauPiZero::kTrivial));

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -27,7 +27,7 @@ class RecoTauPiZeroTrivialPlugin : public RecoTauPiZeroBuilderPlugin {
   public:
   explicit RecoTauPiZeroTrivialPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector &&iC);
     ~RecoTauPiZeroTrivialPlugin() override {}
-    return_type operator()(const reco::PFJet& jet) const override;
+    return_type operator()(const reco::Jet& jet) const override;
   private:
     RecoTauQualityCuts qcuts_;
 };
@@ -38,7 +38,7 @@ RecoTauPiZeroTrivialPlugin::RecoTauPiZeroTrivialPlugin(
           "qualityCuts").getParameterSet("signalQualityCuts")) {}
 
 RecoTauPiZeroBuilderPlugin::return_type RecoTauPiZeroTrivialPlugin::operator()(
-    const reco::PFJet& jet) const {
+    const reco::Jet& jet) const {
   std::vector<CandidatePtr> pfGammaCands = qcuts_.filterCandRefs(pfGammas(jet));
   PiZeroVector output;
   output.reserve(pfGammaCands.size());

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -134,7 +134,8 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   evt.getByToken(jet_token, jetView);
   
   // Convert to a vector of PFJetRefs
-  reco::PFJetRefVector jets = reco::tau::castView<reco::PFJetRefVector>(jetView);
+  // reco::PFJetRefVector jets = reco::tau::castView<reco::PFJetRefVector>(jetView);
+  edm::RefToBaseVector<reco::Jet> jets = reco::tau::castView<edm::RefToBaseVector<reco::Jet>>(jetView);
   
   // Get the jet region producer
   edm::Handle<edm::Association<reco::PFJetCollection> > jetRegionHandle;

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -211,7 +211,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
       // JAN - convert reco::Jet ref to PFJet ref (only in direct interaction with PFTau)
 
       // Make sure all taus have their jetref set correctly
-      std::for_each(taus.begin(), taus.end(), boost::bind(&reco::PFTau::setjetRef, _1, jetRef.castTo<reco::PFJetRef>()));
+      std::for_each(taus.begin(), taus.end(), boost::bind(&reco::PFTau::setjetRef, _1, reco::JetBaseRef(jetRef)));
       // Copy without selection
       if ( !outputSelector_.get() ) {
         output->insert(output->end(), taus.begin(), taus.end());
@@ -231,7 +231,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     // jet.
     if ( !nTausBuilt && buildNullTaus_ ) {
       reco::PFTau nullTau(std::numeric_limits<int>::quiet_NaN(), jetRef->p4());
-      nullTau.setjetRef(jetRef.castTo<reco::PFJetRef>());
+      nullTau.setjetRef(reco::JetBaseRef(jetRef));
       output->push_back(nullTau);
     }
   }

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -64,7 +64,7 @@ class RecoTauProducer : public edm::stream::EDProducer<>
   double maxJetAbsEta_;
  //token definition
   edm::EDGetTokenT<reco::JetView> jet_token;
-  edm::EDGetTokenT<edm::Association<reco::PFJetCollection> > jetRegion_token;
+  edm::EDGetTokenT<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > > jetRegion_token;
   edm::EDGetTokenT<reco::PFJetChargedHadronAssociation> chargedHadron_token;
   edm::EDGetTokenT<reco::JetPiZeroAssociation> piZero_token;
 
@@ -89,7 +89,7 @@ RecoTauProducer::RecoTauProducer(const edm::ParameterSet& pset)
   maxJetAbsEta_ = ( pset.exists("maxJetAbsEta") ) ? pset.getParameter<double>("maxJetAbsEta") : 99.0;
   //consumes definition
   jet_token=consumes<reco::JetView>(jetSrc_);
-  jetRegion_token = consumes<edm::Association<reco::PFJetCollection> >(jetRegionSrc_);
+  jetRegion_token = consumes<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > >(jetRegionSrc_);
   chargedHadron_token = consumes<reco::PFJetChargedHadronAssociation>(chargedHadronSrc_); 
   piZero_token = consumes<reco::JetPiZeroAssociation>(piZeroSrc_);
 
@@ -139,7 +139,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   // edm::RefToBaseVector<reco::Jet> jets = reco::tau::castViewToOtherBase<edm::RefToBaseVector<reco::Jet>>(jetView);
   
   // Get the jet region producer
-  edm::Handle<edm::Association<reco::PFJetCollection> > jetRegionHandle;
+  edm::Handle<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > > jetRegionHandle;
   evt.getByToken(jetRegion_token, jetRegionHandle);
   
   // Get the charged hadron input collection
@@ -172,7 +172,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     // Get the jet with extra constituents from an area around the jet
     if(jetRef->pt() - minJetPt_ < 1e-5) continue;
     if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
-    reco::PFJetRef jetRegionRef = (*jetRegionHandle)[jetRef];
+    reco::JetBaseRef jetRegionRef = (*jetRegionHandle)[jetRef];
     if ( jetRegionRef.isNull() ) {
       throw cms::Exception("BadJetRegionRef") 
 	<< "No jet region can be found for the current jet: " << jetRef.id();

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -132,12 +132,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   // Get the jet input collection via a view of Candidates
   edm::Handle<reco::JetView> jetView;
   evt.getByToken(jet_token, jetView);
-  
-  // Convert to a vector of PFJetRefs
-  // reco::PFJetRefVector jets = reco::tau::castView<reco::PFJetRefVector>(jetView);
-  // edm::RefVector<std::vector<reco::Jet>> jets = reco::tau::castView<edm::RefVector<std::vector<reco::Jet>>>(jetView);
-  // edm::RefToBaseVector<reco::Jet> jets = reco::tau::castViewToOtherBase<edm::RefToBaseVector<reco::Jet>>(jetView);
-  
+    
   // Get the jet region producer
   edm::Handle<edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > > jetRegionHandle;
   evt.getByToken(jetRegion_token, jetRegionHandle);

--- a/RecoTauTag/RecoTau/plugins/RecoTauSoftTwoProngTausCleanerPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauSoftTwoProngTausCleanerPlugin.cc
@@ -8,6 +8,7 @@
 
 #include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
 
 namespace reco { namespace tau {
 
@@ -35,7 +36,8 @@ double RecoTauSoftTwoProngTausCleanerPlugin::operator()(const reco::PFTauRef& ta
   if ( chargedHadrons.size() == 2 ) {
     for ( std::vector<PFRecoTauChargedHadron>::const_iterator chargedHadron = chargedHadrons.begin();
 	  chargedHadron != chargedHadrons.end(); ++chargedHadron ) {
-      if ( !(chargedHadron->getTrack().get() && chargedHadron->getTrack()->pt() > minTrackPt_) ) result += 1.e+3;
+      const reco::Track* track = getTrackFromChargedHadron(*chargedHadron);
+      if ( !(track != nullptr && track->pt() > minTrackPt_) ) result += 1.e+3;
     }
   }
   return result;

--- a/RecoTauTag/RecoTau/plugins/RecoTauTauTagInfoWorkaroundModifier.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauTauTagInfoWorkaroundModifier.cc
@@ -43,11 +43,11 @@ void RecoTauTagInfoWorkaroundModifer::beginEvent() {
 
 void RecoTauTagInfoWorkaroundModifer::operator()(PFTau& tau) const {
   // Find the PFTauTagInfo that comes from the same PFJet
-  PFJetRef tauJetRef = tau.jetRef();
+  JetBaseRef tauJetRef = tau.jetRef();
   for(size_t iInfo = 0; iInfo < infos_->size(); ++iInfo) {
     // Get jet ref from tau tag info
     PFTauTagInfoRef infoRef = PFTauTagInfoRef(infos_, iInfo);
-    PFJetRef infoJetRef = infoRef->pfjetRef();
+    JetBaseRef infoJetRef = infoRef->pfjetRef();
     // Check if they come from the same jet
     if (infoJetRef == tauJetRef) {
       // This tau "comes" from this PFJetRef

--- a/RecoTauTag/RecoTau/plugins/RecoTauTwoProngFilter.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauTwoProngFilter.cc
@@ -18,10 +18,10 @@ namespace reco { namespace tau {
 namespace 
 {
   // Delete an element from a ptr vector
-  std::vector<PFCandidatePtr> deleteFrom(const PFCandidatePtr& ptr, const std::vector<PFCandidatePtr>& collection) 
+  std::vector<CandidatePtr> deleteFrom(const CandidatePtr& ptr, const std::vector<CandidatePtr>& collection) 
   {
-    std::vector<PFCandidatePtr> output;
-    for ( std::vector<PFCandidatePtr>::const_iterator cand = collection.begin();
+    std::vector<CandidatePtr> output;
+    for ( std::vector<CandidatePtr>::const_iterator cand = collection.begin();
 	  cand != collection.end(); ++cand ) {
       if ( (*cand) != ptr) output.push_back(*cand);
     }
@@ -44,7 +44,7 @@ class RecoTauTwoProngFilter : public RecoTauModifierPlugin {
 
 void RecoTauTwoProngFilter::operator()(PFTau& tau) const {
   if (tau.signalPFChargedHadrCands().size() == 2) {
-    const std::vector<PFCandidatePtr>& signalCharged = tau.signalPFChargedHadrCands();
+    const std::vector<CandidatePtr>& signalCharged = tau.signalPFChargedHadrCands();
     size_t indexOfHighestPt =
         (signalCharged[0]->pt() > signalCharged[1]->pt()) ? 0 : 1;
     size_t indexOfLowerPt   = ( indexOfHighestPt ) ? 0 : 1;
@@ -52,18 +52,18 @@ void RecoTauTwoProngFilter::operator()(PFTau& tau) const {
         signalCharged[indexOfHighestPt]->pt();
 
     if (ratio < minPtFractionForSecondProng_) {
-      PFCandidatePtr keep = signalCharged[indexOfHighestPt];
-      PFCandidatePtr filter = signalCharged[indexOfLowerPt];
+      CandidatePtr keep = signalCharged[indexOfHighestPt];
+      CandidatePtr filter = signalCharged[indexOfLowerPt];
       // Make our new signal charged candidate collection
-      std::vector<PFCandidatePtr> newSignalCharged;
+      std::vector<CandidatePtr> newSignalCharged;
       newSignalCharged.push_back(keep);
-      std::vector<PFCandidatePtr> newSignal = deleteFrom(filter, tau.signalPFCands());
+      std::vector<CandidatePtr> newSignal = deleteFrom(filter, tau.signalPFCands());
 
       // Copy our filtered cand to isolation
-      std::vector<PFCandidatePtr> newIsolationCharged =
+      std::vector<CandidatePtr> newIsolationCharged =
           tau.isolationPFChargedHadrCands();
       newIsolationCharged.push_back(filter);
-      std::vector<PFCandidatePtr> newIsolation = tau.isolationPFCands();
+      std::vector<CandidatePtr> newIsolation = tau.isolationPFCands();
       newIsolation.push_back(filter);
 
       // Update tau members

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminationAgainstCaloMuon.cc
@@ -74,12 +74,15 @@ class TauLeadTrackExtractor<reco::PFTau>
  public:
   reco::TrackRef getLeadTrack(const reco::PFTau& tau) const
   {
-    return tau.leadPFChargedHadrCand()->trackRef();
+    const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(tau.leadPFChargedHadrCand().get());
+    if (pflch != nullptr) {
+      return pflch->trackRef();
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
   double getTrackPtSum(const reco::PFTau& tau) const
   {
     double trackPtSum = 0.;
-    for ( std::vector<PFCandidatePtr>::const_iterator signalTrack = tau.signalPFChargedHadrCands().begin();
+    for ( std::vector<CandidatePtr>::const_iterator signalTrack = tau.signalPFChargedHadrCands().begin();
 	  signalTrack != tau.signalPFChargedHadrCands().end(); ++signalTrack ) {
       trackPtSum += (*signalTrack)->pt();
     }

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA5.cc
@@ -701,11 +701,14 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau,
   Float_t TauEtaAtEcalEntrance = -99.;
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
-  const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+  const std::vector<reco::CandidatePtr>& signalPFCands = thePFTau.signalPFCands();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumEtaTimesEnergy += (*pfCandidate)->positionAtECALEntrance().eta()*(*pfCandidate)->energy();
-    sumEnergy += (*pfCandidate)->energy();
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(pfCandidate->get());
+    if (pfcand != nullptr) {
+      sumEtaTimesEnergy += pfcand->positionAtECALEntrance().eta()*pfcand->energy();
+      sumEnergy += pfcand->energy();
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
   if ( sumEnergy > 0. ) {
     TauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
@@ -713,20 +716,23 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau,
   
   float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
   float TauLeadChargedPFCandPt = -99.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    const reco::Track* track = nullptr;
-    if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-    else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
-    if ( track ) {
-      if ( track->pt() > TauLeadChargedPFCandPt ) {
-	TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
-	TauLeadChargedPFCandPt = track->pt();
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(pfCandidate->get());
+    if (pfcand != nullptr) {
+      const reco::Track* track = nullptr;
+      if ( pfcand->trackRef().isNonnull() ) track = pfcand->trackRef().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->innerTrack().isNonnull()  ) track = pfcand->muonRef()->innerTrack().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->globalTrack().isNonnull() ) track = pfcand->muonRef()->globalTrack().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->outerTrack().isNonnull()  ) track = pfcand->muonRef()->outerTrack().get();
+      else if ( pfcand->gsfTrackRef().isNonnull() ) track = pfcand->gsfTrackRef().get();
+      if ( track ) {
+        if ( track->pt() > TauLeadChargedPFCandPt ) {
+	  TauLeadChargedPFCandEtaAtEcalEntrance = pfcand->positionAtECALEntrance().eta();
+	  TauLeadChargedPFCandPt = track->pt();
+        }
       }
-    }
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
 
   Float_t TauPt = thePFTau.pt();
@@ -734,9 +740,13 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau,
   Float_t TauSignalPFGammaCands = thePFTau.signalPFGammaCands().size();
   Float_t TauLeadPFChargedHadrHoP = 0.;
   Float_t TauLeadPFChargedHadrEoP = 0.;
-  if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
-    TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-    TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+  const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(thePFTau.leadPFChargedHadrCand().get());
+  if (pflch == nullptr) {
+    throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+  }
+  if ( pflch->p() > 0. ) {
+      TauLeadPFChargedHadrHoP = pflch->hcalEnergy()/pflch->p();
+      TauLeadPFChargedHadrEoP = pflch->ecalEnergy()/pflch->p();
   }
   Float_t TauVisMass = thePFTau.mass();
   Float_t TauHadrMva = std::max(thePFTau.electronPreIDOutput(), float(-1.0));
@@ -744,7 +754,7 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau,
   std::vector<Float_t> GammasdPhi;
   std::vector<Float_t> GammasPt;
   for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
-    reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
+    reco::CandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
     if ( thePFTau.leadPFChargedHadrCand().isNonnull() ) {
       GammasdEta.push_back(gamma->eta() - thePFTau.leadPFChargedHadrCand()->eta());
       GammasdPhi.push_back(gamma->phi() - thePFTau.leadPFChargedHadrCand()->phi());
@@ -755,30 +765,33 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau,
     GammasPt.push_back(gamma->pt());
   }
   Float_t TauKFNumHits = -99.;
-  if ( (thePFTau.leadPFChargedHadrCand()->trackRef()).isNonnull() ) {
-    TauKFNumHits = thePFTau.leadPFChargedHadrCand()->trackRef()->numberOfValidHits();
+  if ( (pflch->trackRef()).isNonnull() ) {
+    TauKFNumHits = pflch->trackRef()->numberOfValidHits();
   }
   Float_t TauGSFNumHits = -99.;
   Float_t TauGSFChi2 = -99.;
   Float_t TauGSFTrackResol = -99.;
   Float_t TauGSFTracklnPt = -99.;
   Float_t TauGSFTrackEta = -99.;
-  if ( (thePFTau.leadPFChargedHadrCand()->gsfTrackRef()).isNonnull() ) {
-      TauGSFChi2 = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->normalizedChi2();
-      TauGSFNumHits = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->numberOfValidHits();
-      if ( thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->pt() > 0. ) {
-	TauGSFTrackResol = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->ptError()/thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->pt();
-	TauGSFTracklnPt = log(thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->pt())*M_LN10;
+  if ( (pflch->gsfTrackRef()).isNonnull() ) {
+      TauGSFChi2 = pflch->gsfTrackRef()->normalizedChi2();
+      TauGSFNumHits = pflch->gsfTrackRef()->numberOfValidHits();
+      if ( pflch->gsfTrackRef()->pt() > 0. ) {
+	TauGSFTrackResol = pflch->gsfTrackRef()->ptError()/pflch->gsfTrackRef()->pt();
+	TauGSFTracklnPt = log(pflch->gsfTrackRef()->pt())*M_LN10;
       }
-      TauGSFTrackEta = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->eta();
+      TauGSFTrackEta = pflch->gsfTrackRef()->eta();
   }
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumPhiTimesEnergy += (*pfCandidate)->positionAtECALEntrance().phi()*(*pfCandidate)->energy();
-    sumEnergyPhi += (*pfCandidate)->energy();
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(pfCandidate->get());
+    if (pfcand != nullptr) {
+      sumPhiTimesEnergy += pfcand->positionAtECALEntrance().phi()*pfcand->energy();
+      sumEnergyPhi += pfcand->energy();
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
   if ( sumEnergyPhi > 0. ) {
     TauPhi = sumPhiTimesEnergy/sumEnergyPhi;
@@ -786,7 +799,7 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau,
   Float_t TaudCrackPhi = dCrackPhi(TauPhi, TauEtaAtEcalEntrance);
   Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance);
   Float_t TauSignalPFChargedCands = thePFTau.signalPFChargedHadrCands().size();
-  Float_t TauHasGsf = thePFTau.leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
+  Float_t TauHasGsf = pflch->gsfTrackRef().isNonnull();
 
   Float_t ElecEta = theGsfEle.eta();
   Float_t ElecPhi = theGsfEle.phi();
@@ -866,11 +879,14 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau)
   Float_t TauEtaAtEcalEntrance = -99.;
   float sumEtaTimesEnergy = 0.;
   float sumEnergy = 0.;
-  const std::vector<reco::PFCandidatePtr>& signalPFCands = thePFTau.signalPFCands();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+  const std::vector<reco::CandidatePtr>& signalPFCands = thePFTau.signalPFCands();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumEtaTimesEnergy += (*pfCandidate)->positionAtECALEntrance().eta()*(*pfCandidate)->energy();
-    sumEnergy += (*pfCandidate)->energy();
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(pfCandidate->get());
+    if (pfcand != nullptr) {
+      sumEtaTimesEnergy += pfcand->positionAtECALEntrance().eta()*pfcand->energy();
+      sumEnergy += pfcand->energy();
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
   if ( sumEnergy > 0. ) {
     TauEtaAtEcalEntrance = sumEtaTimesEnergy/sumEnergy;
@@ -878,20 +894,23 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau)
   
   float TauLeadChargedPFCandEtaAtEcalEntrance = -99.;
   float TauLeadChargedPFCandPt = -99.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    const reco::Track* track = nullptr;
-    if ( (*pfCandidate)->trackRef().isNonnull() ) track = (*pfCandidate)->trackRef().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->innerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->innerTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->globalTrack().isNonnull() ) track = (*pfCandidate)->muonRef()->globalTrack().get();
-    else if ( (*pfCandidate)->muonRef().isNonnull() && (*pfCandidate)->muonRef()->outerTrack().isNonnull()  ) track = (*pfCandidate)->muonRef()->outerTrack().get();
-    else if ( (*pfCandidate)->gsfTrackRef().isNonnull() ) track = (*pfCandidate)->gsfTrackRef().get();
-    if ( track ) {
-      if ( track->pt() > TauLeadChargedPFCandPt ) {
-	TauLeadChargedPFCandEtaAtEcalEntrance = (*pfCandidate)->positionAtECALEntrance().eta();
-	TauLeadChargedPFCandPt = track->pt();
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(pfCandidate->get());
+    if (pfcand != nullptr) {
+      const reco::Track* track = nullptr;
+      if ( pfcand->trackRef().isNonnull() ) track = pfcand->trackRef().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->innerTrack().isNonnull()  ) track = pfcand->muonRef()->innerTrack().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->globalTrack().isNonnull() ) track = pfcand->muonRef()->globalTrack().get();
+      else if ( pfcand->muonRef().isNonnull() && pfcand->muonRef()->outerTrack().isNonnull()  ) track = pfcand->muonRef()->outerTrack().get();
+      else if ( pfcand->gsfTrackRef().isNonnull() ) track = pfcand->gsfTrackRef().get();
+      if ( track ) {
+        if ( track->pt() > TauLeadChargedPFCandPt ) {
+	  TauLeadChargedPFCandEtaAtEcalEntrance = pfcand->positionAtECALEntrance().eta();
+	  TauLeadChargedPFCandPt = track->pt();
+        }
       }
-    }
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
   
   Float_t TauPt = thePFTau.pt();
@@ -899,9 +918,13 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau)
   Float_t TauSignalPFGammaCands = thePFTau.signalPFGammaCands().size();
   Float_t TauLeadPFChargedHadrHoP = 0.;
   Float_t TauLeadPFChargedHadrEoP = 0.;
-  if ( thePFTau.leadPFChargedHadrCand()->p() > 0. ) {
-    TauLeadPFChargedHadrHoP = thePFTau.leadPFChargedHadrCand()->hcalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
-    TauLeadPFChargedHadrEoP = thePFTau.leadPFChargedHadrCand()->ecalEnergy()/thePFTau.leadPFChargedHadrCand()->p();
+  const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(thePFTau.leadPFChargedHadrCand().get());
+  if (pflch == nullptr) {
+    throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+  }
+  if ( pflch->p() > 0. ) {
+    TauLeadPFChargedHadrHoP = pflch->hcalEnergy()/pflch->p();
+    TauLeadPFChargedHadrEoP = pflch->ecalEnergy()/pflch->p();
   }
   Float_t TauVisMass = thePFTau.mass();
   Float_t TauHadrMva = std::max(thePFTau.electronPreIDOutput(),float(-1.0));
@@ -909,7 +932,7 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau)
   std::vector<Float_t> GammasdPhi;
   std::vector<Float_t> GammasPt;
   for ( unsigned i = 0 ; i < thePFTau.signalPFGammaCands().size(); ++i ) {
-    reco::PFCandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
+    reco::CandidatePtr gamma = thePFTau.signalPFGammaCands().at(i);
     if ( thePFTau.leadPFChargedHadrCand().isNonnull() ) {
       GammasdEta.push_back(gamma->eta() - thePFTau.leadPFChargedHadrCand()->eta());
       GammasdPhi.push_back(gamma->phi() - thePFTau.leadPFChargedHadrCand()->phi());
@@ -920,30 +943,33 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau)
     GammasPt.push_back(gamma->pt());
   }
   Float_t TauKFNumHits = -99.;
-  if ( (thePFTau.leadPFChargedHadrCand()->trackRef()).isNonnull() ) {
-    TauKFNumHits = thePFTau.leadPFChargedHadrCand()->trackRef()->numberOfValidHits();
+  if ( (pflch->trackRef()).isNonnull() ) {
+    TauKFNumHits = pflch->trackRef()->numberOfValidHits();
   }
   Float_t TauGSFNumHits = -99.;
   Float_t TauGSFChi2 = -99.;
   Float_t TauGSFTrackResol = -99.;
   Float_t TauGSFTracklnPt = -99.;
   Float_t TauGSFTrackEta = -99.;
-  if ( (thePFTau.leadPFChargedHadrCand()->gsfTrackRef()).isNonnull() ) {
-    TauGSFChi2 = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->normalizedChi2();
-    TauGSFNumHits = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->numberOfValidHits();
-    if ( thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->pt() > 0. ) {
-      TauGSFTrackResol = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->ptError()/thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->pt();
-      TauGSFTracklnPt = log(thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->pt())*M_LN10;
+  if ( (pflch->gsfTrackRef()).isNonnull() ) {
+    TauGSFChi2 = pflch->gsfTrackRef()->normalizedChi2();
+    TauGSFNumHits = pflch->gsfTrackRef()->numberOfValidHits();
+    if ( pflch->gsfTrackRef()->pt() > 0. ) {
+      TauGSFTrackResol = pflch->gsfTrackRef()->ptError()/pflch->gsfTrackRef()->pt();
+      TauGSFTracklnPt = log(pflch->gsfTrackRef()->pt())*M_LN10;
     }
-    TauGSFTrackEta = thePFTau.leadPFChargedHadrCand()->gsfTrackRef()->eta();
+    TauGSFTrackEta = pflch->gsfTrackRef()->eta();
   }
   Float_t TauPhi = thePFTau.phi();
   float sumPhiTimesEnergy = 0.;
   float sumEnergyPhi = 0.;
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
+  for ( std::vector<reco::CandidatePtr>::const_iterator pfCandidate = signalPFCands.begin();
 	pfCandidate != signalPFCands.end(); ++pfCandidate ) {
-    sumPhiTimesEnergy += (*pfCandidate)->positionAtECALEntrance().phi()*(*pfCandidate)->energy();
-    sumEnergyPhi += (*pfCandidate)->energy();
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(pfCandidate->get());
+    if (pfcand != nullptr) {
+      sumPhiTimesEnergy += pfcand->positionAtECALEntrance().phi()*pfcand->energy();
+      sumEnergyPhi += pfcand->energy();
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
   if ( sumEnergyPhi > 0. ) {
     TauPhi = sumPhiTimesEnergy/sumEnergyPhi;
@@ -951,7 +977,7 @@ double AntiElectronIDMVA5::MVAValue(const reco::PFTau& thePFTau)
   Float_t TaudCrackPhi = dCrackPhi(TauPhi,TauEtaAtEcalEntrance) ;
   Float_t TaudCrackEta = dCrackEta(TauEtaAtEcalEntrance) ;
   Float_t TauSignalPFChargedCands = thePFTau.signalPFChargedHadrCands().size();
-  Float_t TauHasGsf = thePFTau.leadPFChargedHadrCand()->gsfTrackRef().isNonnull();
+  Float_t TauHasGsf = pflch->gsfTrackRef().isNonnull();
 
   Float_t dummyElecEta = 9.9;
 

--- a/RecoTauTag/RecoTau/src/PFRecoTauAlgorithm.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauAlgorithm.cc
@@ -94,21 +94,21 @@ PFRecoTauAlgorithm::PFRecoTauAlgorithm(const edm::ParameterSet& iConfig):PFRecoT
 
 PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, const Vertex& myPV)
 {
-   PFJetRef myPFJet=(*myPFTauTagInfoRef).pfjetRef();  // catch a ref to the initial PFJet
+   JetBaseRef myPFJet=(*myPFTauTagInfoRef).pfjetRef();  // catch a ref to the initial PFJet
    PFTau myPFTau(std::numeric_limits<int>::quiet_NaN(),myPFJet->p4());   // create the PFTau
 
    myPFTau.setpfTauTagInfoRef(myPFTauTagInfoRef);
 
-   std::vector<PFCandidatePtr> myPFCands=(*myPFTauTagInfoRef).PFCands();
+   std::vector<CandidatePtr> myPFCands=(*myPFTauTagInfoRef).PFCands();
 
    PFTauElementsOperators myPFTauElementsOperators(myPFTau);
    double myMatchingConeSize=myPFTauElementsOperators.computeConeSize(myMatchingConeSizeTFormula,MatchingConeSize_min_,MatchingConeSize_max_);
 
-   PFCandidatePtr myleadPFChargedCand=myPFTauElementsOperators.leadPFChargedHadrCand(MatchingConeMetric_,myMatchingConeSize,PFTauAlgo_PFCand_minPt_);
+   CandidatePtr myleadPFChargedCand=myPFTauElementsOperators.leadPFChargedHadrCand(MatchingConeMetric_,myMatchingConeSize,PFTauAlgo_PFCand_minPt_);
 
    // These two quantities always taken from the signal cone
-   PFCandidatePtr myleadPFNeutralCand;
-   PFCandidatePtr myleadPFCand;
+   CandidatePtr myleadPFNeutralCand;
+   CandidatePtr myleadPFCand;
 
    bool myleadPFCand_rectkavailable = false;
    double myleadPFCand_rectkDZ      = 0.;
@@ -116,7 +116,10 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
    // Determine the SIPT of the lead track
    if(myleadPFChargedCand.isNonnull()) {
       myPFTau.setleadPFChargedHadrCand(myleadPFChargedCand);
-      TrackRef myleadPFCand_rectk=(*myleadPFChargedCand).trackRef();
+      const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(myleadPFChargedCand.get());
+      if (pflch == nullptr)
+        throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+      TrackRef myleadPFCand_rectk=pflch->trackRef();
       if(myleadPFCand_rectk.isNonnull()) {
          myleadPFCand_rectkavailable=true;
          myleadPFCand_rectkDZ=(*myleadPFCand_rectk).dz(myPV.position());
@@ -137,12 +140,12 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
       // Compute energy of the PFTau considering only inner constituents
       // (inner == pfcandidates inside a cone which is equal to the maximum value of the signal cone)
       // The axis is built about the lead charged hadron
-      std::vector<PFCandidatePtr> myTmpPFCandsInSignalCone =
+      std::vector<CandidatePtr> myTmpPFCandsInSignalCone =
          myPFTauElementsOperators.PFCandsInCone(tauAxis,TrackerSignalConeMetric_,TrackerSignalConeSize_max_,0.5);
       math::XYZTLorentzVector tmpLorentzVect(0.,0.,0.,0.);
 
       double jetOpeningAngle = 0.0;
-      for (std::vector<PFCandidatePtr>::const_iterator iCand = myTmpPFCandsInSignalCone.begin();
+      for (std::vector<CandidatePtr>::const_iterator iCand = myTmpPFCandsInSignalCone.begin();
             iCand != myTmpPFCandsInSignalCone.end(); iCand++)
       {
          //find the maximum opening angle of the jet (now a parameter in available TFormulas)
@@ -173,7 +176,7 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
             myHCALIsolConeSizeTFormula, HCALIsolConeSize_min_, HCALIsolConeSize_max_, transverseEnergy, energy, jetOpeningAngle);
 
       // Signal cone collections
-      std::vector<PFCandidatePtr> mySignalPFChargedHadrCands, mySignalPFNeutrHadrCands, mySignalPFGammaCands, mySignalPFCands;
+      std::vector<CandidatePtr> mySignalPFChargedHadrCands, mySignalPFNeutrHadrCands, mySignalPFGammaCands, mySignalPFCands;
 
       if (UseChargedHadrCandLeadChargedHadrCand_tksDZconstraint_ && myleadPFCand_rectkavailable) {
          mySignalPFChargedHadrCands=myPFTauElementsOperators.PFChargedHadrCandsInCone(tauAxis,
@@ -240,7 +243,7 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
       }
 
       // Declare isolation collections
-      std::vector<PFCandidatePtr> myUnfilteredIsolPFChargedHadrCands, myIsolPFNeutrHadrCands, myIsolPFGammaCands, myIsolPFCands;
+      std::vector<CandidatePtr> myUnfilteredIsolPFChargedHadrCands, myIsolPFNeutrHadrCands, myIsolPFGammaCands, myIsolPFCands;
 
       // Build unfiltered isolation collection
       if(UseChargedHadrCandLeadChargedHadrCand_tksDZconstraint_ && myleadPFCand_rectkavailable) {
@@ -255,7 +258,7 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
 
       // Filter isolation annulus charge dhadrons with additional nHits quality cut
       // (note that other cuts [pt, chi2, are already cut on])
-      std::vector<PFCandidatePtr> myIsolPFChargedHadrCands;
+      std::vector<CandidatePtr> myIsolPFChargedHadrCands;
       myIsolPFChargedHadrCands = TauTagTools::filteredPFChargedHadrCandsByNumTrkHits(
             myUnfilteredIsolPFChargedHadrCands, ChargedHadrCand_IsolAnnulus_minNhits_);
 
@@ -282,13 +285,13 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
          else
             rPhi = Rphi_;
 
-         std::pair<std::vector<PFCandidatePtr>,std::vector<PFCandidatePtr>> elementsInOutEllipse =
+         std::pair<std::vector<CandidatePtr>,std::vector<CandidatePtr>> elementsInOutEllipse =
             myPFTauElementsOperators.PFGammaCandsInOutEllipse(myIsolPFGammaCands, *myleadPFCand, rPhi, myECALSignalConeSize, MaxEtInEllipse_);
 
-         std::vector<PFCandidatePtr> elementsInEllipse = elementsInOutEllipse.first;
-         std::vector<PFCandidatePtr> elementsOutEllipse = elementsInOutEllipse.second;
+         std::vector<CandidatePtr> elementsInEllipse = elementsInOutEllipse.first;
+         std::vector<CandidatePtr> elementsOutEllipse = elementsInOutEllipse.second;
          //add the inside elements to signal PFCandidates and reset signal PFCands
-         for(std::vector<PFCandidatePtr>::const_iterator inEllipseIt = elementsInEllipse.begin(); inEllipseIt != elementsInEllipse.end(); inEllipseIt++){
+         for(std::vector<CandidatePtr>::const_iterator inEllipseIt = elementsInEllipse.begin(); inEllipseIt != elementsInEllipse.end(); inEllipseIt++){
             mySignalPFCands.push_back(*inEllipseIt);
             mySignalPFGammaCands.push_back(*inEllipseIt);
          }
@@ -322,12 +325,12 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
 
       //Making the alternateLorentzVector, i.e. direction with only signal components
       math::XYZTLorentzVector alternatLorentzVect(0.,0.,0.,0.);
-      for (std::vector<PFCandidatePtr>::const_iterator iGammaCand = mySignalPFGammaCands.begin();
+      for (std::vector<CandidatePtr>::const_iterator iGammaCand = mySignalPFGammaCands.begin();
             iGammaCand != mySignalPFGammaCands.end(); iGammaCand++) {
          alternatLorentzVect+=(**iGammaCand).p4();
       }
 
-      for (std::vector<PFCandidatePtr>::const_iterator iChargedHadrCand = mySignalPFChargedHadrCands.begin();
+      for (std::vector<CandidatePtr>::const_iterator iChargedHadrCand = mySignalPFChargedHadrCands.begin();
             iChargedHadrCand != mySignalPFChargedHadrCands.end(); iChargedHadrCand++) {
          alternatLorentzVect+=(**iChargedHadrCand).p4();
       }
@@ -336,7 +339,7 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
 
       // Optionally add the neutral hadrons to the p4
       if (putNeutralHadronsInP4_) {
-        for (std::vector<PFCandidatePtr>::const_iterator iNeutralHadrCand = mySignalPFNeutrHadrCands.begin();
+        for (std::vector<CandidatePtr>::const_iterator iNeutralHadrCand = mySignalPFNeutrHadrCands.begin();
             iNeutralHadrCand != mySignalPFNeutrHadrCands.end(); iNeutralHadrCand++) {
           alternatLorentzVect+=(**iNeutralHadrCand).p4();
         }
@@ -348,9 +351,9 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
    }
 
    // set the leading, signal cone and isolation annulus Tracks (the initial list of Tracks was catched through a JetTracksAssociation
-   // object, not through the charged hadr. PFCandidates inside the PFJet ;
+   // object, not through the charged hadr. Candidates inside the PFJet ;
    // the motivation for considering these objects is the need for checking that a selection by the
-   // charged hadr. PFCandidates is equivalent to a selection by the rec. Tracks.)
+   // charged hadr. Candidates is equivalent to a selection by the rec. Tracks.)
    TrackRef myleadTk=myPFTauElementsOperators.leadTk(MatchingConeMetric_,myMatchingConeSize,LeadTrack_minPt_);
    myPFTau.setleadTrack(myleadTk);
    if(myleadTk.isNonnull()){
@@ -391,42 +394,48 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
 
    //Use the electron rejection only in case there is a charged leading pion
    if(myleadPFChargedCand.isNonnull()){
-      myElectronPreIDOutput = myleadPFChargedCand->mva_e_pi();
+      const reco::PFCandidate* pflch = dynamic_cast<const reco::PFCandidate*>(myleadPFChargedCand.get());
+      if (pflch == nullptr)
+        throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+      myElectronPreIDOutput = pflch->mva_e_pi();
 
-      math::XYZPointF myElecTrkEcalPos = myleadPFChargedCand->positionAtECALEntrance();
-      myElecTrk = myleadPFChargedCand->trackRef();//Electron candidate
+      math::XYZPointF myElecTrkEcalPos = pflch->positionAtECALEntrance();
+      myElecTrk = pflch->trackRef();//Electron candidate
 
       if(myElecTrk.isNonnull()) {
          //FROM AOD
          if(DataType_ == "AOD"){
             // Corrected Cluster energies
             for(int i=0;i<(int)myPFCands.size();i++){
-               myHCALenergy += myPFCands[i]->hcalEnergy();
-               myECALenergy += myPFCands[i]->ecalEnergy();
+               const reco::PFCandidate* myPFCand = dynamic_cast<const reco::PFCandidate*>(myPFCands[i].get());
+               if (myPFCand == nullptr)
+                 throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+               myHCALenergy += myPFCand->hcalEnergy();
+               myECALenergy += myPFCand->ecalEnergy();
 
                math::XYZPointF candPos;
-               if (myPFCands[i]->particleId()==1 || myPFCands[i]->particleId()==2)//if charged hadron or electron
-                  candPos = myPFCands[i]->positionAtECALEntrance();
+               if (myPFCand->particleId()==1 || myPFCand->particleId()==2)//if charged hadron or electron
+                  candPos = myPFCand->positionAtECALEntrance();
                else
-                  candPos = math::XYZPointF(myPFCands[i]->px(),myPFCands[i]->py(),myPFCands[i]->pz());
+                  candPos = math::XYZPointF(myPFCand->px(),myPFCand->py(),myPFCand->pz());
 
                double deltaR   = ROOT::Math::VectorUtil::DeltaR(myElecTrkEcalPos,candPos);
                double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(myElecTrkEcalPos,candPos);
                double deltaEta = std::abs(myElecTrkEcalPos.eta()-candPos.eta());
                double deltaPhiOverQ = deltaPhi/(double)myElecTrk->charge();
 
-               if (myPFCands[i]->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
+               if (myPFCand->ecalEnergy() >= EcalStripSumE_minClusEnergy_ && deltaEta < EcalStripSumE_deltaEta_ &&
                      deltaPhiOverQ > EcalStripSumE_deltaPhiOverQ_minValue_  && deltaPhiOverQ < EcalStripSumE_deltaPhiOverQ_maxValue_) {
-                  myStripClusterE += myPFCands[i]->ecalEnergy();
+                  myStripClusterE += myPFCand->ecalEnergy();
                }
                if (deltaR<0.184) {
-                  myHCALenergy3x3 += myPFCands[i]->hcalEnergy();
+                  myHCALenergy3x3 += myPFCand->hcalEnergy();
                }
-               if (myPFCands[i]->hcalEnergy()>myMaximumHCALPFClusterE) {
-                  myMaximumHCALPFClusterE = myPFCands[i]->hcalEnergy();
+               if (myPFCand->hcalEnergy()>myMaximumHCALPFClusterE) {
+                  myMaximumHCALPFClusterE = myPFCand->hcalEnergy();
                }
-               if ((myPFCands[i]->hcalEnergy()*fabs(sin(candPos.Theta())))>myMaximumHCALPFClusterEt) {
-                  myMaximumHCALPFClusterEt = (myPFCands[i]->hcalEnergy()*fabs(sin(candPos.Theta())));
+               if ((myPFCand->hcalEnergy()*fabs(sin(candPos.Theta())))>myMaximumHCALPFClusterEt) {
+                  myMaximumHCALPFClusterEt = (myPFCand->hcalEnergy()*fabs(sin(candPos.Theta())));
                }
             }
 
@@ -435,7 +444,10 @@ PFTau PFRecoTauAlgorithm::buildPFTau(const PFTauTagInfoRef& myPFTauTagInfoRef, c
             std::vector<math::XYZPoint> hcalPosV; hcalPosV.clear();
             std::vector<math::XYZPoint> ecalPosV; ecalPosV.clear();
             for(int i=0;i<(int)myPFCands.size();i++){
-               const ElementsInBlocks& elts = myPFCands[i]->elementsInBlocks();
+               const reco::PFCandidate* myPFCand = dynamic_cast<const reco::PFCandidate*>(myPFCands[i].get());
+               if (myPFCand == nullptr)
+                 throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+               const ElementsInBlocks& elts = myPFCand->elementsInBlocks();
                for(ElementsInBlocks::const_iterator it=elts.begin(); it!=elts.end(); ++it) {
                   const reco::PFBlock& block = *(it->first);
                   unsigned indexOfElementInBlock = it->second;

--- a/RecoTauTag/RecoTau/src/PFRecoTauTagInfoAlgorithm.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauTagInfoAlgorithm.cc
@@ -26,11 +26,11 @@ PFRecoTauTagInfoAlgorithm::PFRecoTauTagInfoAlgorithm(const edm::ParameterSet& pa
   tkPVmaxDZ_                          = parameters.getParameter<double>("tkPVmaxDZ");
 }
 
-PFTauTagInfo PFRecoTauTagInfoAlgorithm::buildPFTauTagInfo(const PFJetRef& thePFJet,const std::vector<reco::PFCandidatePtr>& thePFCandsInEvent, const TrackRefVector& theTracks,const Vertex& thePV) const {
+PFTauTagInfo PFRecoTauTagInfoAlgorithm::buildPFTauTagInfo(const JetBaseRef& thePFJet,const std::vector<reco::CandidatePtr>& thePFCandsInEvent, const TrackRefVector& theTracks,const Vertex& thePV) const {
   PFTauTagInfo resultExtended;
   resultExtended.setpfjetRef(thePFJet);
 
-  std::vector<reco::PFCandidatePtr> thePFCands;
+  std::vector<reco::CandidatePtr> thePFCands;
   const float jetPhi = (*thePFJet).phi();
   const float jetEta = (*thePFJet).eta();
   auto dr2 = [jetPhi,jetEta](float phi, float eta) { return reco::deltaR2(jetEta,jetPhi,eta,phi);};
@@ -40,7 +40,7 @@ PFTauTagInfo PFRecoTauTagInfoAlgorithm::buildPFTauTagInfo(const PFJetRef& thePFJ
   }
   bool pvIsFake = (thePV.z() < -500.);
 
-  std::vector<reco::PFCandidatePtr> theFilteredPFChargedHadrCands;
+  std::vector<reco::CandidatePtr> theFilteredPFChargedHadrCands;
   if (UsePVconstraint_ && !pvIsFake) theFilteredPFChargedHadrCands=TauTagTools::filteredPFChargedHadrCands(thePFCands,ChargedHadrCand_tkminPt_,ChargedHadrCand_tkminPixelHitsn_,ChargedHadrCand_tkminTrackerHitsn_,ChargedHadrCand_tkmaxipt_,ChargedHadrCand_tkmaxChi2_,ChargedHadrCand_tkPVmaxDZ_, thePV, thePV.z());
   else theFilteredPFChargedHadrCands=TauTagTools::filteredPFChargedHadrCands(thePFCands,ChargedHadrCand_tkminPt_,ChargedHadrCand_tkminPixelHitsn_,ChargedHadrCand_tkminTrackerHitsn_,ChargedHadrCand_tkmaxipt_,ChargedHadrCand_tkmaxChi2_, thePV);
   resultExtended.setPFChargedHadrCands(theFilteredPFChargedHadrCands);

--- a/RecoTauTag/RecoTau/src/RecoTauBinnedIsolationPlugin.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauBinnedIsolationPlugin.cc
@@ -1,7 +1,7 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauBinnedIsolationPlugin.h"
 #include <boost/foreach.hpp>
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
@@ -73,9 +73,9 @@ std::vector<double> RecoTauDiscriminationBinnedIsolation::operator()(
   // Create our output spectrum
   std::vector<double> output(bins->size(), 0.0);
   // Get the desired isolation objects
-  std::vector<reco::PFCandidatePtr> isoObjects = extractIsoObjects(tau);
+  std::vector<reco::CandidatePtr> isoObjects = extractIsoObjects(tau);
   // Loop over each and histogram their pt
-  BOOST_FOREACH(const reco::PFCandidatePtr& cand, isoObjects) {
+  BOOST_FOREACH(const reco::CandidatePtr& cand, isoObjects) {
     int highestBinLessThan = -1;
     for (size_t ibin = 0; ibin < bins->size(); ++ibin) {
       if (cand->pt() > bins->at(ibin)) {

--- a/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
@@ -15,6 +15,22 @@ typedef CandPtrs::iterator CandIter;
 
 namespace reco { namespace tau {
 
+namespace {
+  // Re-implemented from PFCandidate.cc
+  int translateTypeToAbsPdgId(int type) {
+    switch( type ) {
+    case reco::PFCandidate::h:     return 211; // pi+
+    case reco::PFCandidate::e:     return 11;
+    case reco::PFCandidate::mu:    return 13;
+    case reco::PFCandidate::gamma: return 22;
+    case reco::PFCandidate::h0:    return 130; // K_L0
+    case reco::PFCandidate::h_HF:         return 1; // dummy pdg code 
+    case reco::PFCandidate::egamma_HF:    return 2;  // dummy pdg code
+    case reco::PFCandidate::X: 
+    default:    return 0;  
+    }
+  }
+}
 std::vector<CandidatePtr>
 flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator& piZerosBegin, const std::vector<RecoTauPiZero>::const_iterator& piZerosEnd) {
   std::vector<CandidatePtr> output;
@@ -35,6 +51,20 @@ flattenPiZeros(const std::vector<RecoTauPiZero>& piZeros) {
 }
 
 std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet,
+    int particleId, bool sort) {
+  return pfCandidatesByPdgId(jet, translateTypeToAbsPdgId(particleId), sort);
+}
+
+std::vector<CandidatePtr> pfCandidates(const Jet& jet,
+                                         const std::vector<int>& particleIds,
+                                         bool sort) {
+  std::vector<int> pdgIds;
+  for (auto particleId : particleIds)
+    pdgIds.push_back(translateTypeToAbsPdgId(particleId));
+  return pfCandidatesByPdgId(jet, pdgIds, sort);
+}
+
+std::vector<reco::CandidatePtr> pfCandidatesByPdgId(const reco::Jet& jet,
     int pdgId, bool sort) {
   CandPtrs pfCands = jet.daughterPtrVector();
   CandPtrs selectedPFCands = filterPFCandidates(
@@ -42,7 +72,7 @@ std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet,
   return selectedPFCands;
 }
 
-std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet,
+std::vector<reco::CandidatePtr> pfCandidatesByPdgId(const reco::Jet& jet,
     const std::vector<int>& pdgIds, bool sort) {
   const CandPtrs& pfCands = jet.daughterPtrVector();
   CandPtrs output;

--- a/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
@@ -73,4 +73,29 @@ std::vector<reco::CandidatePtr> pfChargedCands(const reco::Jet& jet,
   return output;
 }
 
+math::XYZPoint atECALEntrance(const reco::Candidate* part) {
+  const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate>(part);
+  if (pfCand)
+    return pfCand->positionAtECALEntrance();
+
+  math::XYZPoint pos;
+  BaseParticlePropagator theParticle =
+    BaseParticlePropagator(RawParticle(math::XYZTLorentzVector(part->px(),
+                     part->py(),
+                     part->pz(),
+                     part->energy()),
+               math::XYZTLorentzVector(part->vertex().x(),
+                     part->vertex().y(),
+                     part->vertex().z(),
+                     0.)), 
+         0.,0.,bField_);
+  theParticle.setCharge(part->charge());
+  theParticle.propagateToEcalEntrance(false);
+  if(theParticle.getSuccess()!=0){
+    pos = math::XYZPoint(theParticle.vertex());
+  }
+  return pos;
+}
+
+
 } }

--- a/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
@@ -1,69 +1,70 @@
 #include "RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h"
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/CandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/Candidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 #include <algorithm>
 
-typedef std::vector<reco::PFCandidatePtr> PFCandPtrs;
-typedef PFCandPtrs::iterator PFCandIter;
+typedef std::vector<reco::CandidatePtr> CandPtrs;
+typedef CandPtrs::iterator CandIter;
 
 namespace reco { namespace tau {
 
-std::vector<PFCandidatePtr>
+std::vector<CandidatePtr>
 flattenPiZeros(const std::vector<RecoTauPiZero>::const_iterator& piZerosBegin, const std::vector<RecoTauPiZero>::const_iterator& piZerosEnd) {
-  std::vector<PFCandidatePtr> output;
+  std::vector<CandidatePtr> output;
 
   for(std::vector<RecoTauPiZero>::const_iterator piZero = piZerosBegin;
       piZero != piZerosEnd; ++piZero) {
     for(size_t iDaughter = 0; iDaughter < piZero->numberOfDaughters();
         ++iDaughter) {
-      output.push_back(PFCandidatePtr(piZero->daughterPtr(iDaughter)));
+      output.push_back(CandidatePtr(piZero->daughterPtr(iDaughter)));
     }
   }
   return output;
 }
 
-std::vector<PFCandidatePtr>
+std::vector<CandidatePtr>
 flattenPiZeros(const std::vector<RecoTauPiZero>& piZeros) {
   return flattenPiZeros(piZeros.begin(), piZeros.end()); 
 }
 
-std::vector<reco::PFCandidatePtr> pfCandidates(const reco::PFJet& jet,
-    int particleId, bool sort) {
-  PFCandPtrs pfCands = jet.getPFConstituents();
-  PFCandPtrs selectedPFCands = filterPFCandidates(
-      pfCands.begin(), pfCands.end(), particleId, sort);
+std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet,
+    int pdgId, bool sort) {
+  CandPtrs pfCands = jet.getPFConstituents();
+  CandPtrs selectedPFCands = filterPFCandidates(
+      pfCands.begin(), pfCands.end(), pdgId, sort);
   return selectedPFCands;
 }
 
-std::vector<reco::PFCandidatePtr> pfCandidates(const reco::PFJet& jet,
-    const std::vector<int>& particleIds, bool sort) {
-  PFCandPtrs&& pfCands = jet.getPFConstituents();
-  PFCandPtrs output;
+std::vector<reco::CandidatePtr> pfCandidates(const reco::Jet& jet,
+    const std::vector<int>& pdgIds, bool sort) {
+  CandPtrs&& pfCands = jet.getPFConstituents();
+  CandPtrs output;
   // Get each desired candidate type, unsorted for now
-  for(std::vector<int>::const_iterator particleId = particleIds.begin();
-      particleId != particleIds.end(); ++particleId) {
-    PFCandPtrs&& selectedPFCands = filterPFCandidates(pfCands.begin(), pfCands.end(), *particleId, false);
+  for(std::vector<int>::const_iterator pdgId = pdgIds.begin();
+      pdgId != pdgIds.end(); ++pdgId) {
+    CandPtrs&& selectedPFCands = filterPFCandidates(pfCands.begin(), pfCands.end(), *pdgId, false);
     output.insert(output.end(), selectedPFCands.begin(), selectedPFCands.end());
   }
   if (sort) std::sort(output.begin(), output.end(), SortPFCandsDescendingPt());
   return output;
 }
 
-std::vector<reco::PFCandidatePtr> pfGammas(const reco::PFJet& jet, bool sort) {
-  return pfCandidates(jet, reco::PFCandidate::gamma, sort);
+std::vector<reco::CandidatePtr> pfGammas(const reco::Jet& jet, bool sort) {
+  return pfCandidates(jet, 22, sort);
 }
 
-std::vector<reco::PFCandidatePtr> pfChargedCands(const reco::PFJet& jet,
+std::vector<reco::CandidatePtr> pfChargedCands(const reco::Jet& jet,
                                                  bool sort) {
-  PFCandPtrs&& pfCands = jet.getPFConstituents();
-  PFCandPtrs output;
-  PFCandPtrs&& mus = filterPFCandidates(pfCands.begin(), pfCands.end(), reco::PFCandidate::mu, false);
-  PFCandPtrs&& es = filterPFCandidates(pfCands.begin(), pfCands.end(), reco::PFCandidate::e, false);
-  PFCandPtrs&& chs = filterPFCandidates(pfCands.begin(), pfCands.end(), reco::PFCandidate::h, false);
+  CandPtrs&& pfCands = jet.getPFConstituents();
+  CandPtrs output;
+  CandPtrs&& mus = filterPFCandidates(pfCands.begin(), pfCands.end(), 13, false);
+  CandPtrs&& es = filterPFCandidates(pfCands.begin(), pfCands.end(), 11, false);
+  CandPtrs&& chs = filterPFCandidates(pfCands.begin(), pfCands.end(), 211, false);
   output.reserve(mus.size() + es.size() + chs.size());
   output.insert(output.end(), mus.begin(), mus.end());
   output.insert(output.end(), es.begin(), es.end());

--- a/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauCommonUtilities.cc
@@ -105,24 +105,6 @@ std::vector<reco::CandidatePtr> pfChargedCands(const reco::Jet& jet,
   return output;
 }
 
-std::vector<PFCandidatePtr> convertPtrVectorToPF(const std::vector<CandidatePtr>& cands) {
-  std::vector<PFCandidatePtr> newSignalPFCands;
-  for (auto& cand : cands) {
-    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::PFCandidate> >();
-    newSignalPFCands.push_back(newPtr);
-  }
-  return std::move(newSignalPFCands);
-}
-
-std::vector<CandidatePtr> convertPtrVector(const std::vector<PFCandidatePtr>& cands) {
-  std::vector<CandidatePtr> newSignalCands;
-  for (auto& cand : cands) {
-    const auto& newPtr = cand->masterClone().castTo<edm::Ptr<reco::Candidate> >();
-    newSignalCands.push_back(newPtr);
-  }
-  return std::move(newSignalCands);
-}
-
 math::XYZPointF atECALEntrance(const reco::Candidate* part, double bField) {
   const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(part);
   if (pfCand)

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -12,7 +12,7 @@
 
 namespace reco { namespace tau {
 
-RecoTauConstructor::RecoTauConstructor(const JetBaseRef& jet, const edm::Handle<PFCandidateCollection>& pfCands, 
+RecoTauConstructor::RecoTauConstructor(const JetBaseRef& jet, const edm::Handle<edm::View<reco::Candidate> >& pfCands, 
 				       bool copyGammasFromPiZeros,
 				       const StringObjectFunction<reco::PFTau>* signalConeSize,
 				       double minAbsPhotonSumPt_insideSignalCone, double minRelPhotonSumPt_insideSignalCone,
@@ -55,25 +55,25 @@ RecoTauConstructor::RecoTauConstructor(const JetBaseRef& jet, const edm::Handle<
         new SortedListPtr::element_type);
   }
 
-  tau_->setjetRef(jet.castTo<reco::PFJetRef>());
+  tau_->setjetRef(jet);
 }
 
-void RecoTauConstructor::addPFCand(Region region, ParticleType type, const PFCandidateRef& ref, bool skipAddToP4) {
-  LogDebug("TauConstructorAddPFCand") << " region = " << region << ", type = " << type << ": Pt = " << ref->pt() << ", eta = " << ref->eta() << ", phi = " << ref->phi();
-  if ( region == kSignal ) {
-    // Keep track of the four vector of the signal vector products added so far.
-    // If a photon add it if we are not using PiZeros to build the gammas
-    if ( ((type != kGamma) || !copyGammas_) && !skipAddToP4 ) {
-      LogDebug("TauConstructorAddPFCand") << "--> adding PFCand to tauP4." ;
-      p4_ += ref->p4();
-    }
-  }
-  getSortedCollection(region, type)->push_back(edm::refToPtr<PFCandidateCollection>(ref));
-  // Add to global collection
-  getSortedCollection(region, kAll)->push_back(edm::refToPtr<PFCandidateCollection>(ref));
-}
+// void RecoTauConstructor::addPFCand(Region region, ParticleType type, const CandidateRef& ref, bool skipAddToP4) {
+//   LogDebug("TauConstructorAddPFCand") << " region = " << region << ", type = " << type << ": Pt = " << ref->pt() << ", eta = " << ref->eta() << ", phi = " << ref->phi();
+//   if ( region == kSignal ) {
+//     // Keep track of the four vector of the signal vector products added so far.
+//     // If a photon add it if we are not using PiZeros to build the gammas
+//     if ( ((type != kGamma) || !copyGammas_) && !skipAddToP4 ) {
+//       LogDebug("TauConstructorAddPFCand") << "--> adding PFCand to tauP4." ;
+//       p4_ += ref->p4();
+//     }
+//   }
+//   getSortedCollection(region, type)->push_back(edm::refToPtr<PFCandidateCollection>(ref));
+//   // Add to global collection
+//   getSortedCollection(region, kAll)->push_back(edm::refToPtr<PFCandidateCollection>(ref));
+// }
 
-void RecoTauConstructor::addPFCand(Region region, ParticleType type, const PFCandidatePtr& ptr, bool skipAddToP4) {
+void RecoTauConstructor::addPFCand(Region region, ParticleType type, const CandidatePtr& ptr, bool skipAddToP4) {
   LogDebug("TauConstructorAddPFCand") << " region = " << region << ", type = " << type << ": Pt = " << ptr->pt() << ", eta = " << ptr->eta() << ", phi = " << ptr->phi();
   if ( region == kSignal ) {
     // Keep track of the four vector of the signal vector products added so far.
@@ -111,10 +111,10 @@ void RecoTauConstructor::reserveTauChargedHadron(Region region, size_t size)
 
 namespace
 {
-  void checkOverlap(const CandidatePtr& neutral, const std::vector<PFCandidatePtr>& pfGammas, bool& isUnique)
+  void checkOverlap(const CandidatePtr& neutral, const std::vector<CandidatePtr>& pfGammas, bool& isUnique)
   {
     LogDebug("TauConstructorCheckOverlap") << " pfGammas: #entries = " << pfGammas.size();
-    for ( std::vector<PFCandidatePtr>::const_iterator pfGamma = pfGammas.begin();
+    for ( std::vector<CandidatePtr>::const_iterator pfGamma = pfGammas.begin();
 	  pfGamma != pfGammas.end(); ++pfGamma ) {
       LogDebug("TauConstructorCheckOverlap") << "pfGamma = " << pfGamma->id() << ":" << pfGamma->key();
       // JAN - FIXME - double-check that id() equality is fine!
@@ -225,7 +225,7 @@ void RecoTauConstructor::addPiZero(Region region, const RecoTauPiZero& piZero)
   }
 }
 
-std::vector<PFCandidatePtr>*
+std::vector<CandidatePtr>*
 RecoTauConstructor::getCollection(Region region, ParticleType type) {
     return collections_[std::make_pair(region, type)];
 }
@@ -236,8 +236,8 @@ RecoTauConstructor::getSortedCollection(Region region, ParticleType type) {
 }
 
 // Trivial converter needed for polymorphism
-PFCandidatePtr RecoTauConstructor::convertToPtr(
-    const PFCandidatePtr& pfPtr) const {
+CandidatePtr RecoTauConstructor::convertToPtr(
+    const CandidatePtr& pfPtr) const {
   return pfPtr;
 }
 
@@ -254,20 +254,20 @@ void checkMatchedProductIds(const T1& t1, const T2& t2) {
 }
 }
 
-PFCandidatePtr RecoTauConstructor::convertToPtr(
-    const PFCandidateRef& pfRef) const {
-  if(pfRef.isNonnull()) {
-    checkMatchedProductIds(pfRef, pfCands_);
-    return PFCandidatePtr(pfCands_, pfRef.key());
-  } else return PFCandidatePtr();
-}
+// PFCandidatePtr RecoTauConstructor::convertToPtr(
+//     const PFCandidateRef& pfRef) const {
+//   if(pfRef.isNonnull()) {
+//     checkMatchedProductIds(pfRef, pfCands_);
+//     return PFCandidatePtr(pfCands_, pfRef.key());
+//   } else return PFCandidatePtr();
+// }
 
 // Convert from a CandidateRef to a Ptr
-PFCandidatePtr RecoTauConstructor::convertToPtr(
-    const CandidatePtr& candPtr) const {
+CandidatePtr RecoTauConstructor::convertToPtr(
+    const PFCandidatePtr& candPtr) const {
   if(candPtr.isNonnull()) {
     checkMatchedProductIds(candPtr, pfCands_);
-    return PFCandidatePtr(pfCands_, candPtr.key());
+    return CandidatePtr(pfCands_, candPtr.key());
   } else return PFCandidatePtr();
 }
 
@@ -301,9 +301,9 @@ void RecoTauConstructor::sortAndCopyIntoTau() {
     SortedListPtr sortedCollection = sortedCollections_[colkey.first];
     std::sort(sortedCollection->begin(),
               sortedCollection->end(),
-              ptDescendingPtr<PFCandidatePtr>);
+              ptDescendingPtr<CandidatePtr>);
     // Copy into the real tau collection
-    for ( std::vector<PFCandidatePtr>::const_iterator particle = sortedCollection->begin();
+    for ( std::vector<CandidatePtr>::const_iterator particle = sortedCollection->begin();
 	  particle != sortedCollection->end(); ++particle ) {
       colkey.second->push_back(*particle);
     }
@@ -422,7 +422,7 @@ std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects)
           getCollection(kSignal, kGamma)->end()) / tau_->pt());
 
   if ( setupLeadingObjects ) {
-    typedef std::vector<PFCandidatePtr>::const_iterator Iter;
+    typedef std::vector<CandidatePtr>::const_iterator Iter;
     // Find the highest PT object in the signal cone
     Iter leadingCand = leadPFCand(
         getCollection(kSignal, kAll)->begin(),

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -117,8 +117,6 @@ namespace
     for ( std::vector<CandidatePtr>::const_iterator pfGamma = pfGammas.begin();
 	  pfGamma != pfGammas.end(); ++pfGamma ) {
       LogDebug("TauConstructorCheckOverlap") << "pfGamma = " << pfGamma->id() << ":" << pfGamma->key();
-      // JAN - FIXME - double-check that id() equality is fine!
-      // lhs.refCore() == rhs.refCore() && lhs.key() == rhs.key() ???
       if ( (*pfGamma).refCore() == neutral.refCore() && (*pfGamma).key() == neutral.key() ) isUnique = false;
     }
   }

--- a/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauDiscriminantFunctions.cc
@@ -2,8 +2,8 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/angle.h"
 #include <algorithm>
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include <boost/foreach.hpp>
 
@@ -12,7 +12,7 @@ namespace reco { namespace tau { namespace disc {
 // Helper functions
 namespace {
 
-const PFCandidate& removeRef(const PFCandidatePtr& pfRef) {
+const Candidate& removeRef(const CandidatePtr& pfRef) {
   return *pfRef;
 }
 
@@ -46,7 +46,7 @@ class DeltaRToAxis {
 
 } // end helper functions
 
-PFCandidatePtr mainTrack(Tau tau) {
+CandidatePtr mainTrack(Tau tau) {
   if (tau.signalPFChargedHadrCands().size() ==  3) {
     for (size_t itrk = 0; itrk < 3; ++itrk) {
       if (tau.signalPFChargedHadrCands()[itrk]->charge() * tau.charge() < 0)
@@ -56,12 +56,12 @@ PFCandidatePtr mainTrack(Tau tau) {
   return tau.leadPFChargedHadrCand();
 }
 
-std::vector<PFCandidatePtr> notMainTrack(Tau tau)
+std::vector<CandidatePtr> notMainTrack(Tau tau)
 {
-  const PFCandidatePtr& mainTrackPtr = mainTrack(tau);
-  std::vector<PFCandidatePtr> output;
+  const CandidatePtr& mainTrackPtr = mainTrack(tau);
+  std::vector<CandidatePtr> output;
   output.reserve(tau.signalPFChargedHadrCands().size() - 1);
-  BOOST_FOREACH(const PFCandidatePtr& ptr, tau.signalPFChargedHadrCands()) {
+  BOOST_FOREACH(const CandidatePtr& ptr, tau.signalPFChargedHadrCands()) {
     if (ptr != mainTrackPtr)
       output.push_back(ptr);
   }
@@ -115,7 +115,7 @@ double IsolationECALPtFraction(Tau tau) {
 
 double IsolationNeutralHadronPtFraction(Tau tau) {
   double sum = 0.0;
-  BOOST_FOREACH(PFCandidatePtr cand, tau.isolationPFNeutrHadrCands()) {
+  BOOST_FOREACH(CandidatePtr cand, tau.isolationPFNeutrHadrCands()) {
     sum += cand->pt();
   }
   return sum/tau.jetRef()->pt();
@@ -129,7 +129,7 @@ double ScaledEtaJetCollimation(Tau tau) {
 double OpeningDeltaR(Tau tau) {
   double sumEt = 0;
   double weightedDeltaR = 0;
-  BOOST_FOREACH(const reco::PFCandidatePtr& cand, tau.signalPFCands()) {
+  BOOST_FOREACH(const reco::CandidatePtr& cand, tau.signalPFCands()) {
     double candEt = cand->et();
     double candDeltaR = reco::deltaR(cand->p4(), tau.p4());
     sumEt += candEt;
@@ -141,7 +141,7 @@ double OpeningDeltaR(Tau tau) {
 double OpeningAngle3D(Tau tau) {
   double sumE = 0;
   double weightedAngle = 0;
-  BOOST_FOREACH(const reco::PFCandidatePtr& cand, tau.signalPFCands()) {
+  BOOST_FOREACH(const reco::CandidatePtr& cand, tau.signalPFCands()) {
     double candE = cand->energy();
     double candAngle = angle(cand->p4(), tau.p4());
     sumE += candE;
@@ -152,7 +152,7 @@ double OpeningAngle3D(Tau tau) {
 
 double ScaledOpeningDeltaR(Tau tau) {
   double max = 0.0;
-  const std::vector<PFCandidatePtr>& cands = tau.signalPFCands();
+  const std::vector<CandidatePtr>& cands = tau.signalPFCands();
   for (size_t i = 0; i < cands.size()-1; ++i) {
     for (size_t j = i+1; j < cands.size(); ++j) {
       double deltaRVal = deltaR(cands[i]->p4(), cands[j]->p4());
@@ -185,13 +185,13 @@ double MainTrackPtFraction(Tau tau) {
 }
 
 VDouble Dalitz2(Tau tau) {
-  PFCandidatePtr theMainTrack = mainTrack(tau);
-  std::vector<PFCandidatePtr> otherSignalTracks = notMainTrack(tau);
+  CandidatePtr theMainTrack = mainTrack(tau);
+  std::vector<CandidatePtr> otherSignalTracks = notMainTrack(tau);
   const std::vector<RecoTauPiZero> &pizeros = tau.signalPiZeroCandidates();
   VDouble output;
   output.reserve(otherSignalTracks.size() + pizeros.size());
   // Add combos with tracks
-  BOOST_FOREACH(PFCandidatePtr trk, otherSignalTracks) {
+  BOOST_FOREACH(CandidatePtr trk, otherSignalTracks) {
     reco::Candidate::LorentzVector p4 = theMainTrack->p4() + trk->p4();
     output.push_back(p4.mass());
   }
@@ -205,7 +205,7 @@ VDouble Dalitz2(Tau tau) {
 
 double IsolationChargedSumHard(Tau tau) {
   VDouble isocands = extract(tau.isolationPFChargedHadrCands(),
-                             std::mem_fun_ref(&PFCandidate::pt));
+                             std::mem_fun_ref(&Candidate::pt));
   double output = 0.0;
   BOOST_FOREACH(double pt, isocands) {
     if (pt > 1.0)
@@ -216,7 +216,7 @@ double IsolationChargedSumHard(Tau tau) {
 
 double IsolationChargedSumSoft(Tau tau) {
   VDouble isocands = extract(tau.isolationPFChargedHadrCands(),
-                             std::mem_fun_ref(&PFCandidate::pt));
+                             std::mem_fun_ref(&Candidate::pt));
   double output = 0.0;
   BOOST_FOREACH(double pt, isocands) {
     if (pt < 1.0)
@@ -236,7 +236,7 @@ double IsolationChargedSumSoftRelative(Tau tau) {
 
 double IsolationECALSumHard(Tau tau) {
   VDouble isocands = extract(tau.isolationPFGammaCands(),
-                             std::mem_fun_ref(&PFCandidate::pt));
+                             std::mem_fun_ref(&Candidate::pt));
   double output = 0.0;
   BOOST_FOREACH(double pt, isocands) {
     if (pt > 1.5)
@@ -247,7 +247,7 @@ double IsolationECALSumHard(Tau tau) {
 
 double IsolationECALSumSoft(Tau tau) {
   VDouble isocands = extract(tau.isolationPFGammaCands(),
-                             std::mem_fun_ref(&PFCandidate::pt));
+                             std::mem_fun_ref(&Candidate::pt));
   double output = 0.0;
   BOOST_FOREACH(double pt, isocands) {
     if (pt < 1.5)
@@ -267,7 +267,7 @@ double IsolationECALSumSoftRelative(Tau tau) {
 double EMFraction(Tau tau) {
   //double result = tau.emFraction();
   reco::Candidate::LorentzVector gammaP4;
-  BOOST_FOREACH(const reco::PFCandidatePtr& gamma, tau.signalPFGammaCands()) {
+  BOOST_FOREACH(const reco::CandidatePtr& gamma, tau.signalPFGammaCands()) {
     gammaP4 += gamma->p4();
   }
   double result = gammaP4.pt()/tau.pt();
@@ -276,12 +276,12 @@ double EMFraction(Tau tau) {
     LogDebug("TauDiscFunctions") << "EM fraction = " << result
       << tau ;
       LogDebug("TauDiscFunctions") << "charged" ;
-    BOOST_FOREACH(const reco::PFCandidatePtr cand, tau.signalPFChargedHadrCands()) {
-      LogDebug("TauDiscFunctions") << " pt: " << cand->pt() << " type: " << cand->particleId() <<  " key: " << cand.key() ;
+    BOOST_FOREACH(const reco::CandidatePtr cand, tau.signalPFChargedHadrCands()) {
+      LogDebug("TauDiscFunctions") << " pt: " << cand->pt() << " pdgId: " << cand->pdgId() <<  " key: " << cand.key() ;
     }
     LogDebug("TauDiscFunctions") << "gammas" ;
-    BOOST_FOREACH(const reco::PFCandidatePtr cand, tau.signalPFGammaCands()) {
-      LogDebug("TauDiscFunctions") << " pt: " << cand->pt() << " type: " << cand->particleId() <<  " key: " << cand.key() ;
+    BOOST_FOREACH(const reco::CandidatePtr cand, tau.signalPFGammaCands()) {
+      LogDebug("TauDiscFunctions") << " pt: " << cand->pt() << " pdgId: " << cand->pdgId() <<  " key: " << cand.key() ;
     }
   }
   return result;
@@ -301,17 +301,17 @@ double OutlierNCharged(Tau tau) {
 }
 
 double MainTrackPt(Tau tau) {
-  PFCandidatePtr trk = mainTrack(tau);
+  CandidatePtr trk = mainTrack(tau);
   return (!trk) ? 0.0 : trk->pt();
 }
 
 double MainTrackEta(Tau tau) {
-  PFCandidatePtr trk = mainTrack(tau);
+  CandidatePtr trk = mainTrack(tau);
   return (!trk) ? 0.0 : trk->eta();
 }
 
 double MainTrackAngle(Tau tau) {
-  PFCandidatePtr trk = mainTrack(tau);
+  CandidatePtr trk = mainTrack(tau);
   return (!trk) ? 0.0 : deltaR(trk->p4(), tau.p4());
 }
 
@@ -330,11 +330,11 @@ double NeutralOutlierSumPt(Tau tau) {
 
 // Quantities associated to tracks - that are not the main track
 VDouble TrackPt(Tau tau) {
-  return extract(notMainTrack(tau), std::mem_fun_ref(&PFCandidate::pt));
+  return extract(notMainTrack(tau), std::mem_fun_ref(&Candidate::pt));
 }
 
 VDouble TrackEta(Tau tau) {
-  return extract(notMainTrack(tau), std::mem_fun_ref(&PFCandidate::eta));
+  return extract(notMainTrack(tau), std::mem_fun_ref(&Candidate::eta));
 }
 
 VDouble TrackAngle(Tau tau) {
@@ -356,7 +356,7 @@ VDouble PiZeroAngle(Tau tau) {
 
 // Isolation quantities
 VDouble OutlierPt(Tau tau) {
-  return extract(tau.isolationPFCands(), std::mem_fun_ref(&PFCandidate::pt));
+  return extract(tau.isolationPFCands(), std::mem_fun_ref(&Candidate::pt));
 }
 
 VDouble OutlierAngle(Tau tau) {
@@ -365,7 +365,7 @@ VDouble OutlierAngle(Tau tau) {
 
 VDouble ChargedOutlierPt(Tau tau) {
   return extract(tau.isolationPFChargedHadrCands(),
-                 std::mem_fun_ref(&PFCandidate::pt));
+                 std::mem_fun_ref(&Candidate::pt));
 }
 
 VDouble ChargedOutlierAngle(Tau tau) {
@@ -374,7 +374,7 @@ VDouble ChargedOutlierAngle(Tau tau) {
 
 VDouble NeutralOutlierPt(Tau tau) {
   return extract(tau.isolationPFGammaCands(),
-                 std::mem_fun_ref(&PFCandidate::pt));
+                 std::mem_fun_ref(&Candidate::pt));
 }
 
 VDouble NeutralOutlierAngle(Tau tau) {

--- a/RecoTauTag/RecoTau/src/RecoTauIsolationMasking.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauIsolationMasking.cc
@@ -32,11 +32,11 @@ class PtSorter {
 // Check if an object is within DR of a track collection
 class MultiTrackDRFilter {
   public:
-  MultiTrackDRFilter(double deltaR, const std::vector<reco::PFCandidatePtr>& trks)
+  MultiTrackDRFilter(double deltaR, const std::vector<reco::CandidatePtr>& trks)
       :deltaR_(deltaR),tracks_(trks){}
     template <typename T>
     bool operator()(const T& t) const {
-      BOOST_FOREACH(const reco::PFCandidatePtr& trk, tracks_) {
+      BOOST_FOREACH(const reco::CandidatePtr& trk, tracks_) {
         if (reco::deltaR(trk->p4(), t->p4()) < deltaR_)
           return true;
       }
@@ -44,7 +44,7 @@ class MultiTrackDRFilter {
     }
   private:
     double deltaR_;
-  const std::vector<reco::PFCandidatePtr>& tracks_;
+  const std::vector<reco::CandidatePtr>& tracks_;
 };
 
 double square(double x) { return x*x; }
@@ -75,7 +75,7 @@ RecoTauIsolationMasking::IsoMaskResult
 RecoTauIsolationMasking::mask(const reco::PFTau& tau) const {
   IsoMaskResult output;
 
-  typedef std::list<reco::PFCandidatePtr> PFCandList;
+  typedef std::list<reco::CandidatePtr> CandList;
   // Copy original iso collections.
   std::copy(tau.isolationPFGammaCands().begin(),
       tau.isolationPFGammaCands().end(), std::back_inserter(output.gammas));
@@ -83,12 +83,15 @@ RecoTauIsolationMasking::mask(const reco::PFTau& tau) const {
       tau.isolationPFNeutrHadrCands().end(),
       std::back_inserter(output.h0s));
 
-  std::vector<PFCandList*> courses;
+  std::vector<CandList*> courses;
   courses.push_back(&(output.h0s));
   courses.push_back(&(output.gammas));
   // Mask using each one of the tracks
-  BOOST_FOREACH(const reco::PFCandidatePtr& track,
+  BOOST_FOREACH(const reco::CandidatePtr& c_track,
       tau.signalPFChargedHadrCands()) {
+    const reco::PFCandidate* track = dynamic_cast<const reco::PFCandidate*>(c_track.get());
+    if (track == nullptr)
+      throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
     double trackerEnergy = track->energy();
     double linkedEcalEnergy = track->ecalEnergy();
     double linkedHcalEnergy = track->hcalEnergy();
@@ -108,14 +111,14 @@ RecoTauIsolationMasking::mask(const reco::PFTau& tau) const {
     //DRSorter sorter(track->p4());
     PtSorter sorter;
 
-    BOOST_FOREACH(PFCandList* course, courses) {
+    BOOST_FOREACH(CandList* course, courses) {
       // Sort by deltaR to the current track
       course->sort(sorter);
-      PFCandList::iterator toEatIter = course->begin();
+      CandList::iterator toEatIter = course->begin();
       // While there are still candidates to eat in this course and they are
       // within the cone.
       while (toEatIter != course->end()) {
-        const reco::PFCandidate& toEat = **toEatIter;
+        const reco::Candidate& toEat = **toEatIter;
         double toEatEnergy = toEat.energy();
         double toEatErrorSq = square(resolution(toEat));
         // Check if we can absorb this candidate into the track.
@@ -143,35 +146,37 @@ RecoTauIsolationMasking::mask(const reco::PFTau& tau) const {
 }
 
 double RecoTauIsolationMasking::resolution(
-    const reco::PFCandidate& cand) const {
-  if (cand.particleId() == reco::PFCandidate::h0) {
+    const reco::Candidate& cand) const {
+  if (cand.pdgId() == 130) {
     // NB for HCAL it returns relative energy
     return cand.energy()*resolutions_->getEnergyResolutionHad(cand.energy(),
         cand.eta(), cand.phi());
-  } else if (cand.particleId() == reco::PFCandidate::gamma) {
+  } else if (cand.pdgId() == 22) {
     return resolutions_->getEnergyResolutionEm(cand.energy(), cand.eta());
-  } else if (cand.particleId() == reco::PFCandidate::e) {
+  } else if (std::abs(cand.pdgId()) == 11) {
     // FIXME what is the electron resolution??
     return 0.15;
   } else {
     edm::LogWarning("IsoMask::res (bad pf id)")
-      << "Unknown PF ID: " << cand.particleId();
+      << "Unknown PF PDG ID: " << cand.pdgId();
   }
   return -1;
 }
 
-bool RecoTauIsolationMasking::inCone(const reco::PFCandidate& track,
-    const reco::PFCandidate& cand) const {
-  double openingDR = reco::deltaR(track.positionAtECALEntrance(), cand.p4());
-  if (cand.particleId() == reco::PFCandidate::h0) {
+bool RecoTauIsolationMasking::inCone(const reco::Candidate& track,
+    const reco::Candidate& cand) const {
+  const reco::PFCandidate* pf_track = dynamic_cast<const reco::PFCandidate*>(&track);
+    if (pf_track == nullptr)
+      throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
+  double openingDR = reco::deltaR(pf_track->positionAtECALEntrance(), cand.p4());
+  if (cand.pdgId() == 130) {
     return (openingDR < hcalCone_);
-  } else if (cand.particleId() == reco::PFCandidate::gamma ||
-      cand.particleId() == reco::PFCandidate::e) {
+  } else if (cand.pdgId() == 22 ||
+      abs(cand.pdgId()) == 11) {
     return openingDR < ecalCone_;
   } else {
     edm::LogWarning("IsoMask::inCone (bad pf id)")
-      << "Unknown PF ID: " << cand.particleId()
-      << " " <<  reco::PFCandidate::e;
+      << "Unknown PF PDG ID: " << cand.pdgId();
   }
   return -1;
 }

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -10,6 +10,7 @@ namespace reco { namespace tau {
 
 namespace {
   // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
+  // JAN FIXME - WE NEED TO SEE WHAT TO DO FOR MINIAOD
   const reco::TrackBaseRef getTrackRef(const Candidate& cand) 
   {
     if ( cand.trackRef().isNonnull() ) return reco::TrackBaseRef(cand.trackRef());

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -10,7 +10,7 @@ namespace reco { namespace tau {
 
 namespace {
   // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
-  const reco::TrackBaseRef getTrackRef(const PFCandidate& cand) 
+  const reco::TrackBaseRef getTrackRef(const Candidate& cand) 
   {
     if ( cand.trackRef().isNonnull() ) return reco::TrackBaseRef(cand.trackRef());
     else if ( cand.gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(cand.gsfTrackRef());
@@ -33,13 +33,13 @@ bool ptMin(const TrackBaseRef& track, double cut)
   return (track->pt() > cut);
 }
 
-bool ptMin_cand(const PFCandidate& cand, double cut) 
+bool ptMin_cand(const Candidate& cand, double cut) 
 {
   LogDebug("TauQCuts") << "<ptMin_cand>: Pt = " << cand.pt() << ", cut = " << cut ;
   return (cand.pt() > cut);
 }
 
-bool etMin_cand(const PFCandidate& cand, double cut) 
+bool etMin_cand(const Candidate& cand, double cut) 
 {
   LogDebug("TauQCuts") << "<etMin_cand>: Et = " << cand.et() << ", cut = " << cut ;
   return (cand.et() > cut);
@@ -52,7 +52,7 @@ bool trkPixelHits(const TrackBaseRef& track, int cut)
   return (track->hitPattern().numberOfValidPixelHits() >= cut);
 }
 
-bool trkPixelHits_cand(const PFCandidate& cand, int cut) 
+bool trkPixelHits_cand(const Candidate& cand, int cut) 
 {
   // For some reason, the number of hits is signed
   auto track = getTrackRef(cand);
@@ -71,7 +71,7 @@ bool trkTrackerHits(const TrackBaseRef& track, int cut)
   return (track->hitPattern().numberOfValidHits() >= cut);
 }
 
-bool trkTrackerHits_cand(const PFCandidate& cand, int cut) 
+bool trkTrackerHits_cand(const Candidate& cand, int cut) 
 {
   auto track = getTrackRef(cand);
   if ( track.isNonnull() ) {
@@ -96,7 +96,7 @@ bool trkTransverseImpactParameter(const TrackBaseRef& track, const reco::VertexR
   return (std::fabs(track->dxy((*pv)->position())) <= cut);
 }
 
-bool trkTransverseImpactParameter_cand(const PFCandidate& cand, const reco::VertexRef* pv, double cut) 
+bool trkTransverseImpactParameter_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) 
 {
   auto track = getTrackRef(cand);
   if ( track.isNonnull() ) {
@@ -120,7 +120,7 @@ bool trkLongitudinalImpactParameter(const TrackBaseRef& track, const reco::Verte
   return (std::fabs(track->dz((*pv)->position())) <= cut);
 }
 
-bool trkLongitudinalImpactParameter_cand(const PFCandidate& cand, const reco::VertexRef* pv, double cut) 
+bool trkLongitudinalImpactParameter_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) 
 {
   auto track = getTrackRef(cand);
   if ( track.isNonnull() ) {
@@ -142,7 +142,7 @@ bool trkLongitudinalImpactParameterWrtTrack(const TrackBaseRef& track, const rec
   return (std::fabs(track->dz((*pv)->position()) - (*leadTrack)->dz((*pv)->position())) <= cut);
 }
 
-bool trkLongitudinalImpactParameterWrtTrack_cand(const PFCandidate& cand, const reco::TrackBaseRef* leadTrack, const reco::VertexRef* pv, double cut) 
+bool trkLongitudinalImpactParameterWrtTrack_cand(const Candidate& cand, const reco::TrackBaseRef* leadTrack, const reco::VertexRef* pv, double cut) 
 {
   auto track = getTrackRef(cand);
   if ( track.isNonnull() ) return trkLongitudinalImpactParameterWrtTrack(track, leadTrack, pv, cut);
@@ -162,7 +162,7 @@ bool minTrackVertexWeight(const TrackBaseRef& track, const reco::VertexRef* pv, 
   return ((*pv)->trackWeight(track) >= cut);
 }
 
-bool minTrackVertexWeight_cand(const PFCandidate& cand, const reco::VertexRef* pv, double cut) 
+bool minTrackVertexWeight_cand(const Candidate& cand, const reco::VertexRef* pv, double cut) 
 {
   auto track = getTrackRef(cand);
   if ( track.isNonnull() ) {
@@ -179,7 +179,7 @@ bool trkChi2(const TrackBaseRef& track, double cut)
   return (track->normalizedChi2() <= cut);
 }
 
-bool trkChi2_cand(const PFCandidate& cand, double cut) 
+bool trkChi2_cand(const Candidate& cand, double cut) 
 {
   auto track = getTrackRef(cand);
   if ( track.isNonnull() ) {
@@ -200,7 +200,7 @@ bool AND(const TrackBaseRef& track, const RecoTauQualityCuts::TrackQCutFuncColle
   return true;
 }
 
-bool AND_cand(const PFCandidate& cand, const RecoTauQualityCuts::CandQCutFuncCollection& cuts) 
+bool AND_cand(const Candidate& cand, const RecoTauQualityCuts::CandQCutFuncCollection& cuts) 
 {
   BOOST_FOREACH( const RecoTauQualityCuts::CandQCutFunc& func, cuts ) {
     if ( !func(cand) ) return false;
@@ -209,10 +209,10 @@ bool AND_cand(const PFCandidate& cand, const RecoTauQualityCuts::CandQCutFuncCol
 }
 
 // Get the set of Q cuts for a given type (i.e. gamma)
-bool mapAndCutByType(const PFCandidate& cand, const RecoTauQualityCuts::CandQCutFuncMap& funcMap) 
+bool mapAndCutByType(const Candidate& cand, const RecoTauQualityCuts::CandQCutFuncMap& funcMap) 
 {
   // Find the cuts that for this particle type
-  RecoTauQualityCuts::CandQCutFuncMap::const_iterator cuts = funcMap.find(cand.particleId());
+  RecoTauQualityCuts::CandQCutFuncMap::const_iterator cuts = funcMap.find(std::abs(cand.pdgId()));
   // Return false if we dont' know how to deal with this particle type
   if ( cuts == funcMap.end() ) return false; 
   return AND_cand(cand, cuts->second); // Otherwise AND all the cuts
@@ -378,26 +378,26 @@ bool RecoTauQualityCuts::filterTrack_(const T& trackRef) const
   return true;
 }
 
-bool RecoTauQualityCuts::filterGammaCand(const reco::PFCandidate& cand) const {
+bool RecoTauQualityCuts::filterGammaCand(const reco::Candidate& cand) const {
   if(minGammaEt_ >= 0 && !(cand.et() > minGammaEt_)) return false;
   return true;
 }
 
-bool RecoTauQualityCuts::filterNeutralHadronCand(const reco::PFCandidate& cand) const {
+bool RecoTauQualityCuts::filterNeutralHadronCand(const reco::Candidate& cand) const {
   if(minNeutralHadronEt_ >= 0 && !(cand.et() > minNeutralHadronEt_)) return false;
   return true;
 }
 
-bool RecoTauQualityCuts::filterCandByType(const reco::PFCandidate& cand) const {
-  switch(cand.particleId()) {
-  case PFCandidate::gamma:
+bool RecoTauQualityCuts::filterCandByType(const reco::Candidate& cand) const {
+  switch(std::abs(cand.pdgId())) {
+  case 22:
     return filterGammaCand(cand);
-  case PFCandidate::h0:
+  case 130:
     return filterNeutralHadronCand(cand);
   // We use the same qcuts for muons/electrons and charged hadrons.
-  case PFCandidate::h:
-  case PFCandidate::e:
-  case PFCandidate::mu:
+  case 211:
+  case 11:
+  case 13:
     // no cuts ATM (track cuts applied in filterCand)
     return true;
   // Return false if we dont' know how to deal with this particle type
@@ -407,7 +407,7 @@ bool RecoTauQualityCuts::filterCandByType(const reco::PFCandidate& cand) const {
   return false;
 }
 
-bool RecoTauQualityCuts::filterCand(const reco::PFCandidate& cand) const 
+bool RecoTauQualityCuts::filterCand(const reco::Candidate& cand) const 
 {
   auto trackRef = cand.trackRef();
   bool result = true;
@@ -430,12 +430,12 @@ void RecoTauQualityCuts::setLeadTrack(const reco::TrackRef& leadTrack) const
   leadTrack_ = reco::TrackBaseRef(leadTrack);
 }
 
-void RecoTauQualityCuts::setLeadTrack(const reco::PFCandidate& leadCand) const 
+void RecoTauQualityCuts::setLeadTrack(const reco::Candidate& leadCand) const 
 {
   leadTrack_ = getTrackRef(leadCand);
 }
 
-void RecoTauQualityCuts::setLeadTrack(const reco::PFCandidateRef& leadCand) const 
+void RecoTauQualityCuts::setLeadTrack(const reco::CandidateRef& leadCand) const 
 {
   if ( leadCand.isNonnull() ) {
     leadTrack_ = getTrackRef(*leadCand);

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -11,12 +11,11 @@
 namespace reco { namespace tau {
 
 namespace {
-  // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
-  // JAN FIXME - WE NEED TO SEE WHAT TO DO FOR MINIAOD
   const reco::Track* getTrack(const Candidate& cand) 
   { 
     const PFCandidate* pfCandPtr = dynamic_cast<const PFCandidate*>(&cand);
     if (pfCandPtr) {
+      // Get the KF track if it exists.  Otherwise, see if PFCandidate has a GSF track.
       if      ( pfCandPtr->trackRef().isNonnull()    ) return pfCandPtr->trackRef().get();
       else if ( pfCandPtr->gsfTrackRef().isNonnull() ) return pfCandPtr->gsfTrackRef().get();
       else return nullptr;

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -17,7 +17,7 @@ namespace reco { namespace tau {
 
 // Get the highest pt track in a jet.
 // Get the KF track if it exists.  Otherwise, see if it has a GSF track.
-reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const PFJet& jet) const
+reco::TrackBaseRef RecoTauVertexAssociator::getLeadTrack(const Jet& jet) const
 {
   std::vector<PFCandidatePtr> chargedPFCands = pfChargedCands(jet, true);
   if ( verbosity_ >= 1 ) {
@@ -229,7 +229,7 @@ void RecoTauVertexAssociator::setEvent(const edm::Event& evt)
   }
   edm::EventNumber_t currentEvent = evt.id().event();
   if ( currentEvent != lastEvent_ || !jetToVertexAssociation_ ) {
-    if ( !jetToVertexAssociation_ ) jetToVertexAssociation_ = new std::map<const reco::PFJet*, reco::VertexRef>;
+    if ( !jetToVertexAssociation_ ) jetToVertexAssociation_ = new std::map<const reco::Jet*, reco::VertexRef>;
     else jetToVertexAssociation_->clear();
     lastEvent_ = currentEvent;
   }
@@ -248,7 +248,7 @@ RecoTauVertexAssociator::associatedVertex(const PFTau& tau, bool useJet) const
     }
   }
   // MB: use vertex associated to a given jet if explicitely requested or in case of missing leading track
-  reco::PFJetRef jetRef = tau.jetRef();
+  reco::JetRef jetRef = tau.jetRef();
   // FIXME workaround for HLT which does not use updated data format
   if ( jetRef.isNull() ) jetRef = tau.pfTauTagInfoRef()->pfjetRef();
   return associatedVertex(*jetRef);
@@ -335,7 +335,7 @@ RecoTauVertexAssociator::associatedVertex(const TrackBaseRef& track) const
 }
 
 reco::VertexRef
-RecoTauVertexAssociator::associatedVertex(const PFJet& jet) const 
+RecoTauVertexAssociator::associatedVertex(const Jet& jet) const 
 {
   if ( verbosity_ >= 1 ) {
     std::cout << "<RecoTauVertexAssociator::associatedVertex>:" << std::endl;
@@ -348,10 +348,10 @@ RecoTauVertexAssociator::associatedVertex(const PFJet& jet) const
   }
 
   reco::VertexRef jetVertex = ( !selectedVertices_.empty() ) ? selectedVertices_[0] : reco::VertexRef();
-  const PFJet* jetPtr = &jet;
+  const Jet* jetPtr = &jet;
 
   // check if jet-vertex association has been determined for this jet before
-  std::map<const reco::PFJet*, reco::VertexRef>::iterator vertexPtr = jetToVertexAssociation_->find(jetPtr);
+  std::map<const reco::Jet*, reco::VertexRef>::iterator vertexPtr = jetToVertexAssociation_->find(jetPtr);
   if ( vertexPtr != jetToVertexAssociation_->end() ) {
     jetVertex = vertexPtr->second;
   } else {
@@ -372,7 +372,7 @@ RecoTauVertexAssociator::associatedVertex(const PFJet& jet) const
       }
     }
     
-    jetToVertexAssociation_->insert(std::pair<const PFJet*, reco::VertexRef>(jetPtr, jetVertex));
+    jetToVertexAssociation_->insert(std::pair<const Jet*, reco::VertexRef>(jetPtr, jetVertex));
   }
 
   if ( verbosity_ >= 1 ) {

--- a/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
+++ b/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
@@ -1,7 +1,7 @@
 #include "RecoTauTag/RecoTau/interface/pfRecoTauChargedHadronAuxFunctions.h"
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 #include <TMath.h>
 
@@ -16,7 +16,7 @@ void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scal
   double SumNeutrals = 0.;
   if ( chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kChargedPFCandidate) ||
        chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kPFNeutralHadron)   ) {
-    const reco::PFCandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
+    const reco::CandidatePtr& chargedPFCand = chargedHadron.getChargedPFCandidate();
     assert(chargedPFCand.isNonnull());
     chargedHadronP     += chargedPFCand->p();
     chargedHadronPx     = chargedPFCand->px();
@@ -30,8 +30,8 @@ void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scal
     chargedHadronPy     = track->py();
     chargedHadronPz     = track->pz();
   } else assert(0);
-  const std::vector<reco::PFCandidatePtr>& neutralPFCands = chargedHadron.getNeutralPFCandidates();
-  for ( std::vector<reco::PFCandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
+  const std::vector<reco::CandidatePtr>& neutralPFCands = chargedHadron.getNeutralPFCandidates();
+  for ( std::vector<reco::CandidatePtr>::const_iterator neutralPFCand = neutralPFCands.begin();
 	neutralPFCand != neutralPFCands.end(); ++neutralPFCand ) {
     SumNeutrals += (*neutralPFCand)->p();
   }

--- a/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
+++ b/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
@@ -7,6 +7,27 @@
 
 namespace reco { namespace tau {
 
+namespace {
+  const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron) {
+    // Charged hadron made from track (reco::Track) - RECO/AOD only
+    if ( chargedHadron.getTrack().isNonnull()) {
+      return chargedHadron.getTrack().get();
+    }
+    // In MiniAOD, even isolated tracks are saved as candidates, so the track Ptr doesn't exist
+    const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getChargedPFCandidate());
+    if (chargedPFPCand != nullptr) {
+        if (chargedPFPCand->hasTrackDetails())
+          return &chargedPFPCand->pseudoTrack();
+    }
+    const pat::PackedCandidate* lostTrackCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getLostTrackCandidate());
+    if (lostTrackCand != nullptr) {
+        if (lostTrackCand->hasTrackDetails())
+          return &lostTrackCand->pseudoTrack();
+    }
+    return nullptr;
+  }
+}
+
 void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scaleFactor_neutralPFCands)
 {
   double chargedHadronP  = 0.;

--- a/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
+++ b/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
@@ -2,6 +2,7 @@
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include <TMath.h>
 
@@ -44,8 +45,8 @@ void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scal
     chargedHadronPy     = chargedPFCand->py();
     chargedHadronPz     = chargedPFCand->pz();
   } else if ( chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kTrack) ) {
-    const reco::PFRecoTauChargedHadron::TrackPtr& track = chargedHadron.getTrack();
-    assert(track.isNonnull());
+    const reco::Track* track = getTrackFromChargedHadron(chargedHadron);
+    assert(track != nullptr);
     chargedHadronP     += track->p();
     chargedHadronPx     = track->px();
     chargedHadronPy     = track->py();

--- a/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
+++ b/RecoTauTag/RecoTau/src/pfRecoTauChargedHadronAuxFunctions.cc
@@ -8,27 +8,25 @@
 
 namespace reco { namespace tau {
 
-namespace {
-  const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron) {
-    // Charged hadron made from track (reco::Track) - RECO/AOD only
-    if ( chargedHadron.getTrack().isNonnull()) {
-      return chargedHadron.getTrack().get();
-    }
-    // In MiniAOD, even isolated tracks are saved as candidates, so the track Ptr doesn't exist
-    const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getChargedPFCandidate());
-    if (chargedPFPCand != nullptr) {
-        if (chargedPFPCand->hasTrackDetails())
-          return &chargedPFPCand->pseudoTrack();
-    }
-    const pat::PackedCandidate* lostTrackCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getLostTrackCandidate());
-    if (lostTrackCand != nullptr) {
-        if (lostTrackCand->hasTrackDetails())
-          return &lostTrackCand->pseudoTrack();
-    }
-    return nullptr;
+const reco::Track* getTrackFromChargedHadron(const reco::PFRecoTauChargedHadron& chargedHadron) {
+  // Charged hadron made from track (reco::Track) - RECO/AOD only
+  if ( chargedHadron.getTrack().isNonnull()) {
+    return chargedHadron.getTrack().get();
   }
+  // In MiniAOD, even isolated tracks are saved as candidates, so the track Ptr doesn't exist
+  const pat::PackedCandidate* chargedPFPCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getChargedPFCandidate());
+  if (chargedPFPCand != nullptr) {
+      if (chargedPFPCand->hasTrackDetails())
+        return &chargedPFPCand->pseudoTrack();
+  }
+  const pat::PackedCandidate* lostTrackCand = dynamic_cast<const pat::PackedCandidate*> (&*chargedHadron.getLostTrackCandidate());
+  if (lostTrackCand != nullptr) {
+      if (lostTrackCand->hasTrackDetails())
+        return &lostTrackCand->pseudoTrack();
+  }
+  return nullptr;
 }
-
+  
 void setChargedHadronP4(reco::PFRecoTauChargedHadron& chargedHadron, double scaleFactor_neutralPFCands)
 {
   double chargedHadronP  = 0.;

--- a/RecoTauTag/TauTagTools/interface/PFCandidateMergerBase.h
+++ b/RecoTauTag/TauTagTools/interface/PFCandidateMergerBase.h
@@ -13,7 +13,7 @@ class PFCandidateMergerBase
 
   virtual ~PFCandidateMergerBase()=0;
 
-  virtual std::vector<std::vector<reco::PFCandidatePtr> > mergeCandidates(const std::vector<reco::PFCandidatePtr>&) =0;
+  virtual std::vector<std::vector<reco::CandidatePtr> > mergeCandidates(const std::vector<reco::CandidatePtr>&) =0;
 
 };
 

--- a/RecoTauTag/TauTagTools/interface/PFCandidateStripMerger.h
+++ b/RecoTauTag/TauTagTools/interface/PFCandidateStripMerger.h
@@ -19,7 +19,7 @@ class PFCandidateStripMerger : public PFCandidateMergerBase
   PFCandidateStripMerger(const edm::ParameterSet&);
   ~PFCandidateStripMerger() override;
 
-  std::vector<std::vector<reco::PFCandidatePtr>> mergeCandidates(const std::vector<reco::PFCandidatePtr>&) override;
+  std::vector<std::vector<reco::CandidatePtr>> mergeCandidates(const std::vector<reco::CandidatePtr>&) override;
 
  private:
 
@@ -29,7 +29,7 @@ class PFCandidateStripMerger : public PFCandidateMergerBase
   
 
   //Private Methods
-  bool candidateMatches(const reco::PFCandidatePtr&);
+  bool candidateMatches(const reco::CandidatePtr&);
 
 
 };

--- a/RecoTauTag/TauTagTools/interface/PFTauElementsOperators.h
+++ b/RecoTauTag/TauTagTools/interface/PFTauElementsOperators.h
@@ -34,45 +34,45 @@ class PFTauElementsOperators : public TauElementsOperators {
   ~PFTauElementsOperators(){}   
   void setAreaMetricrecoElementsmaxabsEta( double x);
   //return the leading PFCandidate in a given cone around the jet axis or a given direction
-  reco::PFCandidatePtr leadPFCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
-  reco::PFCandidatePtr leadPFCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
-  reco::PFCandidatePtr leadPFChargedHadrCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
-  reco::PFCandidatePtr leadPFChargedHadrCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
-  reco::PFCandidatePtr leadPFNeutrHadrCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
-  reco::PFCandidatePtr leadPFNeutrHadrCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
-  reco::PFCandidatePtr leadPFGammaCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
-  reco::PFCandidatePtr leadPFGammaCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
+  reco::CandidatePtr leadPFCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
+  reco::CandidatePtr leadPFCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
+  reco::CandidatePtr leadPFChargedHadrCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
+  reco::CandidatePtr leadPFChargedHadrCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
+  reco::CandidatePtr leadPFNeutrHadrCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
+  reco::CandidatePtr leadPFNeutrHadrCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
+  reco::CandidatePtr leadPFGammaCand(const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;
+  reco::CandidatePtr leadPFGammaCand(const math::XYZVector& myVector,const std::string matchingcone_metric,const double matchingcone_size,const double minPt)const;  
   
   // return all PFCandidates in a cone of metric* "cone_metric" and size "conesize" around a direction "myVector" 
-  std::vector<reco::PFCandidatePtr> PFCandsInCone(const std::vector<reco::PFCandidatePtr>& PFCands,const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFChargedHadrCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFChargedHadrCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const reco::Vertex &mPV)const;
-  std::vector<reco::PFCandidatePtr> PFNeutrHadrCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFGammaCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFCandsInCone(const std::vector<reco::CandidatePtr>& PFCands,const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFChargedHadrCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFChargedHadrCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const reco::Vertex &mPV)const;
+  std::vector<reco::CandidatePtr> PFNeutrHadrCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFGammaCandsInCone(const math::XYZVector& myVector,const std::string conemetric,const double conesize,const double minPt)const;
   
   // return all PFCandidates in a annulus defined by inner(metric* "innercone_metric" and size "innercone_size") and outer(metric* "outercone_metric" and size "outercone_size") cones around a direction "myVector" 
-  std::vector<reco::PFCandidatePtr> PFCandsInAnnulus(const std::vector<reco::PFCandidatePtr>& PFCands,const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const reco::Vertex &myPV)const;
-  std::vector<reco::PFCandidatePtr> PFNeutrHadrCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
-  std::vector<reco::PFCandidatePtr> PFGammaCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFCandsInAnnulus(const std::vector<reco::CandidatePtr>& PFCands,const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const reco::Vertex &myPV)const;
+  std::vector<reco::CandidatePtr> PFNeutrHadrCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
+  std::vector<reco::CandidatePtr> PFGammaCandsInAnnulus(const math::XYZVector& myVector,const std::string innercone_metric,const double innercone_size,const std::string outercone_metric,const double outercone_size,const double minPt)const;
   //Put function to get elements inside ellipse here ... EELL
-  std::pair<std::vector<reco::PFCandidatePtr>,std::vector<reco::PFCandidatePtr>> PFGammaCandsInOutEllipse(const std::vector<reco::PFCandidatePtr>&, const reco::PFCandidate&, double rPhi, double rEta, double maxPt) const;
+  std::pair<std::vector<reco::CandidatePtr>,std::vector<reco::CandidatePtr>> PFGammaCandsInOutEllipse(const std::vector<reco::CandidatePtr>&, const reco::Candidate&, double rPhi, double rEta, double maxPt) const;
   //EELL
 
   /// append elements of theInputCands that pass Pt requirement to the end of theOutputCands
-  void                 copyCandRefsFilteredByPt(const std::vector<reco::PFCandidatePtr>& theInputCands, std::vector<reco::PFCandidatePtr>& theOutputCands, const double minPt);
+  void                 copyCandRefsFilteredByPt(const std::vector<reco::CandidatePtr>& theInputCands, std::vector<reco::CandidatePtr>& theOutputCands, const double minPt);
 
   /// compute size of cone using the Inside-Out cone (Author Evan Friis, UC Davis)
-  void                 computeInsideOutContents(const std::vector<reco::PFCandidatePtr>& theChargedCands, const std::vector<reco::PFCandidatePtr>& theGammaCands, const math::XYZVector& leadTrackVector, 
+  void                 computeInsideOutContents(const std::vector<reco::CandidatePtr>& theChargedCands, const std::vector<reco::CandidatePtr>& theGammaCands, const math::XYZVector& leadTrackVector, 
                                const TFormula& coneSizeFormula, double (*ptrToMetricFunction)(const math::XYZVector&, const math::XYZVector&),  // determines grow function, and the metric to compare the opening angle to
                                const double minChargedSize, const double maxChargedSize, const double minNeutralSize, const double maxNeutralSize,
                                const double minChargedPt, const double minNeutralPt,
                                const std::string& outlierCollectorConeMetric, const double outlierCollectorConeSize,
-                               std::vector<reco::PFCandidatePtr>& signalChargedObjects, std::vector<reco::PFCandidatePtr>& outlierChargedObjects,
-                               std::vector<reco::PFCandidatePtr>& signalGammaObjects, std::vector<reco::PFCandidatePtr>& outlierGammaObjects, bool useScanningAxis); //these last two quantities are the return values
+                               std::vector<reco::CandidatePtr>& signalChargedObjects, std::vector<reco::CandidatePtr>& outlierChargedObjects,
+                               std::vector<reco::CandidatePtr>& signalGammaObjects, std::vector<reco::CandidatePtr>& outlierGammaObjects, bool useScanningAxis); //these last two quantities are the return values
 
   // return 1 if no/low PFCandidates activity in an isolation annulus around a leading PFCandidate, 0 otherwise; 
   // different possible metrics* for the matching, signal and isolation cones; 
@@ -101,28 +101,28 @@ class PFTauElementsOperators : public TauElementsOperators {
   double discriminatorByIsolPFGammaCandsEtSum(std::string matchingcone_metric,double matchingcone_size,std::string signalcone_metric,double signalcone_size,std::string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFCands_maxEtSum=0);
   double discriminatorByIsolPFGammaCandsEtSum(const math::XYZVector& myVector,std::string matchingcone_metric,double matchingcone_size,std::string signalcone_metric,double signalcone_size,std::string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFCands_maxEtSum=0);  
  private:
-  reco::PFJetRef PFJetRef_;
+  reco::JetBaseRef PFJetRef_;
   double AreaMetric_recoElements_maxabsEta_;
-  std::vector<reco::PFCandidatePtr> PFCands_;
-  std::vector<reco::PFCandidatePtr> IsolPFCands_;
-  std::vector<reco::PFCandidatePtr> PFChargedHadrCands_;
-  std::vector<reco::PFCandidatePtr> IsolPFChargedHadrCands_;
-  std::vector<reco::PFCandidatePtr> PFNeutrHadrCands_;
-  std::vector<reco::PFCandidatePtr> IsolPFNeutrHadrCands_;
-  std::vector<reco::PFCandidatePtr> PFGammaCands_;
-  std::vector<reco::PFCandidatePtr> IsolPFGammaCands_;
+  std::vector<reco::CandidatePtr> PFCands_;
+  std::vector<reco::CandidatePtr> IsolPFCands_;
+  std::vector<reco::CandidatePtr> PFChargedHadrCands_;
+  std::vector<reco::CandidatePtr> IsolPFChargedHadrCands_;
+  std::vector<reco::CandidatePtr> PFNeutrHadrCands_;
+  std::vector<reco::CandidatePtr> IsolPFNeutrHadrCands_;
+  std::vector<reco::CandidatePtr> PFGammaCands_;
+  std::vector<reco::CandidatePtr> IsolPFGammaCands_;
   // template objects for DR and Angle metrics
   DeltaR<math::XYZVector> metricDR_;  
   Angle<math::XYZVector> metricAngle_;
   double computeDeltaR(const math::XYZVector& vec1, const math::XYZVector& vec2);
   double computeAngle(const math::XYZVector& vec1, const math::XYZVector& vec2);
-  ElementsInCone<math::XYZVector,DeltaR<math::XYZVector>,reco::PFCandidate> PFCandsinCone_DRmetric_;
-  ElementsInCone<math::XYZVector,Angle<math::XYZVector>,reco::PFCandidate> PFCandsinCone_Anglemetric_; 
-  ElementsInAnnulus<math::XYZVector,DeltaR<math::XYZVector>,DeltaR<math::XYZVector>,reco::PFCandidate> PFCandsinAnnulus_innerDRouterDRmetrics_;
-  ElementsInAnnulus<math::XYZVector,DeltaR<math::XYZVector>,Angle<math::XYZVector>,reco::PFCandidate> PFCandsinAnnulus_innerDRouterAnglemetrics_; 
-  ElementsInAnnulus<math::XYZVector,Angle<math::XYZVector>,Angle<math::XYZVector>,reco::PFCandidate> PFCandsinAnnulus_innerAngleouterAnglemetrics_;
-  ElementsInAnnulus<math::XYZVector,Angle<math::XYZVector>,DeltaR<math::XYZVector>,reco::PFCandidate> PFCandsinAnnulus_innerAngleouterDRmetrics_; 
-  ElementsInEllipse<reco::PFCandidate, reco::PFCandidate> PFCandidatesInEllipse_;
+  ElementsInCone<math::XYZVector,DeltaR<math::XYZVector>,reco::Candidate> PFCandsinCone_DRmetric_;
+  ElementsInCone<math::XYZVector,Angle<math::XYZVector>,reco::Candidate> PFCandsinCone_Anglemetric_; 
+  ElementsInAnnulus<math::XYZVector,DeltaR<math::XYZVector>,DeltaR<math::XYZVector>,reco::Candidate> PFCandsinAnnulus_innerDRouterDRmetrics_;
+  ElementsInAnnulus<math::XYZVector,DeltaR<math::XYZVector>,Angle<math::XYZVector>,reco::Candidate> PFCandsinAnnulus_innerDRouterAnglemetrics_; 
+  ElementsInAnnulus<math::XYZVector,Angle<math::XYZVector>,Angle<math::XYZVector>,reco::Candidate> PFCandsinAnnulus_innerAngleouterAnglemetrics_;
+  ElementsInAnnulus<math::XYZVector,Angle<math::XYZVector>,DeltaR<math::XYZVector>,reco::Candidate> PFCandsinAnnulus_innerAngleouterDRmetrics_; 
+  ElementsInEllipse<reco::Candidate, reco::Candidate> PFCandidatesInEllipse_;
 };
 #endif
 

--- a/RecoTauTag/TauTagTools/interface/TauTagTools.h
+++ b/RecoTauTag/TauTagTools/interface/TauTagTools.h
@@ -3,8 +3,8 @@
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -27,11 +27,11 @@ namespace TauTagTools{
   reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2, reco::Vertex pV);
   reco::TrackRefVector filteredTracks(const reco::TrackRefVector& theInitialTracks,double tkminPt,int tkminPixelHitsn,int tkminTrackerHitsn,double tkmaxipt,double tkmaxChi2,double tktorefpointmaxDZ,reco::Vertex pV,double refpoint_Z);
 
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(const std::vector<reco::PFCandidatePtr>& theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn);
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, reco::Vertex pV);
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,reco::Vertex pV, double refpoint_Z);
-  std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt);
-  std::vector<reco::PFCandidatePtr> filteredPFGammaCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt);
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(const std::vector<reco::CandidatePtr>& theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn);
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, reco::Vertex pV);
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,reco::Vertex pV, double refpoint_Z);
+  std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt);
+  std::vector<reco::CandidatePtr> filteredPFGammaCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt);
   math::XYZPoint propagTrackECALSurfContactPoint(const MagneticField*,reco::TrackRef); 
 
   TFormula computeConeSizeTFormula(const std::string& ConeSizeFormula,const char* errorMessage);
@@ -41,32 +41,32 @@ namespace TauTagTools{
   double computeAngle(const math::XYZVector& vec1, const math::XYZVector& vec2);
 
   //MIKE: Sort a reference vector
-  void sortRefVectorByPt(std::vector<reco::PFCandidatePtr>&);
+  void sortRefVectorByPt(std::vector<reco::CandidatePtr>&);
 
 
   //binary predicate classes for sorting a list of indexes corresponding to PFPtrVectors...(as they can't use STL??)
   class sortRefsByOpeningDistance
   {
      public:
-     sortRefsByOpeningDistance(const math::XYZVector& theAxis, double (*ptrToMetricFunction)(const math::XYZVector&, const math::XYZVector&), const std::vector<reco::PFCandidatePtr>& myInputVector):myMetricFunction(ptrToMetricFunction),axis(theAxis),myVector(myInputVector){};
+     sortRefsByOpeningDistance(const math::XYZVector& theAxis, double (*ptrToMetricFunction)(const math::XYZVector&, const math::XYZVector&), const std::vector<reco::CandidatePtr>& myInputVector):myMetricFunction(ptrToMetricFunction),axis(theAxis),myVector(myInputVector){};
      bool operator()(uint32_t indexA, uint32_t indexB)
      {
-        const reco::PFCandidatePtr candA = myVector.at(indexA);
-        const reco::PFCandidatePtr candB = myVector.at(indexB);
+        const reco::CandidatePtr candA = myVector.at(indexA);
+        const reco::CandidatePtr candB = myVector.at(indexB);
         return (myMetricFunction(axis, candA->momentum()) < myMetricFunction(axis, candB->momentum()));
      }
      private:
      double (*myMetricFunction)(const math::XYZVector&, const math::XYZVector&);
      math::XYZVector axis;  //axis about which candidates are sorted
-     const std::vector<reco::PFCandidatePtr> myVector;
+     const std::vector<reco::CandidatePtr> myVector;
   };
   class filterChargedAndNeutralsByPt
   {
      public:
-     filterChargedAndNeutralsByPt(double minNeutralPt, double minChargedPt, const std::vector<reco::PFCandidatePtr>& myInputVector):minNeutralPt_(minNeutralPt),minChargedPt_(minChargedPt),myVector(myInputVector){};
+     filterChargedAndNeutralsByPt(double minNeutralPt, double minChargedPt, const std::vector<reco::CandidatePtr>& myInputVector):minNeutralPt_(minNeutralPt),minChargedPt_(minChargedPt),myVector(myInputVector){};
      bool operator()(uint32_t candIndex)
      {
-        const reco::PFCandidatePtr cand = myVector.at(candIndex);
+        const reco::CandidatePtr cand = myVector.at(candIndex);
         bool output          = true;
         unsigned char charge = std::abs(cand->charge());
         double thePt         = cand->pt();
@@ -79,12 +79,12 @@ namespace TauTagTools{
      private:
      double minNeutralPt_;
      double minChargedPt_;
-     const std::vector<reco::PFCandidatePtr>& myVector;
+     const std::vector<reco::CandidatePtr>& myVector;
   };
 
   class refVectorPtSorter {
   public:
-    refVectorPtSorter(const std::vector<reco::PFCandidatePtr>& vec)
+    refVectorPtSorter(const std::vector<reco::CandidatePtr>& vec)
       {
 	vec_ = vec;
       }
@@ -102,7 +102,7 @@ namespace TauTagTools{
     }
 
   private:
-    std::vector<reco::PFCandidatePtr> vec_;
+    std::vector<reco::CandidatePtr> vec_;
   };
 
 

--- a/RecoTauTag/TauTagTools/plugins/RecoTauDifferenceAnalyzer.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauDifferenceAnalyzer.cc
@@ -46,7 +46,7 @@ RecoTauDifferenceAnalyzer::RecoTauDifferenceAnalyzer(
 }
 
 namespace {
-  reco::PFJetRef getJetRef(const reco::PFTau& tau) {
+  reco::JetBaseRef getJetRef(const reco::PFTau& tau) {
     if (tau.jetRef().isNonnull())
       return tau.jetRef();
     else if (tau.pfTauTagInfoRef()->pfjetRef().isNonnull())
@@ -80,8 +80,8 @@ bool RecoTauDifferenceAnalyzer::filter(
     double bestDeltaR = -1;
     for (size_t iTau2 = 0; iTau2 < taus2->size(); ++iTau2) {
       reco::PFTauRef tau2(taus2, iTau2);
-      reco::PFJetRef jet1 = getJetRef(*tau1);
-      reco::PFJetRef jet2 = getJetRef(*tau2);
+      reco::JetBaseRef jet1 = getJetRef(*tau1);
+      reco::JetBaseRef jet2 = getJetRef(*tau2);
       double deltaRVal = deltaR(jet2->p4(), jet1->p4());
       if (bestMatch.isNull() || deltaRVal < bestDeltaR) {
         bestMatch = tau2;

--- a/RecoTauTag/TauTagTools/plugins/RecoTauDumper.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauDumper.cc
@@ -18,6 +18,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 // Methods to write the different types

--- a/RecoTauTag/TauTagTools/plugins/RecoTauPiZeroFlattener.cc
+++ b/RecoTauTag/TauTagTools/plugins/RecoTauPiZeroFlattener.cc
@@ -61,7 +61,7 @@ RecoTauPiZeroFlattener::produce(edm::Event& evt, const edm::EventSetup& es) {
   // Loop over the jets and append the pizeros for each jet to our output
   // collection.
   BOOST_FOREACH(reco::PFJetRef jetRef, jets) {
-    const std::vector<reco::RecoTauPiZero>& pizeros = (*piZeroAssoc)[jetRef];
+    const std::vector<reco::RecoTauPiZero>& pizeros = (*piZeroAssoc)[reco::JetBaseRef(jetRef)];
     output->reserve(output->size() + pizeros.size());
     output->insert(output->end(), pizeros.begin(), pizeros.end());
   }

--- a/RecoTauTag/TauTagTools/src/PFCandidateStripMerger.cc
+++ b/RecoTauTag/TauTagTools/src/PFCandidateStripMerger.cc
@@ -22,7 +22,7 @@ PFCandidateStripMerger::~PFCandidateStripMerger()
 
 
 bool 
-PFCandidateStripMerger::candidateMatches(const reco::PFCandidatePtr& cand)
+PFCandidateStripMerger::candidateMatches(const reco::CandidatePtr& cand)
 {
   bool matches = false;
   for(unsigned int i=0; i < inputPdgIds_.size(); ++i) {
@@ -39,12 +39,12 @@ PFCandidateStripMerger::candidateMatches(const reco::PFCandidatePtr& cand)
 
 
 
-vector<vector<PFCandidatePtr>> 
-PFCandidateStripMerger::mergeCandidates(const vector<PFCandidatePtr>& candidates) 
+vector<vector<CandidatePtr>> 
+PFCandidateStripMerger::mergeCandidates(const vector<CandidatePtr>& candidates) 
 {
 
   //Copy the input getting the relevant candidates and sort by pt 
-  vector<PFCandidatePtr> cands;
+  vector<CandidatePtr> cands;
   for(unsigned int i=0;i<candidates.size();++i)
     if(candidateMatches(candidates.at(i)))
       cands.push_back(candidates.at(i));
@@ -52,17 +52,17 @@ PFCandidateStripMerger::mergeCandidates(const vector<PFCandidatePtr>& candidates
   if(cands.size()>1)
   TauTagTools::sortRefVectorByPt(cands);
 
-  std::vector<vector<PFCandidatePtr>> strips;
+  std::vector<vector<CandidatePtr>> strips;
 
 
   //Repeat while there are still unclusterized gammas
   while(!cands.empty()) {
 
     //save the non associated candidates to a different collection
-    vector<PFCandidatePtr> notAssociated;
+    vector<CandidatePtr> notAssociated;
     
     //Create a cluster from the Seed Photon
-    vector<PFCandidatePtr> strip;
+    vector<CandidatePtr> strip;
     math::XYZTLorentzVector stripVector;
     strip.push_back(cands.at(0));
     stripVector=cands.at(0)->p4();

--- a/RecoTauTag/TauTagTools/src/PFTauElementsOperators.cc
+++ b/RecoTauTag/TauTagTools/src/PFTauElementsOperators.cc
@@ -17,12 +17,12 @@ using std::string;
 }
 void PFTauElementsOperators::setAreaMetricrecoElementsmaxabsEta( double x) {AreaMetric_recoElements_maxabsEta_=x;}
 
-std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFCandsInCone(const std::vector<reco::PFCandidatePtr>& thePFCands,const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCands;
-  for (std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=thePFCands.begin();iPFCand!=thePFCands.end();++iPFCand) {
+std::vector<reco::CandidatePtr> PFTauElementsOperators::PFCandsInCone(const std::vector<reco::CandidatePtr>& thePFCands,const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCands;
+  for (std::vector<reco::CandidatePtr>::const_iterator iPFCand=thePFCands.begin();iPFCand!=thePFCands.end();++iPFCand) {
     if ((**iPFCand).pt()>minPt)theFilteredPFCands.push_back(*iPFCand);
   }  
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone;
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInCone;
   if (conemetric=="DR"){
     theFilteredPFCandsInCone=PFCandsinCone_DRmetric_(myVector,metricDR_,conesize,theFilteredPFCands);
   }else if(conemetric=="angle"){
@@ -34,59 +34,62 @@ std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFCandsInCone(const st
     double coneangle=theFixedAreaCone(myVector.theta(),myVector.phi(),0,conesize,errorFlag); 
     if (errorFlag!=0)return theFilteredPFCandsInCone;   
     theFilteredPFCandsInCone=PFCandsinCone_Anglemetric_(myVector,metricAngle_,coneangle,theFilteredPFCands);
-  }else return std::vector<reco::PFCandidatePtr>();
+  }else return std::vector<reco::CandidatePtr>();
   return theFilteredPFCandsInCone;
 }
-std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFCands_,myVector,conemetric,conesize,minPt);
+std::vector<reco::CandidatePtr> PFTauElementsOperators::PFCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFCands_,myVector,conemetric,conesize,minPt);
   return theFilteredPFCandsInCone;
 }
-std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFChargedHadrCands_,myVector,conemetric,conesize,minPt);
+std::vector<reco::CandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFChargedHadrCands_,myVector,conemetric,conesize,minPt);
   return theFilteredPFCandsInCone;
 }
-std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const Vertex &myPV)const{     
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=PFChargedHadrCands_.begin();iPFCand!=PFChargedHadrCands_.end();iPFCand++){
-    TrackRef PFChargedHadrCand_track=(**iPFCand).trackRef();
-    if (!PFChargedHadrCand_track)continue;
-    if (fabs((*PFChargedHadrCand_track).dz(myPV.position())-refpoint_Z)<=PFChargedHadrCand_tracktorefpoint_maxDZ) filteredPFChargedHadrCands.push_back(*iPFCand);
+std::vector<reco::CandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const Vertex &myPV)const{     
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=PFChargedHadrCands_.begin();iPFCand!=PFChargedHadrCands_.end();iPFCand++){
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(iPFCand->get());
+    if (pfcand != nullptr) {
+      TrackRef PFChargedHadrCand_track = pfcand->trackRef();
+      if (!PFChargedHadrCand_track)continue;
+      if (fabs((*PFChargedHadrCand_track).dz(myPV.position())-refpoint_Z)<=PFChargedHadrCand_tracktorefpoint_maxDZ) filteredPFChargedHadrCands.push_back(*iPFCand);
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(filteredPFChargedHadrCands,myVector,conemetric,conesize,minPt);
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(filteredPFChargedHadrCands,myVector,conemetric,conesize,minPt);
   return theFilteredPFCandsInCone;
 }
-std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFNeutrHadrCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFNeutrHadrCands_,myVector,conemetric,conesize,minPt);
+std::vector<reco::CandidatePtr> PFTauElementsOperators::PFNeutrHadrCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFNeutrHadrCands_,myVector,conemetric,conesize,minPt);
   return theFilteredPFCandsInCone;
 }
- std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFGammaCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFGammaCands_,myVector,conemetric,conesize,minPt);
+ std::vector<reco::CandidatePtr> PFTauElementsOperators::PFGammaCandsInCone(const math::XYZVector& myVector,const string conemetric,const double conesize,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFGammaCands_,myVector,conemetric,conesize,minPt);
   return theFilteredPFCandsInCone;
 }
 
 // Function to get elements inside ellipse here ... EELL
-std::pair<std::vector<reco::PFCandidatePtr>, std::vector<reco::PFCandidatePtr>> PFTauElementsOperators::PFGammaCandsInOutEllipse(const std::vector<reco::PFCandidatePtr>& PFGammaCands_, const PFCandidate& leadCand_, double rPhi, double rEta, double maxPt) const{
-  std::pair<std::vector<reco::PFCandidatePtr>,std::vector<reco::PFCandidatePtr>> myPFGammaCandsInEllipse = PFCandidatesInEllipse_(leadCand_, rPhi, rEta, PFGammaCands_);
-  std::vector<reco::PFCandidatePtr> thePFGammaCandsInEllipse = myPFGammaCandsInEllipse.first;
-  std::vector<reco::PFCandidatePtr> thePFGammaCandsOutEllipse = myPFGammaCandsInEllipse.second;
-  std::vector<reco::PFCandidatePtr> theFilteredPFGammaCandsInEllipse;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFGammaCand = thePFGammaCandsInEllipse.begin(); iPFGammaCand != thePFGammaCandsInEllipse.end(); ++iPFGammaCand){
+std::pair<std::vector<reco::CandidatePtr>, std::vector<reco::CandidatePtr>> PFTauElementsOperators::PFGammaCandsInOutEllipse(const std::vector<reco::CandidatePtr>& PFGammaCands_, const Candidate& leadCand_, double rPhi, double rEta, double maxPt) const{
+  std::pair<std::vector<reco::CandidatePtr>,std::vector<reco::CandidatePtr>> myPFGammaCandsInEllipse = PFCandidatesInEllipse_(leadCand_, rPhi, rEta, PFGammaCands_);
+  std::vector<reco::CandidatePtr> thePFGammaCandsInEllipse = myPFGammaCandsInEllipse.first;
+  std::vector<reco::CandidatePtr> thePFGammaCandsOutEllipse = myPFGammaCandsInEllipse.second;
+  std::vector<reco::CandidatePtr> theFilteredPFGammaCandsInEllipse;
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFGammaCand = thePFGammaCandsInEllipse.begin(); iPFGammaCand != thePFGammaCandsInEllipse.end(); ++iPFGammaCand){
     if((**iPFGammaCand).pt() <= maxPt) theFilteredPFGammaCandsInEllipse.push_back(*iPFGammaCand);
     else thePFGammaCandsOutEllipse.push_back(*iPFGammaCand);
   }
-  std::pair<std::vector<reco::PFCandidatePtr>, std::vector<reco::PFCandidatePtr>> theFilteredPFGammaCandsInOutEllipse(theFilteredPFGammaCandsInEllipse, thePFGammaCandsOutEllipse);
+  std::pair<std::vector<reco::CandidatePtr>, std::vector<reco::CandidatePtr>> theFilteredPFGammaCandsInOutEllipse(theFilteredPFGammaCandsInEllipse, thePFGammaCandsOutEllipse);
   
   return theFilteredPFGammaCandsInOutEllipse;
 }
 // EELL
 
 
- std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFCandsInAnnulus(const std::vector<reco::PFCandidatePtr>& thePFCands,const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCands;
-  for (std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=thePFCands.begin();iPFCand!=thePFCands.end();++iPFCand) {
+ std::vector<reco::CandidatePtr> PFTauElementsOperators::PFCandsInAnnulus(const std::vector<reco::CandidatePtr>& thePFCands,const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCands;
+  for (std::vector<reco::CandidatePtr>::const_iterator iPFCand=thePFCands.begin();iPFCand!=thePFCands.end();++iPFCand) {
     if ((**iPFCand).pt()>minPt)theFilteredPFCands.push_back(*iPFCand);
   }  
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInAnnulus;
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInAnnulus;
   if (outercone_metric=="DR"){
     if (innercone_metric=="DR"){
       theFilteredPFCandsInAnnulus=PFCandsinAnnulus_innerDRouterDRmetrics_(myVector,metricDR_,innercone_size,metricDR_,outercone_size,theFilteredPFCands);
@@ -99,7 +102,7 @@ std::pair<std::vector<reco::PFCandidatePtr>, std::vector<reco::PFCandidatePtr>> 
       double innercone_angle=theFixedAreaSignalCone(myVector.theta(),myVector.phi(),0,innercone_size,errorFlag);
       if (errorFlag!=0)return theFilteredPFCandsInAnnulus;
       theFilteredPFCandsInAnnulus=PFCandsinAnnulus_innerAngleouterDRmetrics_(myVector,metricAngle_,innercone_angle,metricDR_,outercone_size,theFilteredPFCands);
-    }else return std::vector<reco::PFCandidatePtr>();
+    }else return std::vector<reco::CandidatePtr>();
   }else if(outercone_metric=="angle"){
     if (innercone_metric=="DR"){
       theFilteredPFCandsInAnnulus=PFCandsinAnnulus_innerDRouterAnglemetrics_(myVector,metricDR_,innercone_size,metricAngle_,outercone_size,theFilteredPFCands);
@@ -112,7 +115,7 @@ std::pair<std::vector<reco::PFCandidatePtr>, std::vector<reco::PFCandidatePtr>> 
       double innercone_angle=theFixedAreaSignalCone(myVector.theta(),myVector.phi(),0,innercone_size,errorFlag);
       if (errorFlag!=0)return theFilteredPFCandsInAnnulus;
       theFilteredPFCandsInAnnulus=PFCandsinAnnulus_innerAngleouterAnglemetrics_(myVector,metricAngle_,innercone_angle,metricAngle_,outercone_size,theFilteredPFCands);
-    }else return std::vector<reco::PFCandidatePtr>();
+    }else return std::vector<reco::CandidatePtr>();
   }else if(outercone_metric=="area"){
     int errorFlag=0;
     FixedAreaIsolationCone theFixedAreaSignalCone;
@@ -129,44 +132,47 @@ std::pair<std::vector<reco::PFCandidatePtr>, std::vector<reco::PFCandidatePtr>> 
       double outercone_angle=theFixedAreaSignalCone(myVector.theta(),myVector.phi(),innercone_angle,outercone_size,errorFlag);
       if (errorFlag!=0)return theFilteredPFCandsInAnnulus;
       theFilteredPFCandsInAnnulus=PFCandsinAnnulus_innerAngleouterAnglemetrics_(myVector,metricAngle_,innercone_angle,metricAngle_,outercone_angle,theFilteredPFCands);
-    }else return std::vector<reco::PFCandidatePtr>();
+    }else return std::vector<reco::CandidatePtr>();
   }
   return theFilteredPFCandsInAnnulus;
 }
- std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
+ std::vector<reco::CandidatePtr> PFTauElementsOperators::PFCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
   return theFilteredPFCandsInAnnulus;
 }
- std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFChargedHadrCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
+ std::vector<reco::CandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFChargedHadrCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
   return theFilteredPFCandsInAnnulus;
 }
-std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const Vertex &myPV)const{     
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=PFChargedHadrCands_.begin();iPFCand!=PFChargedHadrCands_.end();iPFCand++){
-    TrackRef PFChargedHadrCand_track=(**iPFCand).trackRef();
-    if (!PFChargedHadrCand_track)continue;
-    if (fabs((*PFChargedHadrCand_track).dz(myPV.position())-refpoint_Z)<=PFChargedHadrCand_tracktorefpoint_maxDZ) filteredPFChargedHadrCands.push_back(*iPFCand);
+std::vector<reco::CandidatePtr> PFTauElementsOperators::PFChargedHadrCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt,const double PFChargedHadrCand_tracktorefpoint_maxDZ,const double refpoint_Z, const Vertex &myPV)const{     
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=PFChargedHadrCands_.begin();iPFCand!=PFChargedHadrCands_.end();iPFCand++){
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(iPFCand->get());
+    if (pfcand != nullptr) {
+      TrackRef PFChargedHadrCand_track = pfcand->trackRef();
+      if (!PFChargedHadrCand_track)continue;
+      if (fabs((*PFChargedHadrCand_track).dz(myPV.position())-refpoint_Z)<=PFChargedHadrCand_tracktorefpoint_maxDZ) filteredPFChargedHadrCands.push_back(*iPFCand);
+    } else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
   }
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(filteredPFChargedHadrCands,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(filteredPFChargedHadrCands,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
   return theFilteredPFCandsInAnnulus;
 }
- std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFNeutrHadrCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFNeutrHadrCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
+ std::vector<reco::CandidatePtr> PFTauElementsOperators::PFNeutrHadrCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFNeutrHadrCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
   return theFilteredPFCandsInAnnulus;
 }
- std::vector<reco::PFCandidatePtr> PFTauElementsOperators::PFGammaCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
-  std::vector<reco::PFCandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFGammaCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
+ std::vector<reco::CandidatePtr> PFTauElementsOperators::PFGammaCandsInAnnulus(const math::XYZVector& myVector,const string innercone_metric,const double innercone_size,const string outercone_metric,const double outercone_size,const double minPt)const{     
+  std::vector<reco::CandidatePtr> theFilteredPFCandsInAnnulus=PFCandsInAnnulus(PFGammaCands_,myVector,innercone_metric,innercone_size,outercone_metric,outercone_size,minPt);
   return theFilteredPFCandsInAnnulus;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
+CandidatePtr PFTauElementsOperators::leadPFCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
   if (!PFJetRef_) return myleadPFCand;
   math::XYZVector PFJet_XYZVector=(*PFJetRef_).momentum();
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (theFilteredPFCandsInCone.size()>0.){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -175,12 +181,12 @@ PFCandidatePtr PFTauElementsOperators::leadPFCand(const string matchingcone_metr
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
+CandidatePtr PFTauElementsOperators::leadPFCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (!theFilteredPFCandsInCone.empty()){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -189,14 +195,14 @@ PFCandidatePtr PFTauElementsOperators::leadPFCand(const math::XYZVector& myVecto
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFChargedHadrCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
+CandidatePtr PFTauElementsOperators::leadPFChargedHadrCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
   if (!PFJetRef_) return myleadPFCand;
   math::XYZVector PFJet_XYZVector=(*PFJetRef_).momentum();
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFChargedHadrCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFChargedHadrCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (theFilteredPFCandsInCone.size()>0.){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -205,12 +211,12 @@ PFCandidatePtr PFTauElementsOperators::leadPFChargedHadrCand(const string matchi
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFChargedHadrCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFChargedHadrCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
+CandidatePtr PFTauElementsOperators::leadPFChargedHadrCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFChargedHadrCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (!theFilteredPFCandsInCone.empty()){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -219,14 +225,14 @@ PFCandidatePtr PFTauElementsOperators::leadPFChargedHadrCand(const math::XYZVect
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFNeutrHadrCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
+CandidatePtr PFTauElementsOperators::leadPFNeutrHadrCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
   if (!PFJetRef_) return myleadPFCand;
   math::XYZVector PFJet_XYZVector=(*PFJetRef_).momentum();
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFNeutrHadrCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFNeutrHadrCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (theFilteredPFCandsInCone.size()>0.){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -235,12 +241,12 @@ PFCandidatePtr PFTauElementsOperators::leadPFNeutrHadrCand(const string matching
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFNeutrHadrCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFNeutrHadrCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
+CandidatePtr PFTauElementsOperators::leadPFNeutrHadrCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFNeutrHadrCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (!theFilteredPFCandsInCone.empty()){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -249,14 +255,14 @@ PFCandidatePtr PFTauElementsOperators::leadPFNeutrHadrCand(const math::XYZVector
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFGammaCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
+CandidatePtr PFTauElementsOperators::leadPFGammaCand(const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
   if (!PFJetRef_) return myleadPFCand;
   math::XYZVector PFJet_XYZVector=(*PFJetRef_).momentum();
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFGammaCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFGammaCandsInCone(PFJet_XYZVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (theFilteredPFCandsInCone.size()>0.){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand =theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -265,12 +271,12 @@ PFCandidatePtr PFTauElementsOperators::leadPFGammaCand(const string matchingcone
   }
   return myleadPFCand;
 }
-PFCandidatePtr PFTauElementsOperators::leadPFGammaCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
-  PFCandidatePtr myleadPFCand;
-  const std::vector<reco::PFCandidatePtr> theFilteredPFCandsInCone=PFGammaCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
+CandidatePtr PFTauElementsOperators::leadPFGammaCand(const math::XYZVector& myVector,const string matchingcone_metric,const double matchingcone_size,const double minPt)const{
+  CandidatePtr myleadPFCand;
+  const std::vector<reco::CandidatePtr> theFilteredPFCandsInCone=PFGammaCandsInCone(myVector,matchingcone_metric,matchingcone_size,minPt);
   double pt_cut=minPt;
   if (!theFilteredPFCandsInCone.empty()){
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theFilteredPFCandsInCone.begin();iPFCand!=theFilteredPFCandsInCone.end();iPFCand++){
       if((*iPFCand)->pt()>pt_cut) {
 	myleadPFCand=*iPFCand;
 	pt_cut=(**iPFCand).pt();
@@ -281,9 +287,9 @@ PFCandidatePtr PFTauElementsOperators::leadPFGammaCand(const math::XYZVector& my
 }
 
 void
-PFTauElementsOperators::copyCandRefsFilteredByPt(const std::vector<reco::PFCandidatePtr>& theInputCands, std::vector<reco::PFCandidatePtr>& theOutputCands, const double minPt)
+PFTauElementsOperators::copyCandRefsFilteredByPt(const std::vector<reco::CandidatePtr>& theInputCands, std::vector<reco::CandidatePtr>& theOutputCands, const double minPt)
 {
-   for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand  = theInputCands.begin();
+   for(std::vector<reco::CandidatePtr>::const_iterator iPFCand  = theInputCands.begin();
                                             iPFCand != theInputCands.end();
                                             ++iPFCand)
    {
@@ -295,18 +301,18 @@ PFTauElementsOperators::copyCandRefsFilteredByPt(const std::vector<reco::PFCandi
 // Inside Out Signal contents determination algorithm
 // Determines tau signal content by building from seed track
 void
-PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandidatePtr>& theChargedCands, const std::vector<reco::PFCandidatePtr>& theGammaCands,
+PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::CandidatePtr>& theChargedCands, const std::vector<reco::CandidatePtr>& theGammaCands,
        const math::XYZVector& leadTrackVector, const TFormula& coneSizeFormula, double (*ptrToMetricFunction)(const math::XYZVector&, const math::XYZVector&),  
        const double minChargedSize, const double maxChargedSize, const double minNeutralSize, const double maxNeutralSize,
        const double minChargedPt, const double minNeutralPt,
        const string& outlierCollectorConeMetric, const double outlierCollectionMaxSize,
-       std::vector<reco::PFCandidatePtr>& signalChargedObjects, std::vector<reco::PFCandidatePtr>& outlierChargedObjects,
-       std::vector<reco::PFCandidatePtr>& signalGammaObjects, std::vector<reco::PFCandidatePtr>& outlierGammaObjects, bool useScanningAxis) 
+       std::vector<reco::CandidatePtr>& signalChargedObjects, std::vector<reco::CandidatePtr>& outlierChargedObjects,
+       std::vector<reco::CandidatePtr>& signalGammaObjects, std::vector<reco::CandidatePtr>& outlierGammaObjects, bool useScanningAxis) 
 {
    if (theChargedCands.empty() && theGammaCands.empty()) 
       return;
    //copy the vector of PFCands filtering by Pt
-   std::vector<reco::PFCandidatePtr> filteredCands;
+   std::vector<reco::CandidatePtr> filteredCands;
    filteredCands.reserve(theChargedCands.size() + theGammaCands.size());
 
    copyCandRefsFilteredByPt(theChargedCands, filteredCands, minChargedPt);
@@ -327,7 +333,7 @@ PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandi
    //sort the remaining candidates by angle to seed track
    sort(filteredCandIndexes.begin(), filteredCandIndexes.end(), myAngularSorter);
 
-   std::vector<reco::PFCandidatePtr> sortedCands;
+   std::vector<reco::CandidatePtr> sortedCands;
    for(std::vector<uint32_t>::const_iterator theSortedIndex = filteredCandIndexes.begin();
                                         theSortedIndex != filteredCandIndexes.end();
                                         ++theSortedIndex)
@@ -336,7 +342,7 @@ PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandi
    }
 
    //get first candidate (seed trk by definition)
-   std::vector<reco::PFCandidatePtr>::const_iterator signalObjectCandidate = sortedCands.begin();
+   std::vector<reco::CandidatePtr>::const_iterator signalObjectCandidate = sortedCands.begin();
    double totalEnergySoFar                                    = (**signalObjectCandidate).energy();
    double totalEtSoFar                                        = (**signalObjectCandidate).et();
    math::XYZVector axisVectorSoFar                            = leadTrackVector;
@@ -387,7 +393,7 @@ PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandi
    }
    // split the collection into two collections
    double largest3DOpeningAngleSignal = 0.;  //used for area outlier collection cone
-   for (std::vector<reco::PFCandidatePtr>::const_iterator iterCand =  sortedCands.begin();
+   for (std::vector<reco::CandidatePtr>::const_iterator iterCand =  sortedCands.begin();
                                              iterCand != signalObjectCandidate;
                                              ++iterCand)
    {
@@ -435,7 +441,7 @@ PFTauElementsOperators::computeInsideOutContents(const std::vector<reco::PFCandi
                                             << ") is not recognized! All non-signal associated PFJet constituents will be included in the outliers!";
    }
 
-   for (std::vector<reco::PFCandidatePtr>::const_iterator iterCand =  signalObjectCandidate;
+   for (std::vector<reco::CandidatePtr>::const_iterator iterCand =  signalObjectCandidate;
                                              iterCand != sortedCands.end();
                                              ++iterCand)
    {
@@ -460,25 +466,25 @@ double PFTauElementsOperators::discriminatorByIsolPFCandsN(int IsolPFCands_maxN)
 }
 double PFTauElementsOperators::discriminatorByIsolPFCandsN(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFCands_maxN){
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-  const std::vector<reco::PFCandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+  const std::vector<reco::CandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
   if ((int)isolPFCands.size()<=IsolPFCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFCandsN(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFCands_maxN){
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-  const std::vector<reco::PFCandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+  const std::vector<reco::CandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
   if ((int)isolPFCands.size()<=IsolPFCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
@@ -489,25 +495,25 @@ double PFTauElementsOperators::discriminatorByIsolPFChargedHadrCandsN(int IsolPF
 }
 double PFTauElementsOperators::discriminatorByIsolPFChargedHadrCandsN(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFChargedHadrCands_maxN){
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-  std::vector<reco::PFCandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+  std::vector<reco::CandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
   if ((int)isolPFChargedHadrCands.size()<=IsolPFChargedHadrCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFChargedHadrCandsN(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFChargedHadrCands_maxN){
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+   std::vector<reco::CandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
   if ((int)isolPFChargedHadrCands.size()<=IsolPFChargedHadrCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
@@ -518,25 +524,25 @@ double PFTauElementsOperators::discriminatorByIsolPFNeutrHadrCandsN(int IsolPFNe
 }
 double PFTauElementsOperators::discriminatorByIsolPFNeutrHadrCandsN(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFNeutrHadrCands_maxN){
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+   std::vector<reco::CandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
   if ((int)isolPFNeutrHadrCands.size()<=IsolPFNeutrHadrCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFNeutrHadrCandsN(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFNeutrHadrCands_maxN){
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+   std::vector<reco::CandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
   if ((int)isolPFNeutrHadrCands.size()<=IsolPFNeutrHadrCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
@@ -547,165 +553,165 @@ double PFTauElementsOperators::discriminatorByIsolPFGammaCandsN(int IsolPFGammaC
 }
 double PFTauElementsOperators::discriminatorByIsolPFGammaCandsN(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFGammaCands_maxN){
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+   std::vector<reco::CandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
   if ((int)isolPFGammaCands.size()<=IsolPFGammaCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFGammaCandsN(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,int IsolPFGammaCands_maxN){
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+   std::vector<reco::CandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
   if ((int)isolPFGammaCands.size()<=IsolPFGammaCands_maxN) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFCandsEtSum(double IsolPFCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=IsolPFCands_.begin();iPFCand!=IsolPFCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=IsolPFCands_.begin();iPFCand!=IsolPFCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFCandsEtSum(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFCands.begin();iPFCand!=isolPFCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFCands.begin();iPFCand!=isolPFCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFCandsEtSum(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFCands.begin();iPFCand!=isolPFCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFCands=PFCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFCands.begin();iPFCand!=isolPFCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFChargedHadrCandsEtSum(double IsolPFChargedHadrCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=IsolPFChargedHadrCands_.begin();iPFCand!=IsolPFChargedHadrCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=IsolPFChargedHadrCands_.begin();iPFCand!=IsolPFChargedHadrCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFChargedHadrCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFChargedHadrCandsEtSum(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFChargedHadrCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFChargedHadrCands.begin();iPFCand!=isolPFChargedHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFChargedHadrCands.begin();iPFCand!=isolPFChargedHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFChargedHadrCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFChargedHadrCandsEtSum(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFChargedHadrCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFChargedHadrCands.begin();iPFCand!=isolPFChargedHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFChargedHadrCands=PFChargedHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFChargedHadrCands.begin();iPFCand!=isolPFChargedHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFChargedHadrCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFNeutrHadrCandsEtSum(double IsolPFNeutrHadrCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=IsolPFNeutrHadrCands_.begin();iPFCand!=IsolPFNeutrHadrCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=IsolPFNeutrHadrCands_.begin();iPFCand!=IsolPFNeutrHadrCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFNeutrHadrCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFNeutrHadrCandsEtSum(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFNeutrHadrCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFNeutrHadrCands.begin();iPFCand!=isolPFNeutrHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFNeutrHadrCands.begin();iPFCand!=isolPFNeutrHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFNeutrHadrCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFNeutrHadrCandsEtSum(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFNeutrHadrCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFNeutrHadrCands.begin();iPFCand!=isolPFNeutrHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFNeutrHadrCands=PFNeutrHadrCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFNeutrHadrCands.begin();iPFCand!=isolPFNeutrHadrCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFNeutrHadrCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFGammaCandsEtSum(double IsolPFGammaCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=IsolPFGammaCands_.begin();iPFCand!=IsolPFGammaCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=IsolPFGammaCands_.begin();iPFCand!=IsolPFGammaCands_.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFGammaCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFGammaCandsEtSum(string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFGammaCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0.;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   if(!myleadPFCand)return myDiscriminator;
   if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFGammaCands.begin();iPFCand!=isolPFGammaCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);   
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFGammaCands.begin();iPFCand!=isolPFGammaCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFGammaCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }
 double PFTauElementsOperators::discriminatorByIsolPFGammaCandsEtSum(const math::XYZVector& myVector,string matchingcone_metric,double matchingcone_size,string signalcone_metric,double signalcone_size,string isolcone_metric,double isolcone_size,bool useOnlyChargedHadrforleadPFCand,double minPt_leadPFCand,double minPt_PFCand,double IsolPFGammaCands_maxEtSum){
   double myIsolPFCandsEtSum=0.;
   double myDiscriminator=0;
-  PFCandidatePtr myleadPFCand;
+  CandidatePtr myleadPFCand;
   if (useOnlyChargedHadrforleadPFCand) myleadPFCand=leadPFChargedHadrCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand);  
   else myleadPFCand=leadPFCand(myVector,matchingcone_metric,matchingcone_size,minPt_leadPFCand); 
   if(!myleadPFCand)return myDiscriminator;
   //if(signalcone_size>=isolcone_size) return 1.;
   math::XYZVector leadPFCand_XYZVector=(*myleadPFCand).momentum() ;
-   std::vector<reco::PFCandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
-  for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=isolPFGammaCands.begin();iPFCand!=isolPFGammaCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
+   std::vector<reco::CandidatePtr> isolPFGammaCands=PFGammaCandsInAnnulus(leadPFCand_XYZVector,signalcone_metric,signalcone_size,isolcone_metric,isolcone_size,minPt_PFCand);  
+  for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=isolPFGammaCands.begin();iPFCand!=isolPFGammaCands.end();iPFCand++) myIsolPFCandsEtSum+=(**iPFCand).et();
   if (myIsolPFCandsEtSum<=IsolPFGammaCands_maxEtSum) myDiscriminator=1;
   return myDiscriminator;
 }

--- a/RecoTauTag/TauTagTools/src/TauTagTools.cc
+++ b/RecoTauTag/TauTagTools/src/TauTagTools.cc
@@ -1,4 +1,5 @@
 #include "RecoTauTag/TauTagTools/interface/TauTagTools.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 using namespace reco;
 using std::string;
@@ -101,64 +102,72 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredTracks;
   }
 
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(const std::vector<reco::PFCandidatePtr>& theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn){
-    std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h  || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::mu || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::e){
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCandsByNumTrkHits(const std::vector<reco::CandidatePtr>& theInitialPFCands, int ChargedHadrCand_tkminTrackerHitsn){
+    std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
+      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 || std::abs((*iPFCand)->pdgId()) == 11){
 	// *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties. 
-	TrackRef PFChargedHadrCand_rectk = (**iPFCand).trackRef();
+	const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(iPFCand->get());
+	if (pfcand != nullptr) {
+	  TrackRef PFChargedHadrCand_rectk = pfcand->trackRef();
 
-	if (!PFChargedHadrCand_rectk)continue;
-	if ( (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn )
-	  filteredPFChargedHadrCands.push_back(*iPFCand);
+	  if (!PFChargedHadrCand_rectk)continue;
+	  if ( (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn )
+	    filteredPFChargedHadrCands.push_back(*iPFCand);
+	} else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
       }
     }
     return filteredPFChargedHadrCands;
   }
 
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, Vertex pv){
-    std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h  || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::mu || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::e){
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2, Vertex pv){
+    std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
+      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 || std::abs((*iPFCand)->pdgId()) == 11){
 	// *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties. 
-	TrackRef PFChargedHadrCand_rectk = (**iPFCand).trackRef();
+	const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(iPFCand->get());
+	if (pfcand != nullptr) {
+	  TrackRef PFChargedHadrCand_rectk = pfcand->trackRef();
 	
-
-	if (!PFChargedHadrCand_rectk)continue;
-	if ((*PFChargedHadrCand_rectk).pt()>=ChargedHadrCand_tkminPt &&
-	    (*PFChargedHadrCand_rectk).normalizedChi2()<=ChargedHadrCand_tkmaxChi2 &&
-	    fabs((*PFChargedHadrCand_rectk).dxy(pv.position()))<=ChargedHadrCand_tkmaxipt &&
-	    (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn &&
-	    (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits()>=ChargedHadrCand_tkminPixelHitsn) 
-	  filteredPFChargedHadrCands.push_back(*iPFCand);
+	  if (!PFChargedHadrCand_rectk)continue;
+	  if ((*PFChargedHadrCand_rectk).pt()>=ChargedHadrCand_tkminPt &&
+	      (*PFChargedHadrCand_rectk).normalizedChi2()<=ChargedHadrCand_tkmaxChi2 &&
+	      fabs((*PFChargedHadrCand_rectk).dxy(pv.position()))<=ChargedHadrCand_tkmaxipt &&
+	      (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn &&
+	      (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits()>=ChargedHadrCand_tkminPixelHitsn) 
+	    filteredPFChargedHadrCands.push_back(*iPFCand);
+	} else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
       }
     }
     return filteredPFChargedHadrCands;
   }
-  std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,Vertex pv, double refpoint_Z){
+  std::vector<reco::CandidatePtr> filteredPFChargedHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double ChargedHadrCand_tkminPt,int ChargedHadrCand_tkminPixelHitsn,int ChargedHadrCand_tkminTrackerHitsn,double ChargedHadrCand_tkmaxipt,double ChargedHadrCand_tkmaxChi2,double ChargedHadrCand_tktorefpointmaxDZ,Vertex pv, double refpoint_Z){
     if(pv.isFake()) ChargedHadrCand_tktorefpointmaxDZ = 30.;
-    std::vector<reco::PFCandidatePtr> filteredPFChargedHadrCands;
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h  || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::mu || PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::e){
+    std::vector<reco::CandidatePtr> filteredPFChargedHadrCands;
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
+      if (std::abs((*iPFCand)->pdgId()) == 211 || std::abs((*iPFCand)->pdgId()) == 13 || std::abs((*iPFCand)->pdgId()) == 11){
 	// *** Whether the charged hadron candidate will be selected or not depends on its rec. tk properties. 
-	TrackRef PFChargedHadrCand_rectk = (**iPFCand).trackRef();
-	if (!PFChargedHadrCand_rectk)continue;
-	if ((*PFChargedHadrCand_rectk).pt()>=ChargedHadrCand_tkminPt &&
-	    (*PFChargedHadrCand_rectk).normalizedChi2()<=ChargedHadrCand_tkmaxChi2 &&
-	    fabs((*PFChargedHadrCand_rectk).dxy(pv.position()))<=ChargedHadrCand_tkmaxipt &&
-	    (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn &&
-	    (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits()>=ChargedHadrCand_tkminPixelHitsn &&
-	    fabs((*PFChargedHadrCand_rectk).dz(pv.position()))<=ChargedHadrCand_tktorefpointmaxDZ)
-	  filteredPFChargedHadrCands.push_back(*iPFCand);
+	const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(iPFCand->get());
+	if (pfcand != nullptr) {
+	  TrackRef PFChargedHadrCand_rectk = pfcand->trackRef();
+	  if (!PFChargedHadrCand_rectk)continue;
+	  if ((*PFChargedHadrCand_rectk).pt()>=ChargedHadrCand_tkminPt &&
+	      (*PFChargedHadrCand_rectk).normalizedChi2()<=ChargedHadrCand_tkmaxChi2 &&
+	      fabs((*PFChargedHadrCand_rectk).dxy(pv.position()))<=ChargedHadrCand_tkmaxipt &&
+	      (*PFChargedHadrCand_rectk).numberOfValidHits()>=ChargedHadrCand_tkminTrackerHitsn &&
+	      (*PFChargedHadrCand_rectk).hitPattern().numberOfValidPixelHits()>=ChargedHadrCand_tkminPixelHitsn &&
+	      fabs((*PFChargedHadrCand_rectk).dz(pv.position()))<=ChargedHadrCand_tktorefpointmaxDZ)
+	    filteredPFChargedHadrCands.push_back(*iPFCand);
+	} else throw cms::Exception("Type Mismatch") << "The PFTau was not made from PFCandidates, and this outdated algorithm was not updated to cope with PFTaus made from other Candidates.\n";
       }
     }
     return filteredPFChargedHadrCands;
   }
   
-  std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt){
-    std::vector<reco::PFCandidatePtr> filteredPFNeutrHadrCands;
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::h0){
+  std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double NeutrHadrCand_HcalclusMinEt){
+    std::vector<reco::CandidatePtr> filteredPFNeutrHadrCands;
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
+      if (std::abs((*iPFCand)->pdgId()) == 130){
 	// *** Whether the neutral hadron candidate will be selected or not depends on its rec. HCAL cluster properties. 
 	if ((**iPFCand).et()>=NeutrHadrCand_HcalclusMinEt){
 	  filteredPFNeutrHadrCands.push_back(*iPFCand);
@@ -168,10 +177,10 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     return filteredPFNeutrHadrCands;
   }
   
-  std::vector<reco::PFCandidatePtr> filteredPFGammaCands(const std::vector<reco::PFCandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt){
-    std::vector<reco::PFCandidatePtr> filteredPFGammaCands;
-    for(std::vector<reco::PFCandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
-      if (PFCandidate::ParticleType((**iPFCand).particleId())==PFCandidate::gamma){
+  std::vector<reco::CandidatePtr> filteredPFGammaCands(const std::vector<reco::CandidatePtr>& theInitialPFCands,double GammaCand_EcalclusMinEt){
+    std::vector<reco::CandidatePtr> filteredPFGammaCands;
+    for(std::vector<reco::CandidatePtr>::const_iterator iPFCand=theInitialPFCands.begin();iPFCand!=theInitialPFCands.end();iPFCand++){
+      if (std::abs((*iPFCand)->pdgId()) == 22){
 	// *** Whether the gamma candidate will be selected or not depends on its rec. ECAL cluster properties. 
 	if ((**iPFCand).et()>=GammaCand_EcalclusMinEt){
 	  filteredPFGammaCands.push_back(*iPFCand);
@@ -239,7 +248,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
 
 
   void 
-  sortRefVectorByPt(std::vector<reco::PFCandidatePtr>& vec)
+  sortRefVectorByPt(std::vector<reco::CandidatePtr>& vec)
   {
 
     std::vector<size_t> indices;
@@ -251,7 +260,7 @@ void replaceSubStr(string& s,const string& oldSubStr,const string& newSubStr){
     std::sort(indices.begin(),indices.end(),sorter);
     
     
-    std::vector<reco::PFCandidatePtr> sorted;
+    std::vector<reco::CandidatePtr> sorted;
     sorted.reserve(vec.size());
     
     for(unsigned int i=0;i<indices.size();++i)

--- a/Validation/RecoTau/interface/TauTagValidation.h
+++ b/Validation/RecoTau/interface/TauTagValidation.h
@@ -83,7 +83,7 @@ private:
   /// label of the current module
   std::string moduleLabel_;
   ///sum the transversal momentum of all candidates
-  double getSumPt(const std::vector<edm::Ptr<reco::PFCandidate> > & candidates);
+  double getSumPt(const std::vector<edm::Ptr<reco::Candidate> > & candidates);
   ///get rid of redundant parts to shorten the label
   bool stripDiscriminatorLabel(const std::string& discriminatorLabel, std::string & newLabel);
 

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -600,9 +600,9 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   }//End of PFTau Collection If Loop
 }
 
-double TauTagValidation::getSumPt(const std::vector<edm::Ptr<reco::PFCandidate> > & candidates ){
+double TauTagValidation::getSumPt(const std::vector<edm::Ptr<reco::Candidate> > & candidates ){
   double sumPt = 0.;
-  for (std::vector<edm::Ptr<reco::PFCandidate> >::const_iterator candidate = candidates.begin(); candidate!=candidates.end(); ++candidate) {
+  for (std::vector<edm::Ptr<reco::Candidate> >::const_iterator candidate = candidates.begin(); candidate!=candidates.end(); ++candidate) {
     sumPt += (*candidate)->pt();
   }
   return sumPt;


### PR DESCRIPTION
These changes make it possible to apply tau reconstruction based on MiniAOD input. The main technical change, which has many implications, is to change the reco::PFTau class from using PFCandidatePtrs to CandidatePtrs, and from using PFJetRefs to JetBaseRefs, which allows all relevant plugins to run with a consistent PFTau class regardless of whether this PFTau was built from RECO/AOD or from MiniAOD input.

Several developments were made by @mbluj 

A few notes:
- The usual rejection algorithms of muon->tauh and electron->tauh fakes require input that is not available on MiniAOD. There is a simplified anti-muon rejection (developed by @mbluj) included in this PR. Additional investigation is needed on how to make electron->tauh rejection available (e.g. extend the MiniAOD event content), which should be decoupled from this PR.
- Reconstructed taus are mostly (~99%) well compatible. The main understood difference in taus reconstructed on MiniAOD input is that tracks that don't pass the HighPurity flag are occasionally used in the tau reconstruction, but are not saved in MiniAOD. However, these changes do not seem to affect the general performance. Other minor differences may need further investigation, but are also not essential for this PR.