### PR TITLE
forward-porting DNN-related from branch cms-tau-pog:CMSSW_9_4_X_tau_pog_DNNTauIDs

### DIFF
--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -26,6 +26,16 @@
 
 namespace deep_tau {
 
+class TauWPThreshold {
+public:
+    explicit TauWPThreshold(const std::string& cut_str);
+    double operator()(const pat::Tau& tau) const;
+
+private:
+    std::unique_ptr<TF1> fn;
+    double value;
+};
+
 class DeepTauCache {
 public:
     using GraphPtr = std::shared_ptr<tensorflow::GraphDef>;
@@ -54,7 +64,7 @@ public:
     using ElectronCollection = pat::ElectronCollection;
     using MuonCollection = pat::MuonCollection;
     using LorentzVectorXYZ = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>;
-    using Cutter = StringObjectFunction<TauType>;
+    using Cutter = TauWPThreshold;
     using CutterPtr = std::unique_ptr<Cutter>;
     using WPMap = std::map<std::string, CutterPtr>;
 

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -41,7 +41,7 @@ class DeepTauCache {
 public:
     using GraphPtr = std::shared_ptr<tensorflow::GraphDef>;
 
-    DeepTauCache(const std::string& graph_name, const bool& mem_mapped);
+    DeepTauCache(const std::string& graph_name, bool mem_mapped);
     ~DeepTauCache();
 
    // A Session allows concurrent calls to Run(), though a Session must
@@ -49,7 +49,7 @@ public:
    tensorflow::Session& getSession() const { return *session_; }
    const tensorflow::GraphDef& getGraph() const { return *graph_; }
 
-protected:
+private:
     GraphPtr graph_;
     tensorflow::Session* session_;
     std::unique_ptr<tensorflow::MemmappedEnv> memmappedEnv_;

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -23,6 +23,7 @@
 #include "RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include <TF1.h>
 
 namespace deep_tau {
 
@@ -82,16 +83,16 @@ public:
 
 
     DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputs, const DeepTauCache* cache);
-    virtual ~DeepTauBase();
+    virtual ~DeepTauBase() {}
 
     virtual void produce(edm::Event& event, const edm::EventSetup& es) override;
 
     static std::unique_ptr<DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg);
     static void globalEndJob(const DeepTauCache* cache){ }
 private:
-    virtual tensorflow::Tensor GetPredictions(edm::Event& event, const edm::EventSetup& es,
+    virtual tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) = 0;
-    virtual void CreateOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);
+    virtual void createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);
 
 protected:
     edm::EDGetTokenT<TauCollection> taus_token;

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -29,7 +29,7 @@ namespace deep_tau {
 
 class TauWPThreshold {
 public:
-    explicit TauWPThreshold(const std::string& cutStr);
+    explicit TauWPThreshold(const std::string& cut_str);
     double operator()(const pat::Tau& tau) const;
 
 private:
@@ -41,7 +41,7 @@ class DeepTauCache {
 public:
     using GraphPtr = std::shared_ptr<tensorflow::GraphDef>;
 
-    DeepTauCache(const std::string& graphName, const bool& memMapped);
+    DeepTauCache(const std::string& graph_name, const bool& mem_mapped);
     ~DeepTauCache();
 
    // A Session allows concurrent calls to Run(), though a Session must
@@ -71,24 +71,24 @@ public:
 
     struct Output {
         using ResultMap = std::map<std::string, std::unique_ptr<TauDiscriminator>>;
-        std::vector<size_t> num, den;
+        std::vector<size_t> num_, den_;
 
-        Output(const std::vector<size_t>& num_, const std::vector<size_t>& den_) : num(num_), den(den_) {}
+        Output(const std::vector<size_t>& num, const std::vector<size_t>& den) : num_(num), den_(den) {}
 
         ResultMap get_value(const edm::Handle<TauCollection>& taus, const tensorflow::Tensor& pred,
-                            const WPMap& workingPoints_) const;
+                            const WPMap& working_points) const;
     };
 
     using OutputCollection = std::map<std::string, Output>;
 
 
-    DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputs_, const DeepTauCache* cache_);
+    DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputs, const DeepTauCache* cache);
     virtual ~DeepTauBase() {}
 
     virtual void produce(edm::Event& event, const edm::EventSetup& es) override;
 
     static std::unique_ptr<DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg);
-    static void globalEndJob(const DeepTauCache* cache_){ }
+    static void globalEndJob(const DeepTauCache* cache){ }
 private:
     virtual tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) = 0;

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -29,12 +29,12 @@ namespace deep_tau {
 
 class TauWPThreshold {
 public:
-    explicit TauWPThreshold(const std::string& cut_str);
+    explicit TauWPThreshold(const std::string& cutStr);
     double operator()(const pat::Tau& tau) const;
 
 private:
-    std::unique_ptr<TF1> fn;
-    double value;
+    std::unique_ptr<TF1> fn_;
+    double value_;
 };
 
 class DeepTauCache {
@@ -46,13 +46,13 @@ public:
 
    // A Session allows concurrent calls to Run(), though a Session must
    // be created / extended by a single thread.
-   tensorflow::Session& getSession() const { return *session; }
-   const tensorflow::GraphDef& getGraph() const { return *graph; }
+   tensorflow::Session& getSession() const { return *session_; }
+   const tensorflow::GraphDef& getGraph() const { return *graph_; }
 
 protected:
-    GraphPtr graph;
-    tensorflow::Session* session;
-    std::unique_ptr<tensorflow::MemmappedEnv> memmapped_env;
+    GraphPtr graph_;
+    tensorflow::Session* session_;
+    std::unique_ptr<tensorflow::MemmappedEnv> memmappedEnv_;
 };
 
 class DeepTauBase : public edm::stream::EDProducer<edm::GlobalCache<DeepTauCache>> {
@@ -73,32 +73,32 @@ public:
         using ResultMap = std::map<std::string, std::unique_ptr<TauDiscriminator>>;
         std::vector<size_t> num, den;
 
-        Output(const std::vector<size_t>& _num, const std::vector<size_t>& _den) : num(_num), den(_den) {}
+        Output(const std::vector<size_t>& num_, const std::vector<size_t>& den_) : num(num_), den(den_) {}
 
         ResultMap get_value(const edm::Handle<TauCollection>& taus, const tensorflow::Tensor& pred,
-                            const WPMap& working_points) const;
+                            const WPMap& workingPoints_) const;
     };
 
     using OutputCollection = std::map<std::string, Output>;
 
 
-    DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputs, const DeepTauCache* cache);
+    DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputs_, const DeepTauCache* cache_);
     virtual ~DeepTauBase() {}
 
     virtual void produce(edm::Event& event, const edm::EventSetup& es) override;
 
     static std::unique_ptr<DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg);
-    static void globalEndJob(const DeepTauCache* cache){ }
+    static void globalEndJob(const DeepTauCache* cache_){ }
 private:
     virtual tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) = 0;
     virtual void createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);
 
 protected:
-    edm::EDGetTokenT<TauCollection> taus_token;
-    std::map<std::string, WPMap> working_points;
-    OutputCollection outputs;
-    const DeepTauCache* cache;
+    edm::EDGetTokenT<TauCollection> tausToken_;
+    std::map<std::string, WPMap> workingPoints_;
+    OutputCollection outputs_;
+    const DeepTauCache* cache_;
 };
 
 } // namespace deep_tau

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -87,7 +87,7 @@ public:
     virtual void produce(edm::Event& event, const edm::EventSetup& es) override;
 
     static std::unique_ptr<DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg);
-    static void globalEndJob(const DeepTauCache* cache);
+    static void globalEndJob(const DeepTauCache* cache){ }
 private:
     virtual tensorflow::Tensor GetPredictions(edm::Event& event, const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) = 0;

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -20,8 +20,7 @@ inline int getPFCandidateIndex(const edm::Handle<pat::PackedCandidateCollection>
 }
 } // anonymous namespace
 
-
-class DPFIsolation : public deep_tau::DeepTauBase {
+class DPFIsolation : public deep_tau::DeepTauBase{
 public:
     static OutputCollection& GetOutputs()
     {
@@ -65,8 +64,8 @@ public:
         descriptions.add("DPFTau2016v0", desc);
     }
 
-    explicit DPFIsolation(const edm::ParameterSet& cfg) :
-        DeepTauBase(cfg, GetOutputs()),
+    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache ) :
+        DeepTauBase(cfg, GetOutputs(), cache),
         pfcand_token(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfcands"))),
         vtx_token(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
         graphVersion(cfg.getParameter<unsigned>("version"))
@@ -367,7 +366,7 @@ private:
                 }
                 iPF++;
             }
-            tensorflow::run(session, { { "input_1", tensor } }, { "output_node0" }, {}, &outputs);
+            tensorflow::run(&(cache->getSession()), { { "input_1", tensor } }, { "output_node0" }, {}, &outputs);
             predictions.matrix<float>()(tau_index, 0) = outputs[0].flat<float>()(0);
         }
         return predictions;

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -47,7 +47,7 @@ public:
         desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
         desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb");
+        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb");
         desc.add<unsigned>("version", 0);
         desc.add<bool>("mem_mapped", false);
 

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -47,7 +47,7 @@ public:
         desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
         desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb");
+        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb");
         desc.add<unsigned>("version", 0);
         desc.add<bool>("mem_mapped", false);
 
@@ -71,8 +71,14 @@ public:
         vtx_token(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
         graphVersion(cfg.getParameter<unsigned>("version"))
     {
+        const auto& shape = cache_->getGraph().node(0).attr().at("shape").shape();
+
         if(!(graphVersion == 1 || graphVersion == 0 ))
             throw cms::Exception("DPFIsolation") << "unknown version of the graph_ file.";
+            
+        if(!(shape.dim(1).size() == getNumberOfParticles(graphVersion) && shape.dim(2).size() == GetNumberOfFeatures(graphVersion)))
+            throw cms::Exception("DeepTauId") << "number of inputs does not match the expected inputs for the given version";
+
     }
 
 private:

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -25,8 +25,8 @@ public:
     static OutputCollection& GetOutputs()
     {
         static size_t tau_index = 0;
-        static OutputCollection outputs = { { "VSall", Output({tau_index}, {}) } };
-        return outputs;
+        static OutputCollection outputs_ = { { "VSall", Output({tau_index}, {}) } };
+        return outputs_;
     };
 
     static unsigned getNumberOfParticles(unsigned graphVersion)
@@ -65,14 +65,14 @@ public:
         descriptions.add("DPFTau2016v0", desc);
     }
 
-    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache) :
-        DeepTauBase(cfg, GetOutputs(), cache),
+    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache_) :
+        DeepTauBase(cfg, GetOutputs(), cache_),
         pfcand_token(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfcands"))),
         vtx_token(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
         graphVersion(cfg.getParameter<unsigned>("version"))
     {
         if(!(graphVersion == 1 || graphVersion == 0 ))
-            throw cms::Exception("DPFIsolation") << "unknown version of the graph file.";
+            throw cms::Exception("DPFIsolation") << "unknown version of the graph_ file.";
     }
 
 private:
@@ -90,7 +90,7 @@ private:
 
         tensorflow::Tensor predictions(tensorflow::DT_FLOAT, { static_cast<int>(taus->size()), 1});
 
-        std::vector<tensorflow::Tensor> outputs;
+        std::vector<tensorflow::Tensor> outputs_;
 
         float pfCandPt, pfCandPz, pfCandPtRel, pfCandPzRel, pfCandDr, pfCandDEta, pfCandDPhi, pfCandEta, pfCandDz,
               pfCandDzErr, pfCandD0, pfCandD0D0, pfCandD0Dz, pfCandD0Dphi, pfCandPuppiWeight,
@@ -366,8 +366,8 @@ private:
                 }
                 iPF++;
             }
-            tensorflow::run(&(cache->getSession()), { { "input_1", tensor } }, { "output_node0" }, {}, &outputs);
-            predictions.matrix<float>()(tau_index, 0) = outputs[0].flat<float>()(0);
+            tensorflow::run(&(cache_->getSession()), { { "input_1", tensor } }, { "output_node0" }, {}, &outputs_);
+            predictions.matrix<float>()(tau_index, 0) = outputs_[0].flat<float>()(0);
         }
         return predictions;
     }

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -20,7 +20,7 @@ inline int getPFCandidateIndex(const edm::Handle<pat::PackedCandidateCollection>
 }
 } // anonymous namespace
 
-class DPFIsolation : public deep_tau::DeepTauBase{
+class DPFIsolation : public deep_tau::DeepTauBase {
 public:
     static OutputCollection& GetOutputs()
     {
@@ -49,6 +49,7 @@ public:
         desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb");
         desc.add<unsigned>("version", 0);
+        desc.add<bool>("memMapped", false);
 
         edm::ParameterSetDescription descWP;
         descWP.add<std::string>("VVVLoose", "0");
@@ -64,13 +65,12 @@ public:
         descriptions.add("DPFTau2016v0", desc);
     }
 
-    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache ) :
+    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache) :
         DeepTauBase(cfg, GetOutputs(), cache),
         pfcand_token(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfcands"))),
         vtx_token(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
         graphVersion(cfg.getParameter<unsigned>("version"))
     {
-        std::cout << "graphVersion: " << graphVersion << '\n';
         if(!(graphVersion == 1 || graphVersion == 0 ))
             throw cms::Exception("DPFIsolation") << "unknown version of the graph file.";
     }

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -75,9 +75,9 @@ public:
 
         if(!(graphVersion == 1 || graphVersion == 0 ))
             throw cms::Exception("DPFIsolation") << "unknown version of the graph_ file.";
-            
+
         if(!(shape.dim(1).size() == getNumberOfParticles(graphVersion) && shape.dim(2).size() == GetNumberOfFeatures(graphVersion)))
-            throw cms::Exception("DeepTauId") << "number of inputs does not match the expected inputs for the given version";
+            throw cms::Exception("DPFIsolation") << "number of inputs does not match the expected inputs for the given version";
 
     }
 

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -49,7 +49,7 @@ public:
         desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb");
         desc.add<unsigned>("version", 0);
-        desc.add<bool>("memMapped", false);
+        desc.add<bool>("mem_mapped", false);
 
         edm::ParameterSetDescription descWP;
         descWP.add<std::string>("VVVLoose", "0");
@@ -65,8 +65,8 @@ public:
         descriptions.add("DPFTau2016v0", desc);
     }
 
-    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache_) :
-        DeepTauBase(cfg, GetOutputs(), cache_),
+    explicit DPFIsolation(const edm::ParameterSet& cfg,const deep_tau::DeepTauCache* cache) :
+        DeepTauBase(cfg, GetOutputs(), cache),
         pfcand_token(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfcands"))),
         vtx_token(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
         graphVersion(cfg.getParameter<unsigned>("version"))

--- a/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/DPFIsolation.cc
@@ -29,7 +29,7 @@ public:
         return outputs;
     };
 
-    static unsigned GetNumberOfParticles(unsigned graphVersion)
+    static unsigned getNumberOfParticles(unsigned graphVersion)
     {
         static const std::map<unsigned, unsigned> nparticles { { 0, 60 }, { 1, 36 } };
         return nparticles.at(graphVersion);
@@ -47,7 +47,7 @@ public:
         desc.add<edm::InputTag>("pfcands", edm::InputTag("packedPFCandidates"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
         desc.add<edm::InputTag>("vertices", edm::InputTag("offlineSlimmedPrimaryVertices"));
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb");
+        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb");
         desc.add<unsigned>("version", 0);
         desc.add<bool>("memMapped", false);
 
@@ -76,7 +76,7 @@ public:
     }
 
 private:
-    virtual tensorflow::Tensor GetPredictions(edm::Event& event, const edm::EventSetup& es,
+    virtual tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) override
     {
         edm::Handle<pat::PackedCandidateCollection> pfcands;
@@ -86,7 +86,7 @@ private:
         event.getByToken(vtx_token, vertices);
 
         tensorflow::Tensor tensor(tensorflow::DT_FLOAT, {1,
-            static_cast<int>(GetNumberOfParticles(graphVersion)), static_cast<int>(GetNumberOfFeatures(graphVersion))});
+            static_cast<int>(getNumberOfParticles(graphVersion)), static_cast<int>(GetNumberOfFeatures(graphVersion))});
 
         tensorflow::Tensor predictions(tensorflow::DT_FLOAT, { static_cast<int>(taus->size()), 1});
 
@@ -118,7 +118,7 @@ private:
 
             std::vector<unsigned int> signalCandidateInds;
 
-            for(auto c : tau.signalCands())
+            for(const auto c : tau.signalCands())
                 signalCandidateInds.push_back(getPFCandidateIndex(pfcands,c));
 
             float lepRecoPt = tau.pt();
@@ -126,12 +126,12 @@ private:
 
             // Use of setZero results in warnings in eigen library during compilation.
             //tensor.flat<float>().setZero();
-            const unsigned n_inputs = GetNumberOfParticles(graphVersion) * GetNumberOfFeatures(graphVersion);
+            const unsigned n_inputs = getNumberOfParticles(graphVersion) * GetNumberOfFeatures(graphVersion);
             for(unsigned input_idx = 0; input_idx < n_inputs; ++input_idx)
                 tensor.flat<float>()(input_idx) = 0;
 
             unsigned int iPF = 0;
-            const unsigned max_iPF = GetNumberOfParticles(graphVersion);
+            const unsigned max_iPF = getNumberOfParticles(graphVersion);
 
             std::vector<unsigned int> sorted_inds(pfcands->size());
             std::size_t n = 0;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -100,7 +100,7 @@ struct MuonHitMatch {
         n_hits[MuonSubdetId::RPC].assign(n_muon_stations, 0);
     }
 
-    void AddMatchedMuon(const pat::Muon& muon, const pat::Tau& tau)
+    void addMatchedMuon(const pat::Muon& muon, const pat::Tau& tau)
     {
         static constexpr int n_stations = 4;
 
@@ -119,8 +119,7 @@ struct MuonHitMatch {
 
         if(muon.outerTrack().isNonnull()) {
             const auto& hit_pattern = muon.outerTrack()->hitPattern();
-            for(int hit_index = 0; hit_index < hit_pattern.numberOfAllHits(reco::HitPattern::TRACK_HITS);
-                ++hit_index) {
+            for(int hit_index = 0; hit_index < hit_pattern.numberOfAllHits(reco::HitPattern::TRACK_HITS); ++hit_index) {
                 auto hit_id = hit_pattern.getHitPattern(reco::HitPattern::TRACK_HITS, hit_index);
                 if(hit_id == 0) break;
                 if(hit_pattern.muonHitFilter(hit_id) && (hit_pattern.getHitType(hit_id) == TrackingRecHit::valid
@@ -143,7 +142,7 @@ struct MuonHitMatch {
         }
     }
 
-    static std::vector<const pat::Muon*> FindMatchedMuons(const pat::Tau& tau, const pat::MuonCollection& muons,
+    static std::vector<const pat::Muon*> findMatchedMuons(const pat::Tau& tau, const pat::MuonCollection& muons,
                                                            double deltaR, double minPt)
     {
         const reco::Muon* hadr_cand_muon = nullptr;
@@ -162,7 +161,7 @@ struct MuonHitMatch {
     }
 
     template<typename dnn, typename TensorElemGet>
-    void FillTensor(const TensorElemGet& get, const pat::Tau& tau, float default_value) const
+    void fillTensor(const TensorElemGet& get, const pat::Tau& tau, float default_value) const
     {
         get(dnn::n_matched_muons) = n_muons;
         get(dnn::muon_pt) = best_matched_muon != nullptr ? best_matched_muon->p4().pt() : default_value;
@@ -187,12 +186,12 @@ struct MuonHitMatch {
         get(dnn::muon_n_hits_RPC_2) = n_hits.at(MuonSubdetId::RPC).at(1);
         get(dnn::muon_n_hits_RPC_3) = n_hits.at(MuonSubdetId::RPC).at(2);
         get(dnn::muon_n_hits_RPC_4) = n_hits.at(MuonSubdetId::RPC).at(3);
-        get(dnn::muon_n_stations_with_matches_03) = CountMuonStationsWithMatches(0, 3);
-        get(dnn::muon_n_stations_with_hits_23) = CountMuonStationsWithHits(2, 3);
+        get(dnn::muon_n_stations_with_matches_03) = countMuonStationsWithMatches(0, 3);
+        get(dnn::muon_n_stations_with_hits_23) = countMuonStationsWithHits(2, 3);
     }
 
 private:
-    unsigned CountMuonStationsWithMatches(size_t first_station, size_t last_station) const
+    unsigned countMuonStationsWithMatches(size_t first_station, size_t last_station) const
     {
         static const std::map<int, std::vector<bool>> masks = {
             { MuonSubdetId::DT, { false, false, false, false } },
@@ -208,7 +207,7 @@ private:
         return cnt;
     }
 
-    unsigned CountMuonStationsWithHits(size_t first_station, size_t last_station) const
+    unsigned countMuonStationsWithHits(size_t first_station, size_t last_station) const
     {
         static const std::map<int, std::vector<bool>> masks = {
             { MuonSubdetId::DT, { false, false, false, false } },
@@ -250,9 +249,13 @@ public:
         desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
         desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
+<<<<<<< HEAD
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb");
 <<<<<<< HEAD
 =======
+=======
+        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
+>>>>>>> 1968c81d039... -Overall, changes to improve memory usage, among these are:
         desc.add<bool>("memMapped", false);
 
 
@@ -294,7 +297,7 @@ public:
     }
 
 private:
-    virtual tensorflow::Tensor GetPredictions(edm::Event& event, const edm::EventSetup& es,
+    virtual tensorflow::Tensor getPredictions(edm::Event& event, const edm::EventSetup& es,
                                               edm::Handle<TauCollection> taus) override
     {
         edm::Handle<pat::ElectronCollection> electrons;
@@ -369,19 +372,25 @@ private:
         get(dnn::pt_weighted_dr_signal) = reco::tau::pt_weighted_dr_signal(tau, tau.decayMode());
         get(dnn::pt_weighted_dr_iso) = reco::tau::pt_weighted_dr_iso(tau, tau.decayMode());
         get(dnn::leadingTrackNormChi2) = tau.leadingTrackNormChi2();
+<<<<<<< HEAD
         get(dnn::e_ratio) = reco::tau::eratio(tau);
         get(dnn::gj_angle_diff) = CalculateGottfriedJacksonAngleDifference(tau);
         get(dnn::n_photons) = reco::tau::n_photons_total(tau);
+=======
+        get(dnn::e_ratio) = clusterVariables.tau_Eratio(tau);
+        get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau);
+        get(dnn::n_photons) = clusterVariables.tau_n_photons_total(tau);
+>>>>>>> 1968c81d039... -Overall, changes to improve memory usage, among these are:
         get(dnn::emFraction) = tau.emFraction_MVA();
         get(dnn::has_gsf_track) = leadChargedHadrCand && std::abs(leadChargedHadrCand->pdgId()) == 11;
-        get(dnn::inside_ecal_crack) = IsInEcalCrack(tau.p4().Eta());
-        auto gsf_ele = FindMatchedElectron(tau, electrons, 0.3);
+        get(dnn::inside_ecal_crack) = isInEcalCrack(tau.p4().Eta());
+        auto gsf_ele = findMatchedElectron(tau, electrons, 0.3);
         get(dnn::gsf_ele_matched) = gsf_ele != nullptr;
         get(dnn::gsf_ele_pt) = gsf_ele != nullptr ? gsf_ele->p4().Pt() : default_value;
         get(dnn::gsf_ele_dEta) = gsf_ele != nullptr ? dEta(gsf_ele->p4(), tau.p4()) : default_value;
         get(dnn::gsf_ele_dPhi) = gsf_ele != nullptr ? dPhi(gsf_ele->p4(), tau.p4()) : default_value;
         get(dnn::gsf_ele_mass) = gsf_ele != nullptr ? gsf_ele->p4().mass() : default_value;
-        CalculateElectronClusterVars(gsf_ele, get(dnn::gsf_ele_Ee), get(dnn::gsf_ele_Egamma));
+        calculateElectronClusterVars(gsf_ele, get(dnn::gsf_ele_Ee), get(dnn::gsf_ele_Egamma));
         get(dnn::gsf_ele_Pin) = gsf_ele != nullptr ? gsf_ele->trackMomentumAtVtx().R() : default_value;
         get(dnn::gsf_ele_Pout) = gsf_ele != nullptr ? gsf_ele->trackMomentumOut().R() : default_value;
         get(dnn::gsf_ele_EtotOverPin) = get(dnn::gsf_ele_Pin) > 0
@@ -430,15 +439,15 @@ private:
 
         MuonHitMatch muon_hit_match;
         if(tau.leadPFChargedHadrCand().isNonnull() && tau.leadPFChargedHadrCand()->muonRef().isNonnull())
-            muon_hit_match.AddMatchedMuon(*tau.leadPFChargedHadrCand()->muonRef(), tau);
+            muon_hit_match.addMatchedMuon(*tau.leadPFChargedHadrCand()->muonRef(), tau);
 
-        auto matched_muons = muon_hit_match.FindMatchedMuons(tau, muons, 0.3, 5);
+        auto matched_muons = muon_hit_match.findMatchedMuons(tau, muons, 0.3, 5);
         for(auto muon : matched_muons)
-            muon_hit_match.AddMatchedMuon(*muon, tau);
-        muon_hit_match.FillTensor<dnn>(get, tau, default_value);
+            muon_hit_match.addMatchedMuon(*muon, tau);
+        muon_hit_match.fillTensor<dnn>(get, tau, default_value);
 
         LorentzVectorXYZ signalChargedHadrCands_sumIn, signalChargedHadrCands_sumOut;
-        ProcessSignalPFComponents(tau, tau.signalChargedHadrCands(),
+        processSignalPFComponents(tau, tau.signalChargedHadrCands(),
                                   signalChargedHadrCands_sumIn, signalChargedHadrCands_sumOut,
                                   get(dnn::signalChargedHadrCands_sum_innerSigCone_pt),
                                   get(dnn::signalChargedHadrCands_sum_innerSigCone_dEta),
@@ -452,7 +461,7 @@ private:
                                   get(dnn::signalChargedHadrCands_nTotal_outerSigCone));
 
         LorentzVectorXYZ signalNeutrHadrCands_sumIn, signalNeutrHadrCands_sumOut;
-        ProcessSignalPFComponents(tau, tau.signalNeutrHadrCands(),
+        processSignalPFComponents(tau, tau.signalNeutrHadrCands(),
                                   signalNeutrHadrCands_sumIn, signalNeutrHadrCands_sumOut,
                                   get(dnn::signalNeutrHadrCands_sum_innerSigCone_pt),
                                   get(dnn::signalNeutrHadrCands_sum_innerSigCone_dEta),
@@ -467,7 +476,7 @@ private:
 
 
         LorentzVectorXYZ signalGammaCands_sumIn, signalGammaCands_sumOut;
-        ProcessSignalPFComponents(tau, tau.signalGammaCands(),
+        processSignalPFComponents(tau, tau.signalGammaCands(),
                                   signalGammaCands_sumIn, signalGammaCands_sumOut,
                                   get(dnn::signalGammaCands_sum_innerSigCone_pt),
                                   get(dnn::signalGammaCands_sum_innerSigCone_dEta),
@@ -516,7 +525,7 @@ private:
         return inputs;
     }
 
-    static void CalculateElectronClusterVars(const pat::Electron* ele, float& elecEe, float& elecEgamma)
+    static void calculateElectronClusterVars(const pat::Electron* ele, float& elecEe, float& elecEgamma)
     {
         if(ele) {
             elecEe = elecEgamma = 0;
@@ -535,7 +544,7 @@ private:
     }
 
     template<typename CandidateCollection>
-    static void ProcessSignalPFComponents(const pat::Tau& tau, const CandidateCollection& candidates,
+    static void processSignalPFComponents(const pat::Tau& tau, const CandidateCollection& candidates,
                                           LorentzVectorXYZ& p4_inner, LorentzVectorXYZ& p4_outer,
                                           float& pt_inner, float& dEta_inner, float& dPhi_inner, float& m_inner,
                                           float& pt_outer, float& dEta_outer, float& dPhi_outer, float& m_outer,
@@ -546,7 +555,7 @@ private:
         n_inner = 0;
         n_outer = 0;
 
-        const double innerSigCone_radius = GetInnerSignalConeRadius(tau.pt());
+        const double innerSigCone_radius = getInnerSignalConeRadius(tau.pt());
         for(const auto& cand : candidates) {
             const double dR = reco::deltaR(cand->p4(), tau.leadChargedHadrCand()->p4());
             const bool isInside_innerSigCone = dR < innerSigCone_radius;
@@ -589,13 +598,13 @@ private:
         m = n != 0 ? p4.mass() : default_value;
     }
 
-    static double GetInnerSignalConeRadius(double pt)
+    static double getInnerSignalConeRadius(double pt)
     {
         return std::max(.05, std::min(.1, 3./std::max(1., pt)));
     }
 
     // Copied from https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc#L218
-    static float CalculateGottfriedJacksonAngleDifference(const pat::Tau& tau)
+    static float calculateGottfriedJacksonAngleDifference(const pat::Tau& tau)
     {
         if(tau.decayMode() == 10) {
             static constexpr double mTau = 1.77682;
@@ -613,13 +622,13 @@ private:
         return default_value;
     }
 
-    static bool IsInEcalCrack(double eta)
+    static bool isInEcalCrack(double eta)
     {
         const double abs_eta = std::abs(eta);
         return abs_eta > 1.46 && abs_eta < 1.558;
     }
 
-    static const pat::Electron* FindMatchedElectron(const pat::Tau& tau, const pat::ElectronCollection& electrons,
+    static const pat::Electron* findMatchedElectron(const pat::Tau& tau, const pat::ElectronCollection& electrons,
                                                     double deltaR)
     {
         const double dR2 = deltaR*deltaR;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -249,18 +249,8 @@ public:
         desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
         desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
-<<<<<<< HEAD
-<<<<<<< HEAD
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
-        desc.add<bool>("memMapped", false);
-=======
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb");
-=======
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
->>>>>>> a9f6b7c945b... Applied last comments
         desc.add<bool>("mem_mapped", false);
->>>>>>> c32912aefa5... Applied commets of previus PR
-
 
         edm::ParameterSetDescription descWP;
         descWP.add<std::string>("VVVLoose", "0");
@@ -373,7 +363,7 @@ private:
         get(dnn::pt_weighted_dr_iso) = reco::tau::pt_weighted_dr_iso(tau, tau.decayMode());
         get(dnn::leadingTrackNormChi2) = tau.leadingTrackNormChi2();
         get(dnn::e_ratio) = reco::tau::eratio(tau);
-        get(dnn::gj_angle_diff) = CalculateGottfriedJacksonAngleDifference(tau);
+        get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau);
         get(dnn::n_photons) = reco::tau::n_photons_total(tau);
         get(dnn::emFraction) = tau.emFraction_MVA();
         get(dnn::has_gsf_track) = leadChargedHadrCand && std::abs(leadChargedHadrCand->pdgId()) == 11;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -249,8 +249,13 @@ public:
         desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
         desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
+<<<<<<< HEAD
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
         desc.add<bool>("memMapped", false);
+=======
+        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb");
+        desc.add<bool>("mem_mapped", false);
+>>>>>>> c32912aefa5... Applied commets of previus PR
 
 
         edm::ParameterSetDescription descWP;
@@ -277,6 +282,10 @@ public:
         input_layer(cache_->getGraph().node(0).name()),
         output_layer(cache_->getGraph().node(cache_->getGraph().node_size() - 1).name())
     {
+        const auto& shape = cache_->getGraph().node(0).attr().at("shape").shape();
+        if(shape.dim(1).size() != dnn_inputs_2017v1::NumberOfInputs)
+            throw cms::Exception("DeepTauId") << "number of inputs does not match the expected inputs for the given version";
+
     }
 
     static std::unique_ptr<deep_tau::DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg)

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -250,10 +250,14 @@ public:
         desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
 <<<<<<< HEAD
+<<<<<<< HEAD
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
         desc.add<bool>("memMapped", false);
 =======
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb");
+=======
+        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
+>>>>>>> a9f6b7c945b... Applied last comments
         desc.add<bool>("mem_mapped", false);
 >>>>>>> c32912aefa5... Applied commets of previus PR
 

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -228,7 +228,7 @@ private:
 
 } // anonymous namespace
 
-class DeepTauId : public deep_tau::DeepTauBase{
+class DeepTauId : public deep_tau::DeepTauBase {
 public:
 
     static constexpr float default_value = -999.;
@@ -251,6 +251,12 @@ public:
         desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb");
+<<<<<<< HEAD
+=======
+        desc.add<bool>("memMapped", false);
+
+
+>>>>>>> 0410883ea87... Applied changes on DeepTauBase to allow load new training files using memory mapping
         edm::ParameterSetDescription descWP;
         descWP.add<std::string>("VVVLoose", "0");
         descWP.add<std::string>("VVLoose", "0");

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -235,12 +235,12 @@ public:
     static const OutputCollection& GetOutputs()
     {
         static constexpr size_t e_index = 0, mu_index = 1, tau_index = 2, jet_index = 3;
-        static const OutputCollection outputs = {
+        static const OutputCollection outputs_ = {
             { "VSe", Output({tau_index}, {e_index, tau_index}) },
             { "VSmu", Output({tau_index}, {mu_index, tau_index}) },
             { "VSjet", Output({tau_index}, {jet_index, tau_index}) },
         };
-        return outputs;
+        return outputs_;
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions)
@@ -277,12 +277,12 @@ public:
     }
 
 public:
-    explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache) :
-        DeepTauBase(cfg, GetOutputs(), cache),
+    explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache_) :
+        DeepTauBase(cfg, GetOutputs(), cache_),
         electrons_token(consumes<ElectronCollection>(cfg.getParameter<edm::InputTag>("electrons"))),
         muons_token(consumes<MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))),
-        input_layer(cache->getGraph().node(0).name()),
-        output_layer(cache->getGraph().node(cache->getGraph().node_size() - 1).name())
+        input_layer(cache_->getGraph().node(0).name()),
+        output_layer(cache_->getGraph().node(cache_->getGraph().node_size() - 1).name())
     {
     }
 
@@ -291,9 +291,9 @@ public:
         return DeepTauBase::initializeGlobalCache(cfg);
     }
 
-    static void globalEndJob(const deep_tau::DeepTauCache* cache)
+    static void globalEndJob(const deep_tau::DeepTauCache* cache_)
     {
-        return DeepTauBase::globalEndJob(cache);
+        return DeepTauBase::globalEndJob(cache_);
     }
 
 private:
@@ -311,7 +311,7 @@ private:
         for(size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
             const tensorflow::Tensor& inputs = CreateInputs<dnn_inputs_2017v1>(taus->at(tau_index), *electrons, *muons);
             std::vector<tensorflow::Tensor> pred_vector;
-            tensorflow::run(&(cache->getSession()), { { input_layer, inputs } }, { output_layer }, &pred_vector);
+            tensorflow::run(&(cache_->getSession()), { { input_layer, inputs } }, { output_layer }, &pred_vector);
             for(int k = 0; k < dnn_inputs_2017v1::NumberOfOutputs; ++k)
                 predictions.matrix<float>()(tau_index, k) = pred_vector[0].flat<float>()(k);
         }

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -228,7 +228,7 @@ private:
 
 } // anonymous namespace
 
-class DeepTauId : public deep_tau::DeepTauBase {
+class DeepTauId : public deep_tau::DeepTauBase{
 public:
 
     static constexpr float default_value = -999.;
@@ -268,13 +268,23 @@ public:
     }
 
 public:
-    explicit DeepTauId(const edm::ParameterSet& cfg) :
-        DeepTauBase(cfg, GetOutputs()),
+    explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache) :
+        DeepTauBase(cfg, GetOutputs(), cache),
         electrons_token(consumes<ElectronCollection>(cfg.getParameter<edm::InputTag>("electrons"))),
         muons_token(consumes<MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))),
-        input_layer(graph->node(0).name()),
-        output_layer(graph->node(graph->node_size() - 1).name())
+        input_layer(cache->getGraph().node(0).name()),
+        output_layer(cache->getGraph().node(cache->getGraph().node_size() - 1).name())
     {
+    }
+
+    static std::unique_ptr<deep_tau::DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg)
+    {
+        return DeepTauBase::initializeGlobalCache(cfg);
+    }
+
+    static void globalEndJob(const deep_tau::DeepTauCache* cache)
+    {
+        return DeepTauBase::globalEndJob(cache);
     }
 
 private:
@@ -292,7 +302,7 @@ private:
         for(size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
             const tensorflow::Tensor& inputs = CreateInputs<dnn_inputs_2017v1>(taus->at(tau_index), *electrons, *muons);
             std::vector<tensorflow::Tensor> pred_vector;
-            tensorflow::run(session, { { input_layer, inputs } }, { output_layer }, &pred_vector);
+            tensorflow::run(&(cache->getSession()), { { input_layer, inputs } }, { output_layer }, &pred_vector);
             for(int k = 0; k < dnn_inputs_2017v1::NumberOfOutputs; ++k)
                 predictions.matrix<float>()(tau_index, k) = pred_vector[0].flat<float>()(k);
         }

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -249,17 +249,10 @@ public:
         desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
         desc.add<edm::InputTag>("muons", edm::InputTag("slimmedMuons"));
         desc.add<edm::InputTag>("taus", edm::InputTag("slimmedTaus"));
-<<<<<<< HEAD
-        desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb");
-<<<<<<< HEAD
-=======
-=======
         desc.add<std::string>("graph_file", "RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb");
->>>>>>> 1968c81d039... -Overall, changes to improve memory usage, among these are:
         desc.add<bool>("memMapped", false);
 
 
->>>>>>> 0410883ea87... Applied changes on DeepTauBase to allow load new training files using memory mapping
         edm::ParameterSetDescription descWP;
         descWP.add<std::string>("VVVLoose", "0");
         descWP.add<std::string>("VVLoose", "0");
@@ -277,8 +270,8 @@ public:
     }
 
 public:
-    explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache_) :
-        DeepTauBase(cfg, GetOutputs(), cache_),
+    explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache) :
+        DeepTauBase(cfg, GetOutputs(), cache),
         electrons_token(consumes<ElectronCollection>(cfg.getParameter<edm::InputTag>("electrons"))),
         muons_token(consumes<MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))),
         input_layer(cache_->getGraph().node(0).name()),
@@ -324,15 +317,9 @@ private:
     {
         static constexpr bool check_all_set = false;
         static constexpr float magic_number = -42;
-<<<<<<< HEAD
-        const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(tau_index, var_index); };
-        const TauType& tau = taus.at(tau_index);
-=======
-        static const TauIdMVAAuxiliaries clusterVariables;
 
         tensorflow::Tensor inputs(tensorflow::DT_FLOAT, { 1, dnn_inputs_2017v1::NumberOfInputs});
         const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
->>>>>>> ef7dc2ec57c... - Implemented on runTauIdMVA the option to work with new training files quantized
         auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
 
         if(check_all_set) {
@@ -372,15 +359,9 @@ private:
         get(dnn::pt_weighted_dr_signal) = reco::tau::pt_weighted_dr_signal(tau, tau.decayMode());
         get(dnn::pt_weighted_dr_iso) = reco::tau::pt_weighted_dr_iso(tau, tau.decayMode());
         get(dnn::leadingTrackNormChi2) = tau.leadingTrackNormChi2();
-<<<<<<< HEAD
         get(dnn::e_ratio) = reco::tau::eratio(tau);
         get(dnn::gj_angle_diff) = CalculateGottfriedJacksonAngleDifference(tau);
         get(dnn::n_photons) = reco::tau::n_photons_total(tau);
-=======
-        get(dnn::e_ratio) = clusterVariables.tau_Eratio(tau);
-        get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau);
-        get(dnn::n_photons) = clusterVariables.tau_n_photons_total(tau);
->>>>>>> 1968c81d039... -Overall, changes to improve memory usage, among these are:
         get(dnn::emFraction) = tau.emFraction_MVA();
         get(dnn::has_gsf_track) = leadChargedHadrCand && std::abs(leadChargedHadrCand->pdgId()) == 11;
         get(dnn::inside_ecal_crack) = isInEcalCrack(tau.p4().Eta());

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -653,9 +653,8 @@ class TauIDEmbedder(object):
                     electrons               = self.cms.InputTag('slimmedElectrons'),
                     muons                   = self.cms.InputTag('slimmedMuons'),
                     taus                    = self.cms.InputTag('slimmedTaus'),
-                    # graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'),
-                    graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_qm.pb'),
-                    memMapped              = self.cms.bool(True)
+                    graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'),
+                    memMapped              = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('deepTau2017v1Q', tauIDSources, working_points)
@@ -703,9 +702,9 @@ class TauIDEmbedder(object):
                     pfcands     = self.cms.InputTag('packedPFCandidates'),
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_qm.pb'),
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'),
                     version     = self.cms.uint32(0),
-                    memMapped   = self.cms.bool(True)
+                    memMapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v0Q', tauIDSources, working_points)
@@ -742,9 +741,9 @@ class TauIDEmbedder(object):
                     pfcands     = self.cms.InputTag('packedPFCandidates'),
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_qm.pb'),
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'),
                     version     = self.cms.uint32(1),
-                    memMapped   = self.cms.bool(True)
+                    memMapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v1Q', tauIDSources, working_points)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -639,7 +639,8 @@ class TauIDEmbedder(object):
                     electrons              = self.cms.InputTag('slimmedElectrons'),
                     muons                  = self.cms.InputTag('slimmedMuons'),
                     taus                   = self.cms.InputTag('slimmedTaus'),
-                    graph_file             = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb')
+                    graph_file             = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'),
+                    memMapped              = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('deepTau2017v1', tauIDSources, working_points)
@@ -652,7 +653,9 @@ class TauIDEmbedder(object):
                     electrons               = self.cms.InputTag('slimmedElectrons'),
                     muons                   = self.cms.InputTag('slimmedMuons'),
                     taus                    = self.cms.InputTag('slimmedTaus'),
-                    graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb')
+                    # graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'),
+                    graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_qm.pb'),
+                    memMapped              = self.cms.bool(True)
                 )
 
                 self.processDeepProducer('deepTau2017v1Q', tauIDSources, working_points)
@@ -683,7 +686,8 @@ class TauIDEmbedder(object):
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                     graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'),
-                    version     = self.cms.uint32(0)
+                    version     = self.cms.uint32(0),
+                    memMapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v0', tauIDSources, working_points)
@@ -696,8 +700,9 @@ class TauIDEmbedder(object):
                     pfcands     = self.cms.InputTag('packedPFCandidates'),
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'),
-                    version     = self.cms.uint32(0)
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_qm.pb'),
+                    version     = self.cms.uint32(0),
+                    memMapped   = self.cms.bool(True)
                 )
 
                 self.processDeepProducer('dpfTau2016v0Q', tauIDSources, working_points)
@@ -720,7 +725,8 @@ class TauIDEmbedder(object):
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                     graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'),
-                    version     = self.cms.uint32(1)
+                    version     = self.cms.uint32(1),
+                    memMapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v1', tauIDSources, working_points)
@@ -733,8 +739,9 @@ class TauIDEmbedder(object):
                     pfcands     = self.cms.InputTag('packedPFCandidates'),
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'),
-                    version     = self.cms.uint32(1)
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_qm.pb'),
+                    version     = self.cms.uint32(1),
+                    memMapped   = self.cms.bool(True)
                 )
 
                 self.processDeepProducer('dpfTau2016v1Q', tauIDSources, working_points)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -1,6 +1,7 @@
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1VLoose
 import os
+import re
 
 class TauIDEmbedder(object):
     """class to rerun the tau seq and acces trainings from the database"""
@@ -597,7 +598,7 @@ class TauIDEmbedder(object):
             tauIDSources.byVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VTight')
             tauIDSources.byVVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VVTight')
 
-        if "deepTau2017v1" in self.toKeep or "deepTau2017v1Q" in self.toKeep:
+        if "deepTau2017v1" in self.toKeep:
             print "Adding DeepTau IDs"
 
             workingPoints_ = {
@@ -635,12 +636,13 @@ class TauIDEmbedder(object):
             }
 
             if "deepTau2017v1" in self.toKeep:
+                file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'
                 self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
                     electrons              = self.cms.InputTag('slimmedElectrons'),
                     muons                  = self.cms.InputTag('slimmedMuons'),
                     taus                   = self.cms.InputTag('slimmedTaus'),
-                    graph_file             = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'),
-                    mem_mapped              = self.cms.bool(False)
+                    graph_file             = self.cms.string(file_name),
+                    mem_mapped             = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
@@ -648,23 +650,7 @@ class TauIDEmbedder(object):
                 self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
                 self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
 
-            if "deepTau2017v1Q" in self.toKeep:
-                self.process.deepTau2017v1Q = self.cms.EDProducer("DeepTauId",
-                    electrons               = self.cms.InputTag('slimmedElectrons'),
-                    muons                   = self.cms.InputTag('slimmedMuons'),
-                    taus                    = self.cms.InputTag('slimmedTaus'),
-                    graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'),
-                    mem_mapped              = self.cms.bool(False)
-                )
-
-                self.processDeepProducer('deepTau2017v1Q', tauIDSources, workingPoints_)
-
-                self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1Q)
-                self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1Q
-
-
-
-        if "DPFTau_2016_v0" in self.toKeep or "DPFTau_2016_v0Q" in self.toKeep:
+        if "DPFTau_2016_v0" in self.toKeep:
             print "Adding DPFTau isolation (v0)"
 
             workingPoints_ = {
@@ -683,13 +669,14 @@ class TauIDEmbedder(object):
             }
 
             if "DPFTau_2016_v0" in self.toKeep:
+                file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'
                 self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
                     pfcands     = self.cms.InputTag('packedPFCandidates'),
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'),
-                    version     = self.cms.uint32(0),
-                    mem_mapped   = self.cms.bool(False)
+                    graph_file  = self.cms.string(file_name),
+                    version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
+                    mem_mapped  = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
@@ -697,22 +684,8 @@ class TauIDEmbedder(object):
                 self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
                 self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
 
-            if "DPFTau_2016_v0Q" in self.toKeep:
-                self.process.dpfTau2016v0Q = self.cms.EDProducer("DPFIsolation",
-                    pfcands     = self.cms.InputTag('packedPFCandidates'),
-                    taus 	    = self.cms.InputTag('slimmedTaus'),
-                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'),
-                    version     = self.cms.uint32(0),
-                    mem_mapped   = self.cms.bool(False)
-                )
 
-                self.processDeepProducer('dpfTau2016v0Q', tauIDSources, workingPoints_)
-
-                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0Q)
-                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0Q
-
-        if "DPFTau_2016_v1" in self.toKeep or "DPFTau_2016_v1Q" in self.toKeep:
+        if "DPFTau_2016_v1" in self.toKeep:
             print "Adding DPFTau isolation (v1)"
             print "WARNING: WPs are not defined for DPFTau_2016_v1"
             print "WARNING: The score of DPFTau_2016_v1 is inverted: i.e. for Sig->0, for Bkg->1 with -1 for undefined input (preselection not passed)."
@@ -722,12 +695,13 @@ class TauIDEmbedder(object):
             }
 
             if "DPFTau_2016_v1" in self.toKeep:
+                file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'
                 self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
                     pfcands     = self.cms.InputTag('packedPFCandidates'),
                     taus 	    = self.cms.InputTag('slimmedTaus'),
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'),
-                    version     = self.cms.uint32(1),
+                    graph_file  = self.cms.string(file_name),
+                    version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
                     mem_mapped   = self.cms.bool(False)
                 )
 
@@ -735,21 +709,6 @@ class TauIDEmbedder(object):
 
                 self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
                 self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
-
-            if "DPFTau_2016_v1Q" in self.toKeep:
-                self.process.dpfTau2016v1Q = self.cms.EDProducer("DPFIsolation",
-                    pfcands     = self.cms.InputTag('packedPFCandidates'),
-                    taus 	    = self.cms.InputTag('slimmedTaus'),
-                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'),
-                    version     = self.cms.uint32(1),
-                    mem_mapped   = self.cms.bool(False)
-                )
-
-                self.processDeepProducer('dpfTau2016v1Q', tauIDSources, workingPoints_)
-
-                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1Q)
-                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1Q
 
         print('Embedding new TauIDs into \"'+self.updatedTauName+'\"')
         embedID = self.cms.EDProducer("PATTauIDEmbedder",
@@ -771,3 +730,11 @@ class TauIDEmbedder(object):
                         self.cms.InputTag(producer_name, 'VS{}{}'.format(target, point)))
 
             setattr(getattr(self.process, producer_name), 'VS{}WP'.format(target), cuts)
+
+
+    def getDpfTauVersion(self, file_name):
+        version_search = re.search('.*v([0-9]+)\.pb$', file_name)
+        if not version_search:
+            raise RuntimeError('File "{}" has an invalid name pattern. Unable to extract version number.'.format(file_name))
+        version = version_search.group(1)
+        return int(version)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -634,21 +634,19 @@ class TauIDEmbedder(object):
                     "VVTight": 0.9859
                 }
             }
+            file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'
+            self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
+                electrons              = self.cms.InputTag('slimmedElectrons'),
+                muons                  = self.cms.InputTag('slimmedMuons'),
+                taus                   = self.cms.InputTag('slimmedTaus'),
+                graph_file             = self.cms.string(file_name),
+                mem_mapped             = self.cms.bool(False)
+            )
 
-            if "deepTau2017v1" in self.toKeep:
-                file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'
-                self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
-                    electrons              = self.cms.InputTag('slimmedElectrons'),
-                    muons                  = self.cms.InputTag('slimmedMuons'),
-                    taus                   = self.cms.InputTag('slimmedTaus'),
-                    graph_file             = self.cms.string(file_name),
-                    mem_mapped             = self.cms.bool(False)
-                )
+            self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
 
-                self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
-
-                self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
-                self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
+            self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
+            self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
 
         if "DPFTau_2016_v0" in self.toKeep:
             print "Adding DPFTau isolation (v0)"
@@ -667,22 +665,20 @@ class TauIDEmbedder(object):
                     #            (decayMode == 10) * (0.873958 - 0.0002328 * pt) "
                 }
             }
+            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'
+            self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
+                pfcands     = self.cms.InputTag('packedPFCandidates'),
+                taus 	    = self.cms.InputTag('slimmedTaus'),
+                vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                graph_file  = self.cms.string(file_name),
+                version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
+                mem_mapped  = self.cms.bool(False)
+            )
 
-            if "DPFTau_2016_v0" in self.toKeep:
-                file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'
-                self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
-                    pfcands     = self.cms.InputTag('packedPFCandidates'),
-                    taus 	    = self.cms.InputTag('slimmedTaus'),
-                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string(file_name),
-                    version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
-                    mem_mapped  = self.cms.bool(False)
-                )
+            self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
 
-                self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
-
-                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
-                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
+            self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
+            self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
 
 
         if "DPFTau_2016_v1" in self.toKeep:
@@ -694,21 +690,20 @@ class TauIDEmbedder(object):
                 "all": {"Tight" : 0.123} #FIXME: define WP
             }
 
-            if "DPFTau_2016_v1" in self.toKeep:
-                file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'
-                self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
-                    pfcands     = self.cms.InputTag('packedPFCandidates'),
-                    taus 	    = self.cms.InputTag('slimmedTaus'),
-                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                    graph_file  = self.cms.string(file_name),
-                    version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
-                    mem_mapped   = self.cms.bool(False)
-                )
+            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'
+            self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
+                pfcands     = self.cms.InputTag('packedPFCandidates'),
+                taus 	    = self.cms.InputTag('slimmedTaus'),
+                vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                graph_file  = self.cms.string(file_name),
+                version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
+                mem_mapped   = self.cms.bool(False)
+            )
 
-                self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
+            self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
 
-                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
-                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
+            self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
+            self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
 
         print('Embedding new TauIDs into \"'+self.updatedTauName+'\"')
         embedID = self.cms.EDProducer("PATTauIDEmbedder",

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -729,6 +729,7 @@ class TauIDEmbedder(object):
 
     def getDpfTauVersion(self, file_name):
         version_search = re.search('201[125678]v([0-9]+)[\._]', file_name)
+        """returns the DNN version. Expected that the file name contains a version number in the following format: {year}v{version}"""
         if not version_search:
             raise RuntimeError('File "{}" has an invalid name pattern. Unable to extract version number.'.format(file_name))
         version = version_search.group(1)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -597,7 +597,7 @@ class TauIDEmbedder(object):
             tauIDSources.byVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VTight')
             tauIDSources.byVVTightIsolationMVArun2v1DBnewDMwLT2016 = self.cms.InputTag('rerunDiscriminationByIsolationNewDMMVArun2v1VVTight')
 
-        if "deepTau2017v1" in self.toKeep:
+        if "deepTau2017v1" in self.toKeep or "deepTau2017v1Q" in self.toKeep:
             print "Adding DeepTau IDs"
 
             working_points = {
@@ -633,19 +633,36 @@ class TauIDEmbedder(object):
                     "VVTight": "0.9859"
                 }
             }
-            self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
-                electrons = self.cms.InputTag('slimmedElectrons'),
-                muons = self.cms.InputTag('slimmedMuons'),
-                taus = self.cms.InputTag('slimmedTaus'),
-                graph_file = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb')
-            )
 
-            self.processDeepProducer('deepTau2017v1', tauIDSources, working_points)
+            if "deepTau2017v1" in self.toKeep:
+                self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
+                    electrons              = self.cms.InputTag('slimmedElectrons'),
+                    muons                  = self.cms.InputTag('slimmedMuons'),
+                    taus                   = self.cms.InputTag('slimmedTaus'),
+                    graph_file             = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb')
+                )
 
-            self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
-            self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
+                self.processDeepProducer('deepTau2017v1', tauIDSources, working_points)
 
-	if "DPFTau_2016_v0" in self.toKeep:
+                self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
+                self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
+
+            if "deepTau2017v1Q" in self.toKeep:
+                self.process.deepTau2017v1Q = self.cms.EDProducer("DeepTauId",
+                    electrons               = self.cms.InputTag('slimmedElectrons'),
+                    muons                   = self.cms.InputTag('slimmedMuons'),
+                    taus                    = self.cms.InputTag('slimmedTaus'),
+                    graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb')
+                )
+
+                self.processDeepProducer('deepTau2017v1Q', tauIDSources, working_points)
+
+                self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1Q)
+                self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1Q
+
+
+
+        if "DPFTau_2016_v0" in self.toKeep or "DPFTau_2016_v0Q" in self.toKeep:
             print "Adding DPFTau isolation (v0)"
 
             working_points = {
@@ -660,19 +677,35 @@ class TauIDEmbedder(object):
                 }
             }
 
-            self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
-                pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus 	    = self.cms.InputTag('slimmedTaus'),
-                vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb')
-            )
+            if "DPFTau_2016_v0" in self.toKeep:
+                self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
+                    pfcands     = self.cms.InputTag('packedPFCandidates'),
+                    taus 	    = self.cms.InputTag('slimmedTaus'),
+                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'),
+                    version     = self.cms.uint32(0)
+                )
 
-            self.processDeepProducer('dpfTau2016v0', tauIDSources, working_points)
+                self.processDeepProducer('dpfTau2016v0', tauIDSources, working_points)
 
-            self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
-            self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
+                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
+                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
 
-        if "DPFTau_2016_v1" in self.toKeep:
+            if "DPFTau_2016_v0Q" in self.toKeep:
+                self.process.dpfTau2016v0Q = self.cms.EDProducer("DPFIsolation",
+                    pfcands     = self.cms.InputTag('packedPFCandidates'),
+                    taus 	    = self.cms.InputTag('slimmedTaus'),
+                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'),
+                    version     = self.cms.uint32(0)
+                )
+
+                self.processDeepProducer('dpfTau2016v0Q', tauIDSources, working_points)
+
+                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0Q)
+                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0Q
+
+        if "DPFTau_2016_v1" in self.toKeep or "DPFTau_2016_v1Q" in self.toKeep:
             print "Adding DPFTau isolation (v1)"
             print "WARNING: WPs are not defined for DPFTau_2016_v1"
             print "WARNING: The score of DPFTau_2016_v1 is inverted: i.e. for Sig->0, for Bkg->1 with -1 for undefined input (preselection not passed)."
@@ -681,17 +714,33 @@ class TauIDEmbedder(object):
                 "all": {"Tight" : "0.123"} #FIXME: define WP
             }
 
-            self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
-                pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus 	    = self.cms.InputTag('slimmedTaus'),
-                vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb')
-            )
+            if "DPFTau_2016_v1" in self.toKeep:
+                self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
+                    pfcands     = self.cms.InputTag('packedPFCandidates'),
+                    taus 	    = self.cms.InputTag('slimmedTaus'),
+                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'),
+                    version     = self.cms.uint32(1)
+                )
 
-            self.processDeepProducer('dpfTau2016v1', tauIDSources, working_points)
+                self.processDeepProducer('dpfTau2016v1', tauIDSources, working_points)
 
-            self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
-            self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
+                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
+                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
+
+            if "DPFTau_2016_v1Q" in self.toKeep:
+                self.process.dpfTau2016v1Q = self.cms.EDProducer("DPFIsolation",
+                    pfcands     = self.cms.InputTag('packedPFCandidates'),
+                    taus 	    = self.cms.InputTag('slimmedTaus'),
+                    vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                    graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'),
+                    version     = self.cms.uint32(1)
+                )
+
+                self.processDeepProducer('dpfTau2016v1Q', tauIDSources, working_points)
+
+                self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1Q)
+                self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1Q
 
         print('Embedding new TauIDs into \"'+self.updatedTauName+'\"')
         embedID = self.cms.EDProducer("PATTauIDEmbedder",

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -728,8 +728,8 @@ class TauIDEmbedder(object):
 
 
     def getDpfTauVersion(self, file_name):
-        version_search = re.search('201[125678]v([0-9]+)[\._]', file_name)
         """returns the DNN version. Expected that the file name contains a version number in the following format: {year}v{version}"""
+        version_search = re.search('201[125678]v([0-9]+)[\._]', file_name)
         if not version_search:
             raise RuntimeError('File "{}" has an invalid name pattern. Unable to extract version number.'.format(file_name))
         version = version_search.group(1)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -728,9 +728,11 @@ class TauIDEmbedder(object):
 
 
     def getDpfTauVersion(self, file_name):
-        """returns the DNN version. Expected that the file name contains a version number in the following format: {year}v{version}"""
+        """returns the DNN version. File name should contain a version label with data takig year (2011-2, 2015-8) and \
+           version number (vX), e.g. 2017v0, in general the following format: {year}v{version}"""
         version_search = re.search('201[125678]v([0-9]+)[\._]', file_name)
         if not version_search:
-            raise RuntimeError('File "{}" has an invalid name pattern. Unable to extract version number.'.format(file_name))
+            raise RuntimeError('File "{}" has an invalid name pattern, should be in the format "{year}v{version}". \
+                                Unable to extract version number.'.format(file_name))
         version = version_search.group(1)
         return int(version)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -600,7 +600,7 @@ class TauIDEmbedder(object):
         if "deepTau2017v1" in self.toKeep or "deepTau2017v1Q" in self.toKeep:
             print "Adding DeepTau IDs"
 
-            working_points = {
+            workingPoints_ = {
                 "e": {
                     "VVVLoose" : 0.96424,
                     "VVLoose" : 0.98992,
@@ -643,7 +643,7 @@ class TauIDEmbedder(object):
                     memMapped              = self.cms.bool(False)
                 )
 
-                self.processDeepProducer('deepTau2017v1', tauIDSources, working_points)
+                self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
 
                 self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1)
                 self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1
@@ -657,7 +657,7 @@ class TauIDEmbedder(object):
                     memMapped              = self.cms.bool(False)
                 )
 
-                self.processDeepProducer('deepTau2017v1Q', tauIDSources, working_points)
+                self.processDeepProducer('deepTau2017v1Q', tauIDSources, workingPoints_)
 
                 self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v1Q)
                 self.process.rerunMvaIsolationSequence += self.process.deepTau2017v1Q
@@ -667,12 +667,12 @@ class TauIDEmbedder(object):
         if "DPFTau_2016_v0" in self.toKeep or "DPFTau_2016_v0Q" in self.toKeep:
             print "Adding DPFTau isolation (v0)"
 
-            working_points = {
+            workingPoints_ = {
                 "all": {
                     "Tight" : "if(decayMode == 0) return (0.898328 - 0.000160992 * pt);" + \
                               "if(decayMode == 1) return (0.910138 - 0.000229923 * pt);" + \
                               "if(decayMode == 10) return (0.873958 - 0.0002328 * pt);" + \
-                              "return 1.0;"
+                              "return 99.0;"
                     #"Tight" : "? decayMode == 0 ? (0.898328 - 0.000160992 * pt) : " +
                     #          "(? decayMode == 1 ? 0.910138 - 0.000229923 * pt : " +
                     #          "(? decayMode == 10 ? (0.873958 - 0.0002328 * pt) : 1))"
@@ -692,7 +692,7 @@ class TauIDEmbedder(object):
                     memMapped   = self.cms.bool(False)
                 )
 
-                self.processDeepProducer('dpfTau2016v0', tauIDSources, working_points)
+                self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
 
                 self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0)
                 self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0
@@ -707,7 +707,7 @@ class TauIDEmbedder(object):
                     memMapped   = self.cms.bool(False)
                 )
 
-                self.processDeepProducer('dpfTau2016v0Q', tauIDSources, working_points)
+                self.processDeepProducer('dpfTau2016v0Q', tauIDSources, workingPoints_)
 
                 self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v0Q)
                 self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v0Q
@@ -717,7 +717,7 @@ class TauIDEmbedder(object):
             print "WARNING: WPs are not defined for DPFTau_2016_v1"
             print "WARNING: The score of DPFTau_2016_v1 is inverted: i.e. for Sig->0, for Bkg->1 with -1 for undefined input (preselection not passed)."
 
-            working_points = {
+            workingPoints_ = {
                 "all": {"Tight" : 0.123} #FIXME: define WP
             }
 
@@ -731,7 +731,7 @@ class TauIDEmbedder(object):
                     memMapped   = self.cms.bool(False)
                 )
 
-                self.processDeepProducer('dpfTau2016v1', tauIDSources, working_points)
+                self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
 
                 self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1)
                 self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1
@@ -746,7 +746,7 @@ class TauIDEmbedder(object):
                     memMapped   = self.cms.bool(False)
                 )
 
-                self.processDeepProducer('dpfTau2016v1Q', tauIDSources, working_points)
+                self.processDeepProducer('dpfTau2016v1Q', tauIDSources, workingPoints_)
 
                 self.process.rerunMvaIsolationTask.add(self.process.dpfTau2016v1Q)
                 self.process.rerunMvaIsolationSequence += self.process.dpfTau2016v1Q
@@ -759,8 +759,8 @@ class TauIDEmbedder(object):
         setattr(self.process, self.updatedTauName, embedID)
 
 
-    def processDeepProducer(self, producer_name, tauIDSources, working_points):
-        for target,points in working_points.iteritems():
+    def processDeepProducer(self, producer_name, tauIDSources, workingPoints_):
+        for target,points in workingPoints_.iteritems():
             cuts = self.cms.PSet()
             setattr(tauIDSources, 'by{}VS{}raw'.format(producer_name[0].upper()+producer_name[1:], target),
                         self.cms.InputTag(producer_name, 'VS{}'.format(target)))

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -602,35 +602,35 @@ class TauIDEmbedder(object):
 
             working_points = {
                 "e": {
-                    "VVVLoose" : "0.96424",
-                    "VVLoose" : "0.98992",
-                    "VLoose" : "0.99574",
-                    "Loose": "0.99831",
-                    "Medium": "0.99868",
-                    "Tight": "0.99898",
-                    "VTight": "0.99911",
-                    "VVTight": "0.99918"
+                    "VVVLoose" : 0.96424,
+                    "VVLoose" : 0.98992,
+                    "VLoose" : 0.99574,
+                    "Loose": 0.99831,
+                    "Medium": 0.99868,
+                    "Tight": 0.99898,
+                    "VTight": 0.99911,
+                    "VVTight": 0.99918
                 },
                 "mu": {
-                    "VVVLoose" : "0.959619",
-                    "VVLoose" : "0.997687",
-                    "VLoose" : "0.999392",
-                    "Loose": "0.999755",
-                    "Medium": "0.999854",
-                    "Tight": "0.999886",
-                    "VTight": "0.999944",
-                    "VVTight": "0.9999971"
+                    "VVVLoose" : 0.959619,
+                    "VVLoose" : 0.997687,
+                    "VLoose" : 0.999392,
+                    "Loose": 0.999755,
+                    "Medium": 0.999854,
+                    "Tight": 0.999886,
+                    "VTight": 0.999944,
+                    "VVTight": 0.9999971
                 },
 
                 "jet": {
-                    "VVVLoose" : "0.5329",
-                    "VVLoose" : "0.7645",
-                    "VLoose" : "0.8623",
-                    "Loose": "0.9140",
-                    "Medium": "0.9464",
-                    "Tight": "0.9635",
-                    "VTight": "0.9760",
-                    "VVTight": "0.9859"
+                    "VVVLoose" : 0.5329,
+                    "VVLoose" : 0.7645,
+                    "VLoose" : 0.8623,
+                    "Loose": 0.9140,
+                    "Medium": 0.9464,
+                    "Tight": 0.9635,
+                    "VTight": 0.9760,
+                    "VVTight": 0.9859
                 }
             }
 
@@ -670,10 +670,13 @@ class TauIDEmbedder(object):
 
             working_points = {
                 "all": {
-
-                    "Tight" : "? decayMode == 0 ? (0.898328 - 0.000160992 * pt) : " +
-                              "(? decayMode == 1 ? 0.910138 - 0.000229923 * pt : " +
-                              "(? decayMode == 10 ? (0.873958 - 0.0002328 * pt) : 1))"
+                    "Tight" : "if(decayMode == 0) return (0.898328 - 0.000160992 * pt);" + \
+                              "if(decayMode == 1) return (0.910138 - 0.000229923 * pt);" + \
+                              "if(decayMode == 10) return (0.873958 - 0.0002328 * pt);" + \
+                              "return 1.0;"
+                    #"Tight" : "? decayMode == 0 ? (0.898328 - 0.000160992 * pt) : " +
+                    #          "(? decayMode == 1 ? 0.910138 - 0.000229923 * pt : " +
+                    #          "(? decayMode == 10 ? (0.873958 - 0.0002328 * pt) : 1))"
                     # "Tight" : "(decayMode == 0) * (0.898328 - 0.000160992 * pt) + \
                     #            (decayMode == 1) * (0.910138 - 0.000229923 * pt) + \
                     #            (decayMode == 10) * (0.873958 - 0.0002328 * pt) "
@@ -716,7 +719,7 @@ class TauIDEmbedder(object):
             print "WARNING: The score of DPFTau_2016_v1 is inverted: i.e. for Sig->0, for Bkg->1 with -1 for undefined input (preselection not passed)."
 
             working_points = {
-                "all": {"Tight" : "0.123"} #FIXME: define WP
+                "all": {"Tight" : 0.123} #FIXME: define WP
             }
 
             if "DPFTau_2016_v1" in self.toKeep:
@@ -763,7 +766,7 @@ class TauIDEmbedder(object):
             setattr(tauIDSources, 'by{}VS{}raw'.format(producer_name[0].upper()+producer_name[1:], target),
                         self.cms.InputTag(producer_name, 'VS{}'.format(target)))
             for point,cut in points.iteritems():
-                setattr(cuts, point, self.cms.string(cut))
+                setattr(cuts, point, self.cms.string(str(cut)))
 
                 setattr(tauIDSources, 'by{}{}VS{}'.format(point, producer_name[0].upper()+producer_name[1:], target),
                         self.cms.InputTag(producer_name, 'VS{}{}'.format(target, point)))

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -634,7 +634,7 @@ class TauIDEmbedder(object):
                     "VVTight": 0.9859
                 }
             }
-            file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'
+            file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'
             self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
                 electrons              = self.cms.InputTag('slimmedElectrons'),
                 muons                  = self.cms.InputTag('slimmedMuons'),
@@ -665,10 +665,10 @@ class TauIDEmbedder(object):
                     #            (decayMode == 10) * (0.873958 - 0.0002328 * pt) "
                 }
             }
-            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'
+            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'
             self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
                 pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus 	    = self.cms.InputTag('slimmedTaus'),
+                taus        = self.cms.InputTag('slimmedTaus'),
                 vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 graph_file  = self.cms.string(file_name),
                 version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
@@ -690,14 +690,14 @@ class TauIDEmbedder(object):
                 "all": {"Tight" : 0.123} #FIXME: define WP
             }
 
-            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'
+            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'
             self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
                 pfcands     = self.cms.InputTag('packedPFCandidates'),
-                taus 	    = self.cms.InputTag('slimmedTaus'),
+                taus        = self.cms.InputTag('slimmedTaus'),
                 vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 graph_file  = self.cms.string(file_name),
                 version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
-                mem_mapped   = self.cms.bool(False)
+                mem_mapped  = self.cms.bool(False)
             )
 
             self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
@@ -728,7 +728,7 @@ class TauIDEmbedder(object):
 
 
     def getDpfTauVersion(self, file_name):
-        version_search = re.search('.*v([0-9]+)\.pb$', file_name)
+        version_search = re.search('201[125678]v([0-9]+)[\._]', file_name)
         if not version_search:
             raise RuntimeError('File "{}" has an invalid name pattern. Unable to extract version number.'.format(file_name))
         version = version_search.group(1)

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -640,7 +640,7 @@ class TauIDEmbedder(object):
                     muons                  = self.cms.InputTag('slimmedMuons'),
                     taus                   = self.cms.InputTag('slimmedTaus'),
                     graph_file             = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N.pb'),
-                    memMapped              = self.cms.bool(False)
+                    mem_mapped              = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
@@ -654,7 +654,7 @@ class TauIDEmbedder(object):
                     muons                   = self.cms.InputTag('slimmedMuons'),
                     taus                    = self.cms.InputTag('slimmedTaus'),
                     graph_file              = self.cms.string('RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'),
-                    memMapped              = self.cms.bool(False)
+                    mem_mapped              = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('deepTau2017v1Q', tauIDSources, workingPoints_)
@@ -689,7 +689,7 @@ class TauIDEmbedder(object):
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                     graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0.pb'),
                     version     = self.cms.uint32(0),
-                    memMapped   = self.cms.bool(False)
+                    mem_mapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v0', tauIDSources, workingPoints_)
@@ -704,7 +704,7 @@ class TauIDEmbedder(object):
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                     graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'),
                     version     = self.cms.uint32(0),
-                    memMapped   = self.cms.bool(False)
+                    mem_mapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v0Q', tauIDSources, workingPoints_)
@@ -728,7 +728,7 @@ class TauIDEmbedder(object):
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                     graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1.pb'),
                     version     = self.cms.uint32(1),
-                    memMapped   = self.cms.bool(False)
+                    mem_mapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v1', tauIDSources, workingPoints_)
@@ -743,7 +743,7 @@ class TauIDEmbedder(object):
                     vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                     graph_file  = self.cms.string('RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'),
                     version     = self.cms.uint32(1),
-                    memMapped   = self.cms.bool(False)
+                    mem_mapped   = self.cms.bool(False)
                 )
 
                 self.processDeepProducer('dpfTau2016v1Q', tauIDSources, workingPoints_)

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -117,7 +117,7 @@ std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::Para
     return std::make_unique<DeepTauCache>(graph_name, mem_mapped);
 }
 
-DeepTauCache::DeepTauCache(const std::string& graph_name, const bool& mem_mapped)
+DeepTauCache::DeepTauCache(const std::string& graph_name, bool mem_mapped)
 {
     tensorflow::SessionOptions options;
     tensorflow::setThreading(options, 1, "no_threads");

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -121,7 +121,7 @@ std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::Para
     return std::make_unique<DeepTauCache>(graphName, memMapped );
 }
 
-void DeepTauBase::globalEndJob(const DeepTauCache* cache) { }
+// void DeepTauBase::globalEndJob(const DeepTauCache* cache) { }
 
 DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
 {
@@ -145,12 +145,11 @@ DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
         options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(::tensorflow::OptimizerOptions::L0);
         options.env = memmapped_env.get();
 
-        const tensorflow::Status session_status = tensorflow::NewSession(options, &session);
-        session = tensorflow::createSession(graph.get(), options);        if(!session_status.ok())
-            throw cms::Exception("DeepTauCache: unable to create a session for ") << graphName << ". \n"
-                                                                                  << session_status.ToString();
-      } else {
+        session = tensorflow::createSession(graph.get(), options);
+
+    } else {
         graph.reset(tensorflow::loadGraphDef(graphName));
+        session = tensorflow::createSession(graph.get(), options);
       }
 }
 

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -7,7 +7,7 @@
  * \author Maria Rosaria Di Domenico, University of Siena & INFN Pisa
  */
 
-#include <TF1.h>
+
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 
 namespace deep_tau {
@@ -92,20 +92,16 @@ DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& o
     }
 }
 
-DeepTauBase::~DeepTauBase()
-{
-}
-
 void DeepTauBase::produce(edm::Event& event, const edm::EventSetup& es)
 {
     edm::Handle<TauCollection> taus;
     event.getByToken(taus_token, taus);
 
-    const tensorflow::Tensor& pred = GetPredictions(event, es, taus);
-    CreateOutputs(event, pred, taus);
+    const tensorflow::Tensor& pred = getPredictions(event, es, taus);
+    createOutputs(event, pred, taus);
 }
 
-void DeepTauBase::CreateOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus)
+void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus)
 {
     for(const auto& output_desc : outputs) {
         auto result_map = output_desc.second.get_value(taus, pred, working_points.at(output_desc.first));

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -18,7 +18,7 @@ TauWPThreshold::TauWPThreshold(const std::string& cut_str)
     try {
         size_t pos = 0;
         value_ = std::stod(cut_str, &pos);
-        simple_value = pos == cut_str.size();
+        simple_value = (pos == cut_str.size());
     } catch(std::invalid_argument&) {
     } catch(std::out_of_range&) {
     }

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -12,13 +12,13 @@
 
 namespace deep_tau {
 
-TauWPThreshold::TauWPThreshold(const std::string& cut_str)
+TauWPThreshold::TauWPThreshold(const std::string& cutStr)
 {
     bool simple_value = false;
     try {
         size_t pos = 0;
-        value = std::stod(cut_str, &pos);
-        simple_value = pos == cut_str.size();
+        value_ = std::stod(cutStr, &pos);
+        simple_value = pos == cutStr.size();
     } catch(std::invalid_argument&) {
     } catch(std::out_of_range&) {
     }
@@ -28,32 +28,32 @@ TauWPThreshold::TauWPThreshold(const std::string& cut_str)
         static const int n_params = 3;
         static const auto handler = [](int, Bool_t, const char*, const char*) -> void {};
 
-        const std::string fn_str = prefix + cut_str + "}";
+        const std::string fn_str = prefix + cutStr + "}";
         auto old_handler = SetErrorHandler(handler);
-        fn = std::make_unique<TF1>("fn", fn_str.c_str(), 0, 1, n_params);
+        fn_ = std::make_unique<TF1>("fn_", fn_str.c_str(), 0, 1, n_params);
         SetErrorHandler(old_handler);
-        if(!fn->IsValid())
-            throw cms::Exception("TauWPThreshold: invalid formula") << "Invalid WP cut formula = '" << cut_str << "'.";
+        if(!fn_->IsValid())
+            throw cms::Exception("TauWPThreshold: invalid formula") << "Invalid WP cut formula = '" << cutStr << "'.";
     }
 }
 
 double TauWPThreshold::operator()(const pat::Tau& tau) const
 {
-    if(!fn)
-        return value;
-    fn->SetParameter(0, tau.decayMode());
-    fn->SetParameter(1, tau.pt());
-    fn->SetParameter(2, tau.eta());
-    return fn->Eval(0);
+    if(!fn_)
+        return value_;
+    fn_->SetParameter(0, tau.decayMode());
+    fn_->SetParameter(1, tau.pt());
+    fn_->SetParameter(2, tau.eta());
+    return fn_->Eval(0);
 }
 
 DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<TauCollection>& taus,
                                                               const tensorflow::Tensor& pred,
-                                                              const WPMap& working_points) const
+                                                              const WPMap& workingPoints_) const
 {
     ResultMap output;
     output[""] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
-    for(const auto& wp : working_points)
+    for(const auto& wp : workingPoints_)
         output[wp.first] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
 
     for(size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
@@ -67,7 +67,7 @@ DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<
             x = den_val != 0 ? x / den_val : std::numeric_limits<float>::max();
         }
         output[""]->setValue(tau_index, x);
-        for(const auto& wp : working_points) {
+        for(const auto& wp : workingPoints_) {
             const auto& tau = taus->at(tau_index);
             const bool pass = x > (*wp.second)(tau);
             output[wp.first]->setValue(tau_index, pass);
@@ -76,17 +76,17 @@ DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<
     return output;
 }
 
-DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputCollection, const DeepTauCache* _cache) :
-    taus_token(consumes<TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
-    outputs(outputCollection),
-    cache(_cache)
+DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputCollection, const DeepTauCache* Cache) :
+    tausToken_(consumes<TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
+    outputs_(outputCollection),
+    cache_(Cache)
 {
-    for(const auto& output_desc : outputs) {
+    for(const auto& output_desc : outputs_) {
         produces<TauDiscriminator>(output_desc.first);
         const auto& cut_pset = cfg.getParameter<edm::ParameterSet>(output_desc.first + "WP");
         for(const std::string& wp_name : cut_pset.getParameterNames()) {
-            const auto& cut_str = cut_pset.getParameter<std::string>(wp_name);
-            working_points[output_desc.first][wp_name] = std::make_unique<Cutter>(cut_str);
+            const auto& cutStr = cut_pset.getParameter<std::string>(wp_name);
+            workingPoints_[output_desc.first][wp_name] = std::make_unique<Cutter>(cutStr);
             produces<TauDiscriminator>(output_desc.first + wp_name);
         }
     }
@@ -95,7 +95,7 @@ DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& o
 void DeepTauBase::produce(edm::Event& event, const edm::EventSetup& es)
 {
     edm::Handle<TauCollection> taus;
-    event.getByToken(taus_token, taus);
+    event.getByToken(tausToken_, taus);
 
     const tensorflow::Tensor& pred = getPredictions(event, es, taus);
     createOutputs(event, pred, taus);
@@ -103,8 +103,8 @@ void DeepTauBase::produce(edm::Event& event, const edm::EventSetup& es)
 
 void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus)
 {
-    for(const auto& output_desc : outputs) {
-        auto result_map = output_desc.second.get_value(taus, pred, working_points.at(output_desc.first));
+    for(const auto& output_desc : outputs_) {
+        auto result_map = output_desc.second.get_value(taus, pred, workingPoints_.at(output_desc.first));
         for(auto& result : result_map)
             event.put(std::move(result.second), output_desc.first + result.first);
     }
@@ -114,10 +114,8 @@ std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::Para
 {
     std::string graphName = edm::FileInPath(cfg.getParameter<std::string>("graph_file")).fullPath();
     bool memMapped = cfg.getParameter<bool>("memMapped");
-    return std::make_unique<DeepTauCache>(graphName, memMapped );
+    return std::make_unique<DeepTauCache>(graphName, memMapped);
 }
-
-// void DeepTauBase::globalEndJob(const DeepTauCache* cache) { }
 
 DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
 {
@@ -125,33 +123,33 @@ DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
     tensorflow::setThreading(options, 1, "no_threads");
 
     if(memMapped) {
-        memmapped_env = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
-        const tensorflow::Status mmap_status = memmapped_env.get()->InitializeFromFile(graphName);
+        memmappedEnv_ = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
+        const tensorflow::Status mmap_status = memmappedEnv_.get()->InitializeFromFile(graphName);
         if(!mmap_status.ok())
             throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ") << graphName << ". \n"
                                                                                                  << mmap_status.ToString();
 
-        graph = std::make_unique<tensorflow::GraphDef>();
-        const tensorflow::Status load_graph_status = ReadBinaryProto(memmapped_env.get(),
+        graph_ = std::make_unique<tensorflow::GraphDef>();
+        const tensorflow::Status load_graph_status = ReadBinaryProto(memmappedEnv_.get(),
                                                                      tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
-                                                                     graph.get());
+                                                                     graph_.get());
         if(!load_graph_status.ok())
-            throw cms::Exception("DeepTauCache: unable to load graph from ") << graphName << ". \n"
+            throw cms::Exception("DeepTauCache: unable to load graph_ from ") << graphName << ". \n"
                                                                              << mmap_status.ToString();
         options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(::tensorflow::OptimizerOptions::L0);
-        options.env = memmapped_env.get();
+        options.env = memmappedEnv_.get();
 
-        session = tensorflow::createSession(graph.get(), options);
+        session_ = tensorflow::createSession(graph_.get(), options);
 
     } else {
-        graph.reset(tensorflow::loadGraphDef(graphName));
-        session = tensorflow::createSession(graph.get(), options);
+        graph_.reset(tensorflow::loadGraphDef(graphName));
+        session_ = tensorflow::createSession(graph_.get(), options);
       }
 }
 
 DeepTauCache::~DeepTauCache()
 {
-    tensorflow::closeSession(session);
+    tensorflow::closeSession(session_);
 }
 
 } // namespace deep_tau

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -12,13 +12,13 @@
 
 namespace deep_tau {
 
-TauWPThreshold::TauWPThreshold(const std::string& cutStr)
+TauWPThreshold::TauWPThreshold(const std::string& cut_str)
 {
     bool simple_value = false;
     try {
         size_t pos = 0;
-        value_ = std::stod(cutStr, &pos);
-        simple_value = pos == cutStr.size();
+        value_ = std::stod(cut_str, &pos);
+        simple_value = pos == cut_str.size();
     } catch(std::invalid_argument&) {
     } catch(std::out_of_range&) {
     }
@@ -28,12 +28,12 @@ TauWPThreshold::TauWPThreshold(const std::string& cutStr)
         static const int n_params = 3;
         static const auto handler = [](int, Bool_t, const char*, const char*) -> void {};
 
-        const std::string fn_str = prefix + cutStr + "}";
+        const std::string fn_str = prefix + cut_str + "}";
         auto old_handler = SetErrorHandler(handler);
         fn_ = std::make_unique<TF1>("fn_", fn_str.c_str(), 0, 1, n_params);
         SetErrorHandler(old_handler);
         if(!fn_->IsValid())
-            throw cms::Exception("TauWPThreshold: invalid formula") << "Invalid WP cut formula = '" << cutStr << "'.";
+            throw cms::Exception("TauWPThreshold: invalid formula") << "Invalid WP cut formula = '" << cut_str << "'.";
     }
 }
 
@@ -49,25 +49,25 @@ double TauWPThreshold::operator()(const pat::Tau& tau) const
 
 DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<TauCollection>& taus,
                                                               const tensorflow::Tensor& pred,
-                                                              const WPMap& workingPoints_) const
+                                                              const WPMap& working_points) const
 {
     ResultMap output;
     output[""] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
-    for(const auto& wp : workingPoints_)
+    for(const auto& wp : working_points)
         output[wp.first] = std::make_unique<TauDiscriminator>(TauRefProd(taus));
 
     for(size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
         float x = 0;
-        for(size_t num_elem : num)
+        for(size_t num_elem : num_)
             x += pred.matrix<float>()(tau_index, num_elem);
-        if(x != 0 && den.size() > 0) {
+        if(x != 0 && den_.size() > 0) {
             float den_val = 0;
-            for(size_t den_elem : den)
+            for(size_t den_elem : den_)
                 den_val += pred.matrix<float>()(tau_index, den_elem);
             x = den_val != 0 ? x / den_val : std::numeric_limits<float>::max();
         }
         output[""]->setValue(tau_index, x);
-        for(const auto& wp : workingPoints_) {
+        for(const auto& wp : working_points) {
             const auto& tau = taus->at(tau_index);
             const bool pass = x > (*wp.second)(tau);
             output[wp.first]->setValue(tau_index, pass);
@@ -76,17 +76,17 @@ DeepTauBase::Output::ResultMap DeepTauBase::Output::get_value(const edm::Handle<
     return output;
 }
 
-DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputCollection, const DeepTauCache* Cache) :
+DeepTauBase::DeepTauBase(const edm::ParameterSet& cfg, const OutputCollection& outputCollection, const DeepTauCache* cache) :
     tausToken_(consumes<TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
     outputs_(outputCollection),
-    cache_(Cache)
+    cache_(cache)
 {
     for(const auto& output_desc : outputs_) {
         produces<TauDiscriminator>(output_desc.first);
         const auto& cut_pset = cfg.getParameter<edm::ParameterSet>(output_desc.first + "WP");
         for(const std::string& wp_name : cut_pset.getParameterNames()) {
-            const auto& cutStr = cut_pset.getParameter<std::string>(wp_name);
-            workingPoints_[output_desc.first][wp_name] = std::make_unique<Cutter>(cutStr);
+            const auto& cut_str = cut_pset.getParameter<std::string>(wp_name);
+            workingPoints_[output_desc.first][wp_name] = std::make_unique<Cutter>(cut_str);
             produces<TauDiscriminator>(output_desc.first + wp_name);
         }
     }
@@ -112,21 +112,21 @@ void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pre
 
 std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::ParameterSet& cfg )
 {
-    std::string graphName = edm::FileInPath(cfg.getParameter<std::string>("graph_file")).fullPath();
-    bool memMapped = cfg.getParameter<bool>("memMapped");
-    return std::make_unique<DeepTauCache>(graphName, memMapped);
+    std::string graph_name = edm::FileInPath(cfg.getParameter<std::string>("graph_file")).fullPath();
+    bool mem_mapped = cfg.getParameter<bool>("mem_mapped");
+    return std::make_unique<DeepTauCache>(graph_name, mem_mapped);
 }
 
-DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
+DeepTauCache::DeepTauCache(const std::string& graph_name, const bool& mem_mapped)
 {
     tensorflow::SessionOptions options;
     tensorflow::setThreading(options, 1, "no_threads");
 
-    if(memMapped) {
+    if(mem_mapped) {
         memmappedEnv_ = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
-        const tensorflow::Status mmap_status = memmappedEnv_.get()->InitializeFromFile(graphName);
+        const tensorflow::Status mmap_status = memmappedEnv_.get()->InitializeFromFile(graph_name);
         if(!mmap_status.ok())
-            throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ") << graphName << ". \n"
+            throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ") << graph_name << ". \n"
                                                                                                  << mmap_status.ToString();
 
         graph_ = std::make_unique<tensorflow::GraphDef>();
@@ -134,7 +134,7 @@ DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
                                                                      tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
                                                                      graph_.get());
         if(!load_graph_status.ok())
-            throw cms::Exception("DeepTauCache: unable to load graph_ from ") << graphName << ". \n"
+            throw cms::Exception("DeepTauCache: unable to load graph_ from ") << graph_name << ". \n"
                                                                              << mmap_status.ToString();
         options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(::tensorflow::OptimizerOptions::L0);
         options.env = memmappedEnv_.get();
@@ -142,7 +142,7 @@ DeepTauCache::DeepTauCache(const std::string& graphName, const bool& memMapped)
         session_ = tensorflow::createSession(graph_.get(), options);
 
     } else {
-        graph_.reset(tensorflow::loadGraphDef(graphName));
+        graph_.reset(tensorflow::loadGraphDef(graph_name));
         session_ = tensorflow::createSession(graph_.get(), options);
       }
 }

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -47,11 +47,8 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     updatedTauName = updatedTauName,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
                                "deepTau2017v1",
-                               # "DPFTau_2016_v0",
+                               "DPFTau_2016_v0",
                                # "DPFTau_2016_v1",
-                               # "deepTau2017v1Q",
-                               "DPFTau_2016_v0Q",
-                               # "DPFTau_2016_v1Q",
                                ])
 tauIdEmbedder.runTauID()
 

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -48,7 +48,7 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                                # "deepTau2017v1Q",
                                "DPFTau_2016_v0Q",
                                # "DPFTau_2016_v1Q",
-                               ]) 
+                               ])
 tauIdEmbedder.runTauID()
 
 # Output definition
@@ -88,6 +88,3 @@ process.options = cms.untracked.PSet(
      numberOfThreads = cms.untracked.uint32(nThreads),
      numberOfStreams = cms.untracked.uint32(0)
 )
-
-from Validation.Performance.IgProfInfo import customise
-process = customise(process)

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -9,7 +9,7 @@ import FWCore.ParameterSet.Config as cms
 updatedTauName = "slimmedTausNewID"
 minimalOutput = True
 eventsToProcess = 1000
-nThreads = 2
+nThreads = 1
 
 process = cms.Process('TauID')
 process.load('Configuration.StandardSequences.MagneticField_cff')
@@ -21,8 +21,13 @@ process.GlobalTag.globaltag = '101X_upgrade2018_realistic_v7'
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
+<<<<<<< HEAD
     # File from dataset DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
     '/store/mc/RunIISummer18MiniAOD/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/101X_upgrade2018_realistic_v7-v1/20000/0617A8FC-1CA0-E811-9992-FA163E4CB6BE.root'
+=======
+    # File from dataset /GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+     '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
+>>>>>>> ef7dc2ec57c... - Implemented on runTauIdMVA the option to work with new training files quantized
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )
@@ -34,8 +39,11 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
                                "deepTau2017v1",
                                "DPFTau_2016_v0",
-                               #"DPFTau_2016_v1"
-                               ])
+                               "DPFTau_2016_v1",
+                               "deepTau2017v1Q",
+                               #"DPFTau_2016_v0Q",
+                               #"DPFTau_2016_v1Q",
+                               ]) #DPF quantized files are not working for release 94X
 tauIdEmbedder.runTauID()
 
 # Output definition

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -8,7 +8,7 @@ import FWCore.ParameterSet.Config as cms
 # options.parseArguments()
 updatedTauName = "slimmedTausNewID"
 minimalOutput = True
-eventsToProcess = 1000
+eventsToProcess = 100
 nThreads = 1
 
 process = cms.Process('TauID')
@@ -26,8 +26,13 @@ process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
     '/store/mc/RunIISummer18MiniAOD/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/101X_upgrade2018_realistic_v7-v1/20000/0617A8FC-1CA0-E811-9992-FA163E4CB6BE.root'
 =======
     # File from dataset /GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+<<<<<<< HEAD
      '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
 >>>>>>> ef7dc2ec57c... - Implemented on runTauIdMVA the option to work with new training files quantized
+=======
+     # '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
+     '/store/mc/RunIIFall17MiniAODv2/TTToHadronic_mtop169p5_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/100000/64BE09E8-76A8-E811-8602-FA163EC538AA.root'
+>>>>>>> 1c07197f73b... - Implementation of global cache to avoid reloading graph for each thread and reduce the memory consuption
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )
@@ -37,13 +42,13 @@ import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
 tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     updatedTauName = updatedTauName,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
-                               "deepTau2017v1",
-                               "DPFTau_2016_v0",
-                               "DPFTau_2016_v1",
-                               "deepTau2017v1Q",
-                               #"DPFTau_2016_v0Q",
-                               #"DPFTau_2016_v1Q",
-                               ]) #DPF quantized files are not working for release 94X
+                               # "deepTau2017v1",
+                               # "DPFTau_2016_v0",
+                               # "DPFTau_2016_v1",
+                               # "deepTau2017v1Q",
+                               "DPFTau_2016_v0Q",
+                               # "DPFTau_2016_v1Q",
+                               ]) 
 tauIdEmbedder.runTauID()
 
 # Output definition
@@ -83,3 +88,6 @@ process.options = cms.untracked.PSet(
      numberOfThreads = cms.untracked.uint32(nThreads),
      numberOfStreams = cms.untracked.uint32(0)
 )
+
+from Validation.Performance.IgProfInfo import customise
+process = customise(process)

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -45,7 +45,7 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                                # "deepTau2017v1",
                                # "DPFTau_2016_v0",
                                # "DPFTau_2016_v1",
-                               # "deepTau2017v1Q",
+                               "deepTau2017v1Q",
                                "DPFTau_2016_v0Q",
                                # "DPFTau_2016_v1Q",
                                ])
@@ -88,3 +88,6 @@ process.options = cms.untracked.PSet(
      numberOfThreads = cms.untracked.uint32(nThreads),
      numberOfStreams = cms.untracked.uint32(0)
 )
+
+from Validation.Performance.IgProfInfo import customise
+process = customise(process)

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -8,8 +8,8 @@ import FWCore.ParameterSet.Config as cms
 # options.parseArguments()
 updatedTauName = "slimmedTausNewID"
 minimalOutput = True
-eventsToProcess = 100
-nThreads = 1
+eventsToProcess = 1000
+nThreads = 2
 
 process = cms.Process('TauID')
 process.load('Configuration.StandardSequences.MagneticField_cff')
@@ -17,26 +17,12 @@ process.load('Configuration.Geometry.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.GlobalTag.globaltag = '101X_upgrade2018_realistic_v7'
+process.GlobalTag.globaltag = '103X_upgrade2018_realistic_v8'
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
-<<<<<<< HEAD
     # File from dataset DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
-    '/store/mc/RunIISummer18MiniAOD/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/101X_upgrade2018_realistic_v7-v1/20000/0617A8FC-1CA0-E811-9992-FA163E4CB6BE.root'
-=======
-    # File from dataset /GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
-<<<<<<< HEAD
-<<<<<<< HEAD
-     '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
->>>>>>> ef7dc2ec57c... - Implemented on runTauIdMVA the option to work with new training files quantized
-=======
-     # '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
-     '/store/mc/RunIIFall17MiniAODv2/TTToHadronic_mtop169p5_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/100000/64BE09E8-76A8-E811-8602-FA163EC538AA.root'
->>>>>>> 1c07197f73b... - Implementation of global cache to avoid reloading graph for each thread and reduce the memory consuption
-=======
-    '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
->>>>>>> 1968c81d039... -Overall, changes to improve memory usage, among these are:
+    '/store/mc/RunIIFall17MiniAODv2/TTToHadronic_mtop169p5_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/100000/64BE09E8-76A8-E811-8602-FA163EC538AA.root'
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )
@@ -48,7 +34,7 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
                                "deepTau2017v1",
                                "DPFTau_2016_v0",
-                               # "DPFTau_2016_v1",
+                               # "DPFTau_2016_v1"
                                ])
 tauIdEmbedder.runTauID()
 

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -27,12 +27,16 @@ process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
 =======
     # File from dataset /GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
 <<<<<<< HEAD
+<<<<<<< HEAD
      '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
 >>>>>>> ef7dc2ec57c... - Implemented on runTauIdMVA the option to work with new training files quantized
 =======
      # '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
      '/store/mc/RunIIFall17MiniAODv2/TTToHadronic_mtop169p5_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/100000/64BE09E8-76A8-E811-8602-FA163EC538AA.root'
 >>>>>>> 1c07197f73b... - Implementation of global cache to avoid reloading graph for each thread and reduce the memory consuption
+=======
+    '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
+>>>>>>> 1968c81d039... -Overall, changes to improve memory usage, among these are:
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )
@@ -88,6 +92,3 @@ process.options = cms.untracked.PSet(
      numberOfThreads = cms.untracked.uint32(nThreads),
      numberOfStreams = cms.untracked.uint32(0)
 )
-
-from Validation.Performance.IgProfInfo import customise
-process = customise(process)

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -46,10 +46,10 @@ import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
 tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     updatedTauName = updatedTauName,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
-                               # "deepTau2017v1",
+                               "deepTau2017v1",
                                # "DPFTau_2016_v0",
                                # "DPFTau_2016_v1",
-                               "deepTau2017v1Q",
+                               # "deepTau2017v1Q",
                                "DPFTau_2016_v0Q",
                                # "DPFTau_2016_v1Q",
                                ])


### PR DESCRIPTION
Changes regarding forward-porting DNN-related developments from the PRs #105 and #106 from 94X to 104X

Memory tests were performed and they're attached here. The results are consistent with the ones obtained with the 94X release ( #105) .

[memory_usage_.pdf](https://github.com/cms-tau-pog/cmssw/files/2592376/memory_usage_.pdf)
