### PR TITLE
Updating DNN-based Tau-Id discriminants branch 102X

### DIFF
--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -632,7 +632,6 @@ private:
     edm::EDGetTokenT<ElectronCollection> electrons_token;
     edm::EDGetTokenT<MuonCollection> muons_token;
     std::string input_layer, output_layer;
-    TauIdMVAAuxiliaries clusterVariables;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -49,19 +49,27 @@ class TauIDEmbedder(object):
     @staticmethod
     def get_cmssw_version(debug = False):
         """returns 'CMSSW_X_Y_Z'"""
-        if debug: print "get_cmssw_version:", os.environ["CMSSW_RELEASE_BASE"].split('/')[-1]
-        return os.environ["CMSSW_RELEASE_BASE"].split('/')[-1]
+        cmssw_version = os.environ["CMSSW_VERSION"]
+        if debug: print "get_cmssw_version:", cmssw_version
+        return cmssw_version
 
     @classmethod
     def get_cmssw_version_number(klass, debug = False):
-        """returns 'X_Y_Z' (without 'CMSSW_')"""
-        if debug: print "get_cmssw_version_number:", map(int, klass.get_cmssw_version().split("CMSSW_")[1].split("_")[0:3])
-        return map(int, klass.get_cmssw_version().split("CMSSW_")[1].split("_")[0:3])
+        """returns '(release, subversion, patch)' (without 'CMSSW_')"""
+        v = klass.get_cmssw_version().split("CMSSW_")[1].split("_")[0:3]
+        if debug: print "get_cmssw_version_number:", v
+        if v[2] == "X":
+            patch = -1
+        else:
+            patch = int(v[2])
+        return int(v[0]), int(v[1]), patch
 
     @staticmethod
     def versionToInt(release=9, subversion=4, patch=0, debug = False):
-        if debug: print "versionToInt:", release * 10000 + subversion * 100 + patch
-        return release * 10000 + subversion * 100 + patch
+        version = release * 10000 + subversion * 100 + patch + 1 # shifted by one to account for pre-releases.
+        if debug: print "versionToInt:", version
+        return version
+
 
     @classmethod
     def is_above_cmssw_version(klass, release=9, subversion=4, patch=0, debug = False):

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -17,7 +17,7 @@ process.load('Configuration.Geometry.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.GlobalTag.globaltag = '102X_mc2017_realistic_v4'
+process.GlobalTag.globaltag = '102X_upgrade2018_realistic_v12'
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -17,12 +17,13 @@ process.load('Configuration.Geometry.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.GlobalTag.globaltag = '94X_mc2017_realistic_v14'
+process.GlobalTag.globaltag = '102X_mc2017_realistic_v4'
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
     # File from dataset /GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
-    '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
+    '/store/mc/RunIIFall18MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v12-v1/100000/4A357FA9-ACD1-A546-956F-C0017C2CCD6D.root'
+    # '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -21,9 +21,8 @@ process.GlobalTag.globaltag = '102X_mc2017_realistic_v4'
 
 # Input source
 process.source = cms.Source('PoolSource', fileNames = cms.untracked.vstring(
-    # File from dataset /GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM
+    # File from dataset /TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v12-v1/
     '/store/mc/RunIIFall18MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v12-v1/100000/4A357FA9-ACD1-A546-956F-C0017C2CCD6D.root'
-    # '/store/mc/RunIIFall17MiniAODv2/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/0498CD6A-CC42-E811-95D3-008CFA1CB8A8.root'
 ))
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(eventsToProcess) )


### PR DESCRIPTION
- RecoTauTag/RecoTau/plugins/DeepTauId.cc: Remove  'clusterVariables' as a  class member
- RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py: Update global tag and sample
- RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py:  Added changes made in the commit 194a1d5 from the PR cms-sw#25016