### PR TITLE
back-porting DeepTauId v2 last commits from branch cms-tau-pog:CMSSW_10_6_X_tau-pog_DeepTau2017v2

### DIFF
--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -42,18 +42,18 @@ class DeepTauCache {
 public:
     using GraphPtr = std::shared_ptr<tensorflow::GraphDef>;
 
-    DeepTauCache(const std::string& graph_name, bool mem_mapped);
+    DeepTauCache(const std::map<std::string, std::string>& graph_names, bool mem_mapped);
     ~DeepTauCache();
 
    // A Session allows concurrent calls to Run(), though a Session must
    // be created / extended by a single thread.
-   tensorflow::Session& getSession() const { return *session_; }
-   const tensorflow::GraphDef& getGraph() const { return *graph_; }
+   tensorflow::Session& getSession(const std::string& name = "") const { return *sessions_.at(name); }
+   const tensorflow::GraphDef& getGraph(const std::string& name = "") const { return *graphs_.at(name); }
 
 private:
-    GraphPtr graph_;
-    tensorflow::Session* session_;
-    std::unique_ptr<tensorflow::MemmappedEnv> memmappedEnv_;
+    std::map<std::string, GraphPtr> graphs_;
+    std::map<std::string, tensorflow::Session*> sessions_;
+    std::map<std::string, std::unique_ptr<tensorflow::MemmappedEnv>> memmappedEnv_;
 };
 
 class DeepTauBase : public edm::stream::EDProducer<edm::GlobalCache<DeepTauCache>> {

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1684,6 +1684,7 @@ private:
     std::shared_ptr<tensorflow::Tensor> tauBlockTensor_;
     std::array<std::shared_ptr<tensorflow::Tensor>, 2> eGammaTensor_, muonTensor_, hadronsTensor_,
                                                        convTensor_, zeroOutputTensor_;
+    TauIdMVAAuxiliaries clusterVariables;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -634,7 +634,7 @@ class TauIDEmbedder(object):
                     "VVTight": 0.9859
                 }
             }
-            file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb'
+            file_names = ['RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v1_20L1024N_quantized.pb']
             self.process.deepTau2017v1 = self.cms.EDProducer("DeepTauId",
                 electrons              = self.cms.InputTag('slimmedElectrons'),
                 muons                  = self.cms.InputTag('slimmedMuons'),
@@ -642,9 +642,9 @@ class TauIDEmbedder(object):
                 pfcands                = self.cms.InputTag('packedPFCandidates'),
                 vertices               = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 rho                    = self.cms.InputTag('fixedGridRhoAll'),
-                graph_file             = self.cms.string(file_name),
+                graph_file             = self.cms.vstring(file_names),
                 mem_mapped             = self.cms.bool(False),
-                version                = self.cms.uint32(self.getDeepTauVersion(file_name)[1])
+                version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1])
             )
 
             self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
@@ -683,7 +683,12 @@ class TauIDEmbedder(object):
                     "VVTight": 0.9733927,
                 },
             }
-            file_name = 'RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6.pb'
+            #file_names = ['RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6.pb']
+            file_names = [
+                'core:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_core.pb',
+                'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
+                'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
+            ]
             self.process.deepTau2017v2 = self.cms.EDProducer("DeepTauId",
                 electrons              = self.cms.InputTag('slimmedElectrons'),
                 muons                  = self.cms.InputTag('slimmedMuons'),
@@ -691,9 +696,9 @@ class TauIDEmbedder(object):
                 pfcands                = self.cms.InputTag('packedPFCandidates'),
                 vertices               = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
                 rho                    = self.cms.InputTag('fixedGridRhoAll'),
-                graph_file             = self.cms.string(file_name),
+                graph_file             = self.cms.vstring(file_names),
                 mem_mapped             = self.cms.bool(True),
-                version                = self.cms.uint32(self.getDeepTauVersion(file_name)[1]),
+                version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
                 debug_level            = self.cms.int32(0)
 
             )
@@ -720,13 +725,13 @@ class TauIDEmbedder(object):
                     #            (decayMode == 10) * (0.873958 - 0.0002328 * pt) "
                 }
             }
-            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb'
+            file_names = [ 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v0_quantized.pb' ]
             self.process.dpfTau2016v0 = self.cms.EDProducer("DPFIsolation",
                 pfcands     = self.cms.InputTag('packedPFCandidates'),
                 taus        = self.cms.InputTag('slimmedTaus'),
                 vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                graph_file  = self.cms.string(file_name),
-                version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
+                graph_file  = self.cms.vstring(file_names),
+                version     = self.cms.uint32(self.getDpfTauVersion(file_names[0])),
                 mem_mapped  = self.cms.bool(False)
             )
 
@@ -745,13 +750,13 @@ class TauIDEmbedder(object):
                 "all": {"Tight" : 0.123} #FIXME: define WP
             }
 
-            file_name = 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb'
+            file_names = [ 'RecoTauTag/TrainingFiles/data/DPFTauId/DPFIsolation_2017v1_quantized.pb' ]
             self.process.dpfTau2016v1 = self.cms.EDProducer("DPFIsolation",
                 pfcands     = self.cms.InputTag('packedPFCandidates'),
                 taus        = self.cms.InputTag('slimmedTaus'),
                 vertices    = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
-                graph_file  = self.cms.string(file_name),
-                version     = self.cms.uint32(self.getDpfTauVersion(file_name)),
+                graph_file  = self.cms.vstring(file_names),
+                version     = self.cms.uint32(self.getDpfTauVersion(file_names[0])),
                 mem_mapped  = self.cms.bool(False)
             )
 

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -115,44 +115,66 @@ void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pre
 
 std::unique_ptr<DeepTauCache> DeepTauBase::initializeGlobalCache(const edm::ParameterSet& cfg )
 {
-    std::string graph_name = edm::FileInPath(cfg.getParameter<std::string>("graph_file")).fullPath();
+    const auto graph_name_vector = cfg.getParameter<std::vector<std::string>>("graph_file");
+    std::map<std::string, std::string> graph_names;
+    for(const auto& entry : graph_name_vector) {
+        const size_t sep_pos = entry.find(':');
+        std::string entry_name, graph_file;
+        if(sep_pos != std::string::npos) {
+            entry_name = entry.substr(0, sep_pos);
+            graph_file = entry.substr(sep_pos + 1);
+        } else {
+            entry_name = "";
+            graph_file = entry;
+        }
+        graph_file = edm::FileInPath(graph_file).fullPath();
+        if(graph_names.count(entry_name))
+            throw cms::Exception("DeepTauCache") << "Duplicated graph entries";
+        graph_names[entry_name] = graph_file;
+    }
     bool mem_mapped = cfg.getParameter<bool>("mem_mapped");
-    return std::make_unique<DeepTauCache>(graph_name, mem_mapped);
+    return std::make_unique<DeepTauCache>(graph_names, mem_mapped);
 }
 
-DeepTauCache::DeepTauCache(const std::string& graph_name, bool mem_mapped)
+DeepTauCache::DeepTauCache(const std::map<std::string, std::string>& graph_names, bool mem_mapped)
 {
-    tensorflow::SessionOptions options;
-    tensorflow::setThreading(options, 1, "no_threads");
+    for(const auto& graph_entry : graph_names) {
+        tensorflow::SessionOptions options;
+        tensorflow::setThreading(options, 1, "no_threads");
 
-    if(mem_mapped) {
-        memmappedEnv_ = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
-        const tensorflow::Status mmap_status = memmappedEnv_.get()->InitializeFromFile(graph_name);
-        if(!mmap_status.ok())
-            throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ") << graph_name << ". \n"
-                                                                                                 << mmap_status.ToString();
+        const std::string& entry_name = graph_entry.first;
+        const std::string& graph_file = graph_entry.second;
+        if(mem_mapped) {
+            memmappedEnv_[entry_name] = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
+            const tensorflow::Status mmap_status = memmappedEnv_.at(entry_name)->InitializeFromFile(graph_file);
+            if(!mmap_status.ok()) {
+                throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ")
+                    << graph_file << ". \n" << mmap_status.ToString();
+            }
 
-        graph_ = std::make_unique<tensorflow::GraphDef>();
-        const tensorflow::Status load_graph_status = ReadBinaryProto(memmappedEnv_.get(),
-                                                                     tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
-                                                                     graph_.get());
-        if(!load_graph_status.ok())
-            throw cms::Exception("DeepTauCache: unable to load graph_ from ") << graph_name << ". \n"
-                                                                             << mmap_status.ToString();
-        options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(::tensorflow::OptimizerOptions::L0);
-        options.env = memmappedEnv_.get();
+            graphs_[entry_name] = std::make_unique<tensorflow::GraphDef>();
+            const tensorflow::Status load_graph_status = ReadBinaryProto(memmappedEnv_.at(entry_name).get(),
+                                                                         tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
+                                                                         graphs_.at(entry_name).get());
+            if(!load_graph_status.ok())
+                throw cms::Exception("DeepTauCache: unable to load graph from ") << graph_file << ". \n"
+                                                                                  << mmap_status.ToString();
+            options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(::tensorflow::OptimizerOptions::L0);
+            options.env = memmappedEnv_.at(entry_name).get();
 
-        session_ = tensorflow::createSession(graph_.get(), options);
+            sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
 
-    } else {
-        graph_.reset(tensorflow::loadGraphDef(graph_name));
-        session_ = tensorflow::createSession(graph_.get(), options);
-      }
+        } else {
+            graphs_[entry_name].reset(tensorflow::loadGraphDef(graph_file));
+            sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
+        }
+    }
 }
 
 DeepTauCache::~DeepTauCache()
 {
-    tensorflow::closeSession(session_);
+    for(auto& session_entry : sessions_)
+        tensorflow::closeSession(session_entry.second);
 }
 
 } // namespace deep_tau


### PR DESCRIPTION
Changes regarding back-porting DeepTauId v2 lasts commits of PR #126 from 106X to 102X

Studies of the measure memory consumption and cpu timing have been preformed. 

The updated total memory consumption, calculated with 1000 events with a tthad sample is 21.33 MiB, this is calculated as the sum of the three bigger contributions:

1. DeepTauId::getPredictions =  15.68 MiB that comes from pat::PackedCandidate::dzError(13.94 MiB) 
2. deep_tau::DeepTauBase::initializeGlobalCache = 3.96 MiB
3. DeepTauId::DeepTauId = 1.69 MiB
The file with all the information can be access at this link:  
http://mdidomen.web.cern.ch/mdidomen/cgi-bin/igprof-navigator/changes_PR_126/DeepTau_memory_usage/

The total cpu rates for each of the tested samples are (tested for 1000 events):

-TT :  0.13 s/evt. DeepTauId::getPredictions takes 0.095 s/evt
(http://mdidomen.web.cern.ch/mdidomen/cgi-bin/igprof-navigator/102X/DeepTauCPU_tt/)

-H-tautau:  0.058 s/evt. DeepTauId::getPredictions takes 0.028 s/evt
(http://mdidomen.web.cern.ch/mdidomen/cgi-bin/igprof-navigator/102X/DeepTauCPU_htautau/)

-ttH: 0.17 s/evt. DeepTauId::getPredictions takes 0.13 s/evt
(http://mdidomen.web.cern.ch/mdidomen/cgi-bin/igprof-navigator/changes_PR_126/DeepTauCPU_ttH)
