### PR TITLE
plots for DQM tau

### DIFF
--- a/Validation/RecoTau/interface/TauTagValidation.h
+++ b/Validation/RecoTau/interface/TauTagValidation.h
@@ -139,7 +139,7 @@ private:
   std::map<std::string,  MonitorElement *> plotMap_;
   std::map<std::string,  MonitorElement *> summaryMap;
 
-  std::map<std::string,  int> tauDeacyCountMap_;
+  std::map<std::string,  int> tauDecayCountMap_;
 
   MonitorElement* nTaus_;
 

--- a/Validation/RecoTau/interface/TauTagValidation.h
+++ b/Validation/RecoTau/interface/TauTagValidation.h
@@ -137,6 +137,7 @@ private:
   std::map<std::string,  MonitorElement *> nTauVisibleMap;
   std::map<std::string,  MonitorElement *> massTauVisibleMap;
   std::map<std::string,  MonitorElement *> plotMap_;
+  std::map<std::string,  MonitorElement *> summaryMap;
 
   std::map<std::string,  int> tauDeacyCountMap_;
 

--- a/Validation/RecoTau/python/DQMMCValidation_cfi.py
+++ b/Validation/RecoTau/python/DQMMCValidation_cfi.py
@@ -32,12 +32,19 @@ produceDenoms = cms.Sequence(
 
 runTauEff = cms.Sequence(
     efficienciesQCD+
+    efficienciesQCDSummary+
     efficienciesRealData+
+    efficienciesRealDataSummary+
     efficienciesRealElectronsData+
+    efficienciesRealElectronsDataSummary+
     efficienciesRealMuonsData+
+    efficienciesRealMuonsDataSummary+
     efficienciesZEE+
+    efficienciesZEESummary+
     efficienciesZMM+
+    efficienciesZMMSummary+
     efficienciesZTT+
+    efficienciesZTTSummary+
     normalizePlotsZTT
     )
 ##Full sequences, including normalizations

--- a/Validation/RecoTau/python/DQMSequences_cfi.py
+++ b/Validation/RecoTau/python/DQMSequences_cfi.py
@@ -33,8 +33,11 @@ pfTauRunDQMValidation = cms.Sequence(
 
 runTauEff = cms.Sequence(
     efficienciesRealData+
+    efficienciesRealDataSummary+
     efficienciesRealElectronsData+
+    efficienciesRealElectronsDataSummary+
     efficienciesRealMuonsData+
+    efficienciesRealMuonsDataSummary+
     normalizePlotsRealMuonsData
     )
 

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
@@ -25,8 +25,40 @@ zttLabeler = lambda module : SetValidationExtention(module, 'QCD')
 zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorQCD.visit(zttModifier)
 
+#Set discriminators
+proc.RunHPSValidationQCD.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesQCD.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorQCD)
+proc.efficienciesQCDSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerQCD_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerQCD_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerQCD_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('QCD') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
@@ -26,7 +26,8 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorQCD.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationQCD.discriminators = cms.VPSet([p for p in proc.RunHPSValidationQCD.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+proc.RunHPSValidationQCD.discriminators = cms.VPSet([p for p in proc.RunHPSValidationQCD.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesQCD.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorQCD)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
@@ -26,25 +26,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorQCD.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationQCD.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationQCD.discriminators = cms.VPSet([p for p in proc.RunHPSValidationQCD.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesQCD.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorQCD)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnQCD_cff.py
@@ -26,7 +26,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorQCD.visit(zttModifier)
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBoldDMwLT', 'IsolationMVArun2v1DBnewDMwLT']
 proc.RunHPSValidationQCD.discriminators = cms.VPSet([p for p in proc.RunHPSValidationQCD.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
@@ -46,7 +46,7 @@ proc.TauValNumeratorAndDenominatorRealData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBoldDMwLT', 'IsolationMVArun2v1DBnewDMwLT']
 proc.RunHPSValidationRealData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealData.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
@@ -46,25 +46,7 @@ proc.TauValNumeratorAndDenominatorRealData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-proc.RunHPSValidationRealData.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationRealData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealData.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealData)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
@@ -45,8 +45,40 @@ zttModifier = ApplyFunctionToSequence(lambda m: setBinning(m,binning))
 proc.TauValNumeratorAndDenominatorRealData.visit(zttModifier)
 #-----------------------------------------
 
+#Set discriminators
+proc.RunHPSValidationRealData.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealData)
+proc.efficienciesRealDataSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerRealData_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerRealData_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerRealData_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('RealData') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
@@ -46,7 +46,8 @@ proc.TauValNumeratorAndDenominatorRealData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-proc.RunHPSValidationRealData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealData.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+proc.RunHPSValidationRealData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealData.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealData)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
@@ -121,7 +121,7 @@ proc.TauValNumeratorAndDenominatorRealElectronsData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'MVA6']
+discs_to_retain = ['ByDecayModeFinding', 'ElectronRejection']
 proc.RunHPSValidationRealElectronsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealElectronsData.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
@@ -121,15 +121,7 @@ proc.TauValNumeratorAndDenominatorRealElectronsData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-proc.RunHPSValidationRealElectronsData.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VLooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6LooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6MediumElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6TightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationRealElectronsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealElectronsData.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MVA6' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealElectronsData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealElectronsData)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
@@ -120,8 +120,30 @@ zttModifier = ApplyFunctionToSequence(lambda m: setBinning(m,binning))
 proc.TauValNumeratorAndDenominatorRealElectronsData.visit(zttModifier)
 #-----------------------------------------
 
+#Set discriminators
+proc.RunHPSValidationRealElectronsData.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VLooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6LooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6MediumElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6TightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealElectronsData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealElectronsData)
+proc.efficienciesRealElectronsDataSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerRealElectronsData_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerRealElectronsData_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerRealElectronsData_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('RealElectronsData') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
@@ -121,7 +121,8 @@ proc.TauValNumeratorAndDenominatorRealElectronsData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-proc.RunHPSValidationRealElectronsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealElectronsData.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MVA6' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'MVA6']
+proc.RunHPSValidationRealElectronsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealElectronsData.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealElectronsData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealElectronsData)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
@@ -103,7 +103,8 @@ proc.TauValNumeratorAndDenominatorRealMuonsData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-proc.RunHPSValidationRealMuonsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealMuonsData.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MuonRejection3' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'MuonRejection3']
+proc.RunHPSValidationRealMuonsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealMuonsData.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealMuonsData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealMuonsData)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
@@ -103,7 +103,7 @@ proc.TauValNumeratorAndDenominatorRealMuonsData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'MuonRejection3']
+discs_to_retain = ['ByDecayModeFinding', 'MuonRejection']
 proc.RunHPSValidationRealMuonsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealMuonsData.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
@@ -103,12 +103,7 @@ proc.TauValNumeratorAndDenominatorRealMuonsData.visit(zttModifier)
 #-----------------------------------------
 
 #Set discriminators
-proc.RunHPSValidationRealMuonsData.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-)
+proc.RunHPSValidationRealMuonsData.discriminators = cms.VPSet([p for p in proc.RunHPSValidationRealMuonsData.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MuonRejection3' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealMuonsData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealMuonsData)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
@@ -102,8 +102,27 @@ zttModifier = ApplyFunctionToSequence(lambda m: setBinning(m,binning))
 proc.TauValNumeratorAndDenominatorRealMuonsData.visit(zttModifier)
 #-----------------------------------------
 
+#Set discriminators
+proc.RunHPSValidationRealMuonsData.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesRealMuonsData.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorRealMuonsData)
+proc.efficienciesRealMuonsDataSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerRealMuonsData_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerRealMuonsData_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerRealMuonsData_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('RealMuonsData') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
@@ -18,7 +18,8 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEEFastSim.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZEEFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEEFastSim.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MVA6' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'MVA6']
+proc.RunHPSValidationZEEFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEEFastSim.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZEEFastSim.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZEEFastSim)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
@@ -17,8 +17,30 @@ zttLabeler = lambda module : SetValidationExtention(module, 'FastSim')
 zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEEFastSim.visit(zttModifier)
 
+#Set discriminators
+proc.RunHPSValidationZEEFastSim.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VLooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6LooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6MediumElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6TightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZEEFastSim.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZEEFastSim)
+proc.efficienciesZEEFastSimSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerZEEFastSim_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerZEEFastSim_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerZEEFastSim_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('FastSim') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
@@ -18,7 +18,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEEFastSim.visit(zttModifier)
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'MVA6']
+discs_to_retain = ['ByDecayModeFinding', 'ElectronRejection']
 proc.RunHPSValidationZEEFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEEFastSim.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEEFastSim_cff.py
@@ -18,15 +18,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEEFastSim.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZEEFastSim.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VLooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6LooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6MediumElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6TightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationZEEFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEEFastSim.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MVA6' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZEEFastSim.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZEEFastSim)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
@@ -42,7 +42,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEE.visit(zttModifier)
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'MVA6']
+discs_to_retain = ['ByDecayModeFinding', 'ElectronRejection']
 proc.RunHPSValidationZEE.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEE.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
@@ -41,8 +41,30 @@ zttLabeler = lambda module : SetValidationExtention(module, 'ZEE')
 zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEE.visit(zttModifier)
 
+#Set discriminators
+proc.RunHPSValidationZEE.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VLooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6LooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6MediumElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6TightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZEE.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZEE)
+proc.efficienciesZEESummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerZEE_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerZEE_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerZEE_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('ZEE') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
@@ -42,15 +42,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEE.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZEE.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VLooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6LooseElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6MediumElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6TightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMVA6VTightElectronRejection"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationZEE.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEE.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MVA6' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZEE.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZEE)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZEE_cff.py
@@ -42,7 +42,8 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZEE.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZEE.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEE.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MVA6' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'MVA6']
+proc.RunHPSValidationZEE.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZEE.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZEE.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZEE)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
@@ -39,7 +39,8 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZMM.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZMM.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZMM.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MuonRejection3' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'MuonRejection3']
+proc.RunHPSValidationZMM.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZMM.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZMM.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZMM)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
@@ -39,7 +39,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZMM.visit(zttModifier)
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'MuonRejection3']
+discs_to_retain = ['ByDecayModeFinding', 'MuonRejection']
 proc.RunHPSValidationZMM.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZMM.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
@@ -38,8 +38,27 @@ zttLabeler = lambda module : SetValidationExtention(module, 'ZMM')
 zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZMM.visit(zttModifier)
 
+#Set discriminators
+proc.RunHPSValidationZMM.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZMM.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZMM)
+proc.efficienciesZMMSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerZMM_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerZMM_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerZMM_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('ZMM') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZMM_cff.py
@@ -39,12 +39,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZMM.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZMM.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightMuonRejection3"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-)
+proc.RunHPSValidationZMM.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZMM.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'MuonRejection3' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZMM.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZMM)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
@@ -17,8 +17,40 @@ zttLabeler = lambda module : SetValidationExtention(module, 'FastSim')
 zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTTFastSim.visit(zttModifier)
 
+#Set discriminators
+proc.RunHPSValidationZTTFastSim.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZTTFastSim.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZTTFastSim)
+proc.efficienciesZTTFastSimSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerZTTFastSim_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerZTTFastSim_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerZTTFastSim_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('FastSim') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
@@ -18,7 +18,8 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTTFastSim.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZTTFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTTFastSim.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+proc.RunHPSValidationZTTFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTTFastSim.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZTTFastSim.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZTTFastSim)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
@@ -18,7 +18,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTTFastSim.visit(zttModifier)
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBoldDMwLT', 'IsolationMVArun2v1DBnewDMwLT', 'MuonRejection', 'ElectronRejection']
 proc.RunHPSValidationZTTFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTTFastSim.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTTFastSim_cff.py
@@ -18,25 +18,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTTFastSim.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZTTFastSim.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationZTTFastSim.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTTFastSim.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZTTFastSim.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZTTFastSim)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
@@ -32,25 +32,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTT.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZTT.discriminators = cms.VPSet(
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
-   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
-)
+proc.RunHPSValidationZTT.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTT.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZTT.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZTT)

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
@@ -31,8 +31,40 @@ zttLabeler = lambda module : SetValidationExtention(module, 'ZTT')
 zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTT.visit(zttModifier)
 
+#Set discriminators
+proc.RunHPSValidationZTT.discriminators = cms.VPSet(
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFinding"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByDecayModeFindingNewDMs"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr3Hits"),selectionCut = cms.double(0.5),plotStep = cms.bool(True)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1DBnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByLooseIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByMediumIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False)),
+   cms.PSet( discriminator = cms.string("hpsPFTauDiscriminationByVVTightIsolationMVArun2v1PWnewDMwLT"),selectionCut = cms.double(0.5),plotStep = cms.bool(False))
+)
+
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZTT.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZTT)
+proc.efficienciesZTTSummary = cms.EDProducer("TauDQMHistEffProducer",
+    plots = cms.PSet(
+        Summary = cms.PSet(
+            denominator = cms.string('RecoTauV/hpsPFTauProducerZTT_Summary/#PAR#PlotDen'),
+            efficiency = cms.string('RecoTauV/hpsPFTauProducerZTT_Summary/#PAR#Plot'),
+            numerator = cms.string('RecoTauV/hpsPFTauProducerZTT_Summary/#PAR#PlotNum'),
+            parameter = cms.vstring('summary'),
+            stepByStep = cms.bool(True)
+        ),
+    )
+)
 
 #checks what's new in the process (the cloned sequences and modules in them)
 newProcAttributes = [x for x in dir(proc) if (x not in procAttributes) and (x.find('ZTT') != -1)]

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
@@ -32,7 +32,7 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTT.visit(zttModifier)
 
 #Set discriminators
-discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBoldDMwLT', 'IsolationMVArun2v1DBnewDMwLT', 'MuonRejection', 'ElectronRejection']
 proc.RunHPSValidationZTT.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTT.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnZTT_cff.py
@@ -32,7 +32,8 @@ zttModifier = ApplyFunctionToSequence(zttLabeler)
 proc.TauValNumeratorAndDenominatorZTT.visit(zttModifier)
 
 #Set discriminators
-proc.RunHPSValidationZTT.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTT.discriminators if 'ByDecayModeFinding' in p.discriminator.value() or 'CombinedIsolationDBSumPtCorr3Hits' in p.discriminator.value() or 'IsolationMVArun2v1DBnewDMwLT' in p.discriminator.value() or 'IsolationMVArun2v1PWnewDMwLT' in p.discriminator.value() ])
+discs_to_retain = ['ByDecayModeFinding', 'CombinedIsolationDBSumPtCorr3Hits', 'IsolationMVArun2v1DBnewDMwLT', 'IsolationMVArun2v1PWnewDMwLT']
+proc.RunHPSValidationZTT.discriminators = cms.VPSet([p for p in proc.RunHPSValidationZTT.discriminators if any(disc in p.discriminator.value() for disc in discs_to_retain) ])
 
 #Sets the correct naming to efficiency histograms
 proc.efficienciesZTT.plots = Utils.SetPlotSequence(proc.TauValNumeratorAndDenominatorZTT)

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -374,24 +374,24 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   for ( std::vector< edm::ParameterSet >::iterator it = discriminators_.begin(); it!= discriminators_.end();  it++)
   {
     string DiscriminatorLabel = it->getParameter<string>("discriminator");
-    tauDeacyCountMap_.insert(std::make_pair("allHadronic" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("oneProng0Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("oneProng1Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("oneProng2Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("twoProng0Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("twoProng1Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("twoProng2Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("threeProng0Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.insert(std::make_pair("threeProng1Pi0" + DiscriminatorLabel, 0.));
-    tauDeacyCountMap_.find( "allHadronic"   + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "oneProng0Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "oneProng1Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "oneProng2Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "twoProng0Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "twoProng1Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "twoProng2Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "threeProng0Pi0"+ DiscriminatorLabel)->second = 0;
-    tauDeacyCountMap_.find( "threeProng1Pi0"+ DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.insert(std::make_pair("allHadronic" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("oneProng0Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("oneProng1Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("oneProng2Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("twoProng0Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("twoProng1Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("twoProng2Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("threeProng0Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.insert(std::make_pair("threeProng1Pi0" + DiscriminatorLabel, 0));
+    tauDecayCountMap_.find( "allHadronic"   + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "oneProng0Pi0"  + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "oneProng1Pi0"  + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "oneProng2Pi0"  + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "twoProng0Pi0"  + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "twoProng1Pi0"  + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "twoProng2Pi0"  + DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "threeProng0Pi0"+ DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_.find( "threeProng1Pi0"+ DiscriminatorLabel)->second = 0;
   }
 
   typedef edm::View<reco::Candidate> genCandidateCollection;
@@ -505,7 +505,7 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           plotMap_.find( currentDiscriminatorLabel + "_TauCandMass" )->second->Fill(TAU.M());
 
           //Tau Counter, allHadronic mode
-          tauDeacyCountMap_.find( "allHadronic" + currentDiscriminatorLabel)->second++;
+          tauDecayCountMap_.find( "allHadronic" + currentDiscriminatorLabel)->second++;
 
 	  /*
           //is there a better way than casting the candidate?
@@ -514,41 +514,41 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
             std::string genTauDecayMode =  JetMCTagUtils::genTauDecayMode(*tauGenJet); // gen_particle is the tauGenJet matched to the reconstructed tau
             element = plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + genTauDecayMode );
             if( element != plotMap_.end() ) element->second->Fill(tauPtRes);
-            tauDeacyCountMap_.find( genTauDecayMode + currentDiscriminatorLabel)->second++;
+            tauDecayCountMap_.find( genTauDecayMode + currentDiscriminatorLabel)->second++;
           }else{
             LogInfo("TauTagValidation") << " Failed to cast the MC candidate.";
 	  }*/
 
           if (thePFTau->decayMode() == reco::PFTau::kOneProng0PiZero){
-            tauDeacyCountMap_.find("oneProng0Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("oneProng0Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "oneProng0Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kOneProng1PiZero){
-            tauDeacyCountMap_.find("oneProng1Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("oneProng1Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "oneProng1Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kOneProng2PiZero){
-            tauDeacyCountMap_.find("oneProng2Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("oneProng2Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "oneProng2Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kTwoProng0PiZero){
-            tauDeacyCountMap_.find("twoProng0Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("twoProng0Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "twoProng0Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kTwoProng1PiZero){
-            tauDeacyCountMap_.find("twoProng1Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("twoProng1Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "twoProng1Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kTwoProng2PiZero){
-            tauDeacyCountMap_.find("twoProng2Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("twoProng2Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "twoProng2Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kThreeProng0PiZero){
-            tauDeacyCountMap_.find("threeProng0Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("threeProng0Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "threeProng0Pi0")->second->Fill(tauPtRes);
           }
           else if (thePFTau->decayMode() == reco::PFTau::kThreeProng1PiZero){
-            tauDeacyCountMap_.find("threeProng1Pi0" + currentDiscriminatorLabel)->second++; 
+            tauDecayCountMap_.find("threeProng1Pi0" + currentDiscriminatorLabel)->second++; 
             plotMap_.find( currentDiscriminatorLabel + "_pTRatio_" + "threeProng1Pi0")->second->Fill(tauPtRes);
           }
           //fill: size and sumPt within tau isolation
@@ -613,15 +613,15 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     //Fill the Tau Multiplicity Histograms
     for ( std::vector< edm::ParameterSet >::iterator it = discriminators_.begin(); it!= discriminators_.end();  it++){
       string currentDiscriminatorLabel = it->getParameter<string>("discriminator");
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_allHadronic")->second->Fill(tauDeacyCountMap_.find( "allHadronic" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng0Pi0")->second->Fill(tauDeacyCountMap_.find( "oneProng0Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng1Pi0")->second->Fill(tauDeacyCountMap_.find( "oneProng1Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng2Pi0")->second->Fill(tauDeacyCountMap_.find( "oneProng2Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_twoProng0Pi0")->second->Fill(tauDeacyCountMap_.find( "twoProng0Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_twoProng1Pi0")->second->Fill(tauDeacyCountMap_.find( "twoProng1Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_twoProng2Pi0")->second->Fill(tauDeacyCountMap_.find( "twoProng2Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_threeProng0Pi0")->second->Fill(tauDeacyCountMap_.find( "threeProng0Pi0" + currentDiscriminatorLabel)->second);      
-      plotMap_.find(currentDiscriminatorLabel + "_nTaus_threeProng1Pi0")->second->Fill(tauDeacyCountMap_.find( "threeProng1Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_allHadronic")->second->Fill(tauDecayCountMap_.find( "allHadronic" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng0Pi0")->second->Fill(tauDecayCountMap_.find( "oneProng0Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng1Pi0")->second->Fill(tauDecayCountMap_.find( "oneProng1Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng2Pi0")->second->Fill(tauDecayCountMap_.find( "oneProng2Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_twoProng0Pi0")->second->Fill(tauDecayCountMap_.find( "twoProng0Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_twoProng1Pi0")->second->Fill(tauDecayCountMap_.find( "twoProng1Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_twoProng2Pi0")->second->Fill(tauDecayCountMap_.find( "twoProng2Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_threeProng0Pi0")->second->Fill(tauDecayCountMap_.find( "threeProng0Pi0" + currentDiscriminatorLabel)->second);      
+      plotMap_.find(currentDiscriminatorLabel + "_nTaus_threeProng1Pi0")->second->Fill(tauDecayCountMap_.find( "threeProng1Pi0" + currentDiscriminatorLabel)->second);      
     }
 
   }//End of PFTau Collection If Loop

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -118,7 +118,7 @@ void TauTagValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   MonitorElement * ptTemp,* etaTemp,* phiTemp, *pileupTemp, *tmpME, *summaryTemp;
 
   ibooker.setCurrentFolder("RecoTauV/" + TauProducer_ + extensionName_ + "_Summary" );
-  hinfo summaryHinfo = (histoSettings_.exists("summary")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("summary")) : hinfo(17, -0.5, 15.5);
+  hinfo summaryHinfo = (histoSettings_.exists("summary")) ? hinfo(histoSettings_.getParameter<edm::ParameterSet>("summary")) : hinfo(21, -0.5, 20.5);
   summaryTemp =  ibooker.book1D("summaryPlotNum", "summaryPlotNum", summaryHinfo.nbins, summaryHinfo.min, summaryHinfo.max);
   summaryMap.insert( std::make_pair(refCollection_+"Num",summaryTemp));
   summaryTemp =  ibooker.book1D("summaryPlotDen", "summaryPlotDen", summaryHinfo.nbins, summaryHinfo.min, summaryHinfo.max);

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -373,24 +373,15 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   //Initialize the Tau Multiplicity Counter
   for(const auto& it : discriminators_){
     string DiscriminatorLabel = it.getParameter<string>("discriminator");
-    tauDecayCountMap_.insert(std::make_pair("allHadronic" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("oneProng0Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("oneProng1Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("oneProng2Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("twoProng0Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("twoProng1Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("twoProng2Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("threeProng0Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.insert(std::make_pair("threeProng1Pi0" + DiscriminatorLabel, 0));
-    tauDecayCountMap_.find( "allHadronic"   + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "oneProng0Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "oneProng1Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "oneProng2Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "twoProng0Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "twoProng1Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "twoProng2Pi0"  + DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "threeProng0Pi0"+ DiscriminatorLabel)->second = 0;
-    tauDecayCountMap_.find( "threeProng1Pi0"+ DiscriminatorLabel)->second = 0;
+    tauDecayCountMap_["allHadronic"    + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["oneProng0Pi0"   + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["oneProng1Pi0"   + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["oneProng2Pi0"   + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["twoProng0Pi0"   + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["twoProng1Pi0"   + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["twoProng2Pi0"   + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["threeProng0Pi0" + DiscriminatorLabel] = 0;
+    tauDecayCountMap_["threeProng1Pi0" + DiscriminatorLabel] = 0;
   }
 
   typedef edm::View<reco::Candidate> genCandidateCollection;

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -75,10 +75,8 @@ TauTagValidation::TauTagValidation(const edm::ParameterSet& iConfig):
   refCollectionInputTagToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<InputTag>("RefCollection"));
   primaryVertexCollectionToken_ = consumes<VertexCollection>(PrimaryVertexCollection_); //TO-DO
   tauProducerInputTagToken_ = consumes<reco::PFTauCollection>(iConfig.getParameter<InputTag>("TauProducer"));
-  int j = 0;
-  for(auto&& it : discriminators_){
+  for(const auto& it : discriminators_){
     currentDiscriminatorToken_.push_back( consumes<reco::PFTauDiscriminator>(edm::InputTag(it.getParameter<string>("discriminator"))) );
-    j++;
   }
 
   tversion = edm::getReleaseVersion();
@@ -163,7 +161,7 @@ void TauTagValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
   pileupTauVisibleMap.insert( std::make_pair(TauProducer_+"Matched" ,pileupTemp));
 
   int j = 0;
-  for(auto&& it : discriminators_)
+  for(const auto& it : discriminators_)
   {
     string DiscriminatorLabel = it.getParameter<string>("discriminator");
     std::string histogramName;
@@ -373,7 +371,7 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   double matching_criteria = -1.0;
 
   //Initialize the Tau Multiplicity Counter
-  for(auto&& it : discriminators_){
+  for(const auto& it : discriminators_){
     string DiscriminatorLabel = it.getParameter<string>("discriminator");
     tauDecayCountMap_.insert(std::make_pair("allHadronic" + DiscriminatorLabel, 0));
     tauDecayCountMap_.insert(std::make_pair("oneProng0Pi0" + DiscriminatorLabel, 0));
@@ -483,7 +481,7 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       if( !pass ) continue;
 
       int j = 0;
-      for(auto&& it : discriminators_){
+      for(const auto& it : discriminators_){
         string currentDiscriminatorLabel = it.getParameter<string>("discriminator");
         iEvent.getByToken( currentDiscriminatorToken_[j], currentDiscriminator );
 	summaryMap.find(refCollection_+"Den")->second->Fill(j);
@@ -612,7 +610,7 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     }//End of Reference Collection Loop
 
     //Fill the Tau Multiplicity Histograms
-    for(auto&& it : discriminators_){
+    for(const auto& it : discriminators_){
       string currentDiscriminatorLabel = it.getParameter<string>("discriminator");
       plotMap_.find(currentDiscriminatorLabel + "_nTaus_allHadronic")->second->Fill(tauDecayCountMap_.find( "allHadronic" + currentDiscriminatorLabel)->second);      
       plotMap_.find(currentDiscriminatorLabel + "_nTaus_oneProng0Pi0")->second->Fill(tauDecayCountMap_.find( "oneProng0Pi0" + currentDiscriminatorLabel)->second);      


### PR DESCRIPTION
The following changes have been made.
1) Clean the amount of DQM plots. Now only decayMode and iso efficiencies are shown for RealData/QCD; decayMode and electron discriminators efficiencies for RealElectrons/ZEE; decayMode and muon discriminators efficiencies for RealMuons/ZMM.
2) A summary plot showing the inclusive efficiency for all the discriminators is added.
3) The plots for the number of taus of each event are now correctly initizialized (before it was not the case).