### PR TITLE
- restructured code of againstElectronDeadECAL discriminator to run o…

### DIFF
--- a/RecoTauTag/RecoTau/BuildFile.xml
+++ b/RecoTauTag/RecoTau/BuildFile.xml
@@ -1,12 +1,16 @@
 <use   name="MagneticField/Engine"/>
 <use   name="MagneticField/Records"/>
 <use   name="CondFormats/EgammaObjects"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="CondFormats/EcalObjects"/>
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/TauReco"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="DataFormats/PatCandidates"/>
 <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/DetId"/>
+<use   name="DataFormats/EcalDetId"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h
@@ -1,0 +1,74 @@
+#ifndef RecoTauTag_RecoTau_AntiElectronDeadECAL_h
+#define RecoTauTag_RecoTau_AntiElectronDeadECAL_h
+
+/** \class AntiElectronDeadECAL
+ *
+ * Flag tau candidates reconstructed near dead ECAL channels,
+ * in order to reduce e -> tau fakes not rejected by anti-e MVA discriminator
+ *
+ * The motivation for this flag is this presentation:
+ *   https://indico.cern.ch/getFile.py/access?contribId=0&resId=0&materialId=slides&confId=177223
+ *
+ * Code adapted from:
+ *   RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronDeadECAL.cc
+ *
+ * \authors Lauri Andreas Wendland,
+ *          Christian Veelken
+ *
+ *
+ *
+ */
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "RecoTauTag/RecoTau/interface/PositionAtECalEntrance.h"
+
+#include <vector>
+#include <string>
+
+class AntiElectronDeadECAL
+{
+ public:
+  explicit AntiElectronDeadECAL(const edm::ParameterSet&);
+  ~AntiElectronDeadECAL();
+
+  void beginEvent(const edm::EventSetup&);
+
+  bool operator()(const reco::Candidate* leadPFChargedHadron) const;
+
+ private:
+  unsigned minStatus_;
+  double dR_;
+
+  PositionAtECalEntrance positionAtECalEntrance_;
+
+  void updateBadTowers(const edm::EventSetup&);
+  
+  struct towerInfo 
+  {
+    towerInfo(uint32_t id, unsigned nBad, unsigned maxStatus, double eta, double phi)
+      : id_(id), 
+	nBad_(nBad), 
+	maxStatus_(maxStatus), 
+	eta_(eta), 
+	phi_(phi) 
+    {}
+    uint32_t id_;
+    unsigned nBad_;
+    unsigned maxStatus_;
+    double eta_;
+    double phi_;
+  };
+  typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<double> > PolarLorentzVector;
+
+  std::vector<towerInfo> badTowers_;
+  static const uint16_t statusMask_ = 0x1F;
+
+  uint32_t channelStatusId_cache_;
+  uint32_t caloGeometryId_cache_;
+  uint32_t idealGeometryId_cache_;
+  bool isFirstEvent_;
+};
+
+#endif // RecoTauTag_RecoTau_AntiElectronDeadECAL_h

--- a/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
+++ b/RecoTauTag/RecoTau/interface/AntiElectronIDMVA6.h
@@ -22,9 +22,8 @@
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
-
-#include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "RecoTauTag/RecoTau/interface/PositionAtECalEntrance.h"
 
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
@@ -125,7 +124,7 @@ public:
   double MVAValue(const pat::Tau& theTau, const pat::Electron& theEle);
   // this function can be called for category 1 only !!
   double MVAValue(const pat::Tau& theTau);
-  // track extrapolation to ECAL entrance (used to re-calculate varibales that might not be available on miniAOD)
+  // track extrapolation to ECAL entrance (used to re-calculate variables that might not be available on miniAOD)
   bool atECalEntrance(const reco::Candidate* part, math::XYZPoint& pos);
 
 private:
@@ -168,7 +167,8 @@ private:
 
   std::vector<TFile*> inputFilesToDelete_;
 
-  double bField_;
+  PositionAtECalEntrance positionAtECalEntrance_;
+
   int verbosity_;
 };
 

--- a/RecoTauTag/RecoTau/interface/PositionAtECalEntrance.h
+++ b/RecoTauTag/RecoTau/interface/PositionAtECalEntrance.h
@@ -1,0 +1,33 @@
+#ifndef RecoTauTag_RecoTau_PositionAtECalEntrance_h
+#define RecoTauTag_RecoTau_PositionAtECalEntrance_h
+
+/** \class PositionAtECalEntrance
+ *
+ * Extrapolate particle (charged or neutral) to ECAL entrance,
+ * in order to compute the distance of the tau to ECAL cracks and/or dead ECAL channels
+ *
+ * \authors Fabio Colombo,
+ *          Christian Veelken
+ *
+ *
+ *
+ */
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+class PositionAtECalEntrance 
+{
+ public:
+  PositionAtECalEntrance();
+  ~PositionAtECalEntrance();
+
+  void beginEvent(const edm::EventSetup&);
+
+  reco::Candidate::Point operator()(const reco::Candidate* particle, bool& success) const;
+
+ private:
+  double bField_z_;
+};
+
+#endif // RecoTauTag_RecoTau_PositionAtECalEntrance_h

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronDeadECAL.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationAgainstElectronDeadECAL.cc
@@ -1,9 +1,12 @@
 
-/** \class PFRecoTauDiscriminationAgainstElectronDeadECAL
+/** \class PATTauDiscriminationAgainstElectronDeadECAL
  *
  * Flag tau candidates reconstructed near dead ECAL channels,
  * in order to reduce e -> tau fakes not rejected by anti-e MVA discriminator
  *
+ * Adopted from RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstElectronDeadECAL.cc
+ * to enable computation of the discriminator on MiniAOD
+ * 
  * The motivation for this flag is this presentation:
  *   https://indico.cern.ch/getFile.py/access?contribId=0&resId=0&materialId=slides&confId=177223
  *
@@ -23,15 +26,15 @@
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
 #include "RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h"
 
-class PFRecoTauDiscriminationAgainstElectronDeadECAL : public PFTauDiscriminationProducerBase 
+class PATTauDiscriminationAgainstElectronDeadECAL : public PATTauDiscriminationProducerBase
 {
  public:
-  explicit PFRecoTauDiscriminationAgainstElectronDeadECAL(const edm::ParameterSet& cfg)
-      : PFTauDiscriminationProducerBase(cfg),
+  explicit PATTauDiscriminationAgainstElectronDeadECAL(const edm::ParameterSet& cfg)
+      : PATTauDiscriminationProducerBase(cfg),
         moduleLabel_(cfg.getParameter<std::string>("@module_label")),
         antiElectronDeadECAL_(cfg) 
   {}
-  ~PFRecoTauDiscriminationAgainstElectronDeadECAL() override 
+  ~PATTauDiscriminationAgainstElectronDeadECAL() override 
   {}
 
   void beginEvent(const edm::Event& evt, const edm::EventSetup& es) override 
@@ -39,7 +42,7 @@ class PFRecoTauDiscriminationAgainstElectronDeadECAL : public PFTauDiscriminatio
     antiElectronDeadECAL_.beginEvent(es); 
   }
 
-  double discriminate(const reco::PFTauRef& tau) const override 
+  double discriminate(const TauRef& tau) const override 
   {
     double discriminator = 1.;
     if ( tau->leadChargedHadrCand().isNonnull() ) {
@@ -58,18 +61,18 @@ class PFRecoTauDiscriminationAgainstElectronDeadECAL : public PFTauDiscriminatio
   AntiElectronDeadECAL antiElectronDeadECAL_;
 };
 
-void PFRecoTauDiscriminationAgainstElectronDeadECAL::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
+void PATTauDiscriminationAgainstElectronDeadECAL::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 {
-  // pfRecoTauDiscriminationAgainstElectronDeadECAL
+  // patTauDiscriminationAgainstElectronDeadECAL
   edm::ParameterSetDescription desc;
-
+  
   desc.add<double>("dR", 0.08);
   desc.add<unsigned int>("minStatus", 12);
   desc.add<int>("verbosity", 0);
 
   fillProducerDescriptions(desc); // inherited from the base-class
 
-  descriptions.add("pfRecoTauDiscriminationAgainstElectronDeadECAL", desc);
+  descriptions.add("patTauDiscriminationAgainstElectronDeadECAL", desc);
 }
 
-DEFINE_FWK_MODULE(PFRecoTauDiscriminationAgainstElectronDeadECAL);
+DEFINE_FWK_MODULE(PATTauDiscriminationAgainstElectronDeadECAL);

--- a/RecoTauTag/RecoTau/python/PATTauDiscriminationAgainstElectronDeadECAL_cfi.py
+++ b/RecoTauTag/RecoTau/python/PATTauDiscriminationAgainstElectronDeadECAL_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+
+patTauDiscriminationAgainstElectronDeadECAL = cms.EDProducer("PATTauDiscriminationAgainstElectronDeadECAL",
+    # tau collection to discriminate
+    PATTauProducer = cms.InputTag('slimmedTaus'),
+
+    # require no specific prediscriminants when running on MiniAOD,
+    # assuming that loose tau decay mode (and hence leading track) selection is already applied during MiniAOD production
+    Prediscriminants = noPrediscriminants,
+
+    # status flag indicating dead/masked ECAL crystals
+    minStatus = cms.uint32(12),
+
+    # region around dead/masked ECAL crystals that is to be cut                                                               
+    dR = cms.double(0.08),
+    verbosity = cms.int32(0)
+)

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstElectronDeadECAL_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstElectronDeadECAL_cfi.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+
 from RecoTauTag.RecoTau.TauDiscriminatorTools import requireLeadTrack
 
-pfRecoTauDiscriminationAgainstElectronDeadECAL = cms.EDProducer(
-    "PFRecoTauDiscriminationAgainstElectronDeadECAL",
-
+pfRecoTauDiscriminationAgainstElectronDeadECAL = cms.EDProducer("PFRecoTauDiscriminationAgainstElectronDeadECAL",
     # tau collection to discriminate
     PFTauProducer = cms.InputTag('pfTauProducer'),
 

--- a/RecoTauTag/RecoTau/src/AntiElectronDeadECAL.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronDeadECAL.cc
@@ -1,0 +1,119 @@
+#include "RecoTauTag/RecoTau/interface/AntiElectronDeadECAL.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <TMath.h>
+
+AntiElectronDeadECAL::AntiElectronDeadECAL(const edm::ParameterSet& cfg)
+  : isFirstEvent_(true)
+{
+  minStatus_ = cfg.getParameter<uint32_t>("minStatus");
+  dR_ = cfg.getParameter<double>("dR");
+}
+
+AntiElectronDeadECAL::~AntiElectronDeadECAL()
+{}
+
+void AntiElectronDeadECAL::beginEvent(const edm::EventSetup& es)
+{
+  updateBadTowers(es);
+  positionAtECalEntrance_.beginEvent(es);
+}
+
+namespace
+{
+  template <class Id>
+  void loopXtals(std::map<uint32_t, unsigned>& nBadCrystals,
+		 std::map<uint32_t, unsigned>& maxStatus,
+		 std::map<uint32_t, double>& sumEta,
+		 std::map<uint32_t, double>& sumPhi ,
+		 const EcalChannelStatus* channelStatus,
+		 const CaloGeometry* caloGeometry,
+		 const EcalTrigTowerConstituentsMap* ttMap,
+                 unsigned minStatus,
+                 const uint16_t statusMask)
+  {
+    // NOTE: modified version of SUSY CAF code
+    //         UserCode/SusyCAF/plugins/SusyCAF_EcalDeadChannels.cc
+    for ( int i = 0; i < Id::kSizeForDenseIndexing; ++i ) {
+      Id id = Id::unhashIndex(i);  
+      if ( id == Id(0) ) continue;
+      EcalChannelStatusMap::const_iterator it = channelStatus->getMap().find(id.rawId());
+      unsigned status = ( it == channelStatus->end() ) ? 
+	0 : (it->getStatusCode() & statusMask);
+      if ( status >= minStatus ) {
+	const GlobalPoint& point = caloGeometry->getPosition(id);
+	uint32_t key = ttMap->towerOf(id);
+	maxStatus[key] = TMath::Max(status, maxStatus[key]);
+	++nBadCrystals[key];
+	sumEta[key] += point.eta();
+	sumPhi[key] += point.phi();
+      }
+    }
+  }
+}
+
+void AntiElectronDeadECAL::updateBadTowers(const edm::EventSetup& es) 
+{
+  // NOTE: modified version of SUSY CAF code
+  //         UserCode/SusyCAF/plugins/SusyCAF_EcalDeadChannels.cc
+  const uint32_t channelStatusId = es.get<EcalChannelStatusRcd>().cacheIdentifier();
+  const uint32_t caloGeometryId  = es.get<CaloGeometryRecord>().cacheIdentifier();
+  const uint32_t idealGeometryId = es.get<IdealGeometryRecord>().cacheIdentifier();
+
+  if ( !isFirstEvent_ && channelStatusId == channelStatusId_cache_ && caloGeometryId == caloGeometryId_cache_ && idealGeometryId == idealGeometryId_cache_  ) return;
+
+  edm::ESHandle<EcalChannelStatus> channelStatus;    
+  es.get<EcalChannelStatusRcd>().get(channelStatus);
+  channelStatusId_cache_ = channelStatusId;  
+
+  edm::ESHandle<CaloGeometry> caloGeometry;         
+  es.get<CaloGeometryRecord>().get(caloGeometry);
+  caloGeometryId_cache_ = caloGeometryId;  
+
+  edm::ESHandle<EcalTrigTowerConstituentsMap> ttMap;
+  es.get<IdealGeometryRecord>().get(ttMap);
+  idealGeometryId_cache_ = idealGeometryId;
+
+  std::map<uint32_t,unsigned> nBadCrystals, maxStatus;
+  std::map<uint32_t,double> sumEta, sumPhi;
+    
+  loopXtals<EBDetId>(nBadCrystals, maxStatus, sumEta, sumPhi, channelStatus.product(), caloGeometry.product(), ttMap.product(), minStatus_, statusMask_);
+  loopXtals<EEDetId>(nBadCrystals, maxStatus, sumEta, sumPhi, channelStatus.product(), caloGeometry.product(), ttMap.product(), minStatus_, statusMask_);
+    
+  badTowers_.clear();
+  for ( std::map<uint32_t, unsigned>::const_iterator it = nBadCrystals.begin(); 
+	it != nBadCrystals.end(); ++it ) {
+    uint32_t key = it->first;
+    badTowers_.push_back(towerInfo(key, it->second, maxStatus[key], sumEta[key]/it->second, sumPhi[key]/it->second));
+  }
+
+  isFirstEvent_ = false;
+}
+
+
+bool AntiElectronDeadECAL::operator()(const reco::Candidate* leadPFChargedHadron) const
+{
+  bool isNearBadTower = false;
+  bool success = false;
+  reco::Candidate::Point positionAtECalEntrance = positionAtECalEntrance_(leadPFChargedHadron, success);
+  if ( success ) {
+    for ( std::vector<towerInfo>::const_iterator badTower = badTowers_.begin();
+	  badTower != badTowers_.end(); ++badTower ) {
+      if ( deltaR(badTower->eta_, badTower->phi_, positionAtECalEntrance.eta(), positionAtECalEntrance.phi()) < dR_ ) {
+        isNearBadTower = true;
+      }
+    }
+  }
+  return isNearBadTower;
+}

--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -11,9 +11,6 @@
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
 #include <TMath.h>
 #include <TFile.h>
 #include <array>
@@ -57,7 +54,6 @@ AntiElectronIDMVA6::AntiElectronIDMVA6(const edm::ParameterSet& cfg)
   Var_woGwGSF_Endcap_ = new Float_t[23];
   Var_wGwGSF_Endcap_ = new Float_t[31];
 
-  bField_ = 0;
   verbosity_ = 0;
 }
 
@@ -134,10 +130,7 @@ void AntiElectronIDMVA6::beginEvent(const edm::Event& evt, const edm::EventSetup
     }
     isInitialized_ = true;
   }
-
-  edm::ESHandle<MagneticField> pSetup;
-  es.get<IdealMagneticFieldRecord>().get(pSetup);
-  bField_ = pSetup->inTesla(GlobalPoint(0, 0, 0)).z();
+  positionAtECalEntrance_.beginEvent(es);
 }
 
 double AntiElectronIDMVA6::MVAValue(Float_t TauPt,
@@ -624,9 +617,11 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau, const reco::Gsf
     for (const auto& signalPFCand : signalPFCands) {
       reco::Candidate const* signalCand = signalPFCand.get();
       float phi = thePFTau.phi();
-      math::XYZPoint aPos;
-      if (atECalEntrance(signalCand, aPos))
+      bool success = false;
+      reco::Candidate::Point aPos = positionAtECalEntrance_(signalCand, success);
+      if ( success ) {
         phi = aPos.Phi();
+      }
       sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
@@ -839,9 +834,11 @@ double AntiElectronIDMVA6::MVAValue(const reco::PFTau& thePFTau) {
     for (const auto& signalPFCand : signalPFCands) {
       reco::Candidate const* signalCand = signalPFCand.get();
       float phi = thePFTau.phi();
-      math::XYZPoint aPos;
-      if (atECalEntrance(signalCand, aPos) == true)
+      bool success = false;
+      reco::Candidate::Point aPos = positionAtECalEntrance_(signalCand, success);
+      if ( success ) {
         phi = aPos.Phi();
+      }
       sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
@@ -981,9 +978,11 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau, const pat::Electron&
     for (const auto& signalCandPtr : signalCands) {
       reco::Candidate const* signalCand = signalCandPtr.get();
       float phi = theTau.phi();
-      math::XYZPoint aPos;
-      if (atECalEntrance(signalCand, aPos) == true)
+      bool success = false;
+      reco::Candidate::Point aPos = positionAtECalEntrance_(signalCand, success);
+      if ( success ) {
         phi = aPos.Phi();
+      }
       sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
@@ -1172,9 +1171,11 @@ double AntiElectronIDMVA6::MVAValue(const pat::Tau& theTau) {
     for (const auto& signalCandPtr : signalCands) {
       reco::Candidate const* signalCand = signalCandPtr.get();
       float phi = theTau.phi();
-      math::XYZPoint aPos;
-      if (atECalEntrance(signalCand, aPos) == true)
+      bool success = false;
+      reco::Candidate::Point aPos = positionAtECalEntrance_(signalCand, success);
+      if ( success ) {
         phi = aPos.Phi();
+      }
       sumPhiTimesEnergy += phi * signalCand->energy();
       sumEnergy += signalCand->energy();
     }
@@ -1328,23 +1329,4 @@ double AntiElectronIDMVA6::dCrackEta(double eta) {
   }
 
   return std::abs(retVal);
-}
-
-bool AntiElectronIDMVA6::atECalEntrance(const reco::Candidate* part, math::XYZPoint& pos) {
-  bool result = false;
-  BaseParticlePropagator theParticle = BaseParticlePropagator(
-      RawParticle(math::XYZTLorentzVector(part->px(), part->py(), part->pz(), part->energy()),
-                  math::XYZTLorentzVector(part->vertex().x(), part->vertex().y(), part->vertex().z(), 0.),
-                  part->charge()),
-      0.,
-      0.,
-      bField_);
-  theParticle.propagateToEcalEntrance(false);
-  if (theParticle.getSuccess() != 0) {
-    pos = math::XYZPoint(theParticle.particle().vertex());
-    result = true;
-  } else {
-    result = false;
-  }
-  return result;
 }

--- a/RecoTauTag/RecoTau/src/PositionAtECalEntrance.cc
+++ b/RecoTauTag/RecoTau/src/PositionAtECalEntrance.cc
@@ -1,0 +1,42 @@
+#include "RecoTauTag/RecoTau/interface/PositionAtECalEntrance.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
+
+#include <assert.h>
+
+PositionAtECalEntrance::PositionAtECalEntrance()
+ : bField_z_(-1.)
+{}
+
+PositionAtECalEntrance::~PositionAtECalEntrance()
+{}
+
+void PositionAtECalEntrance::beginEvent(const edm::EventSetup& es)
+{
+  edm::ESHandle<MagneticField> bField;
+  es.get<IdealMagneticFieldRecord>().get(bField);
+  bField_z_ = bField->inTesla(GlobalPoint(0.,0.,0.)).z();
+}
+
+reco::Candidate::Point PositionAtECalEntrance::operator()(const reco::Candidate* particle, bool& success) const
+{
+  assert(bField_z_ != -1.);
+  BaseParticlePropagator propagator = BaseParticlePropagator(
+      RawParticle(math::XYZTLorentzVector(particle->px(), particle->py(), particle->pz(), particle->energy()),
+                  math::XYZTLorentzVector(particle->vertex().x(), particle->vertex().y(), particle->vertex().z(), 0.),
+                  particle->charge()),
+      0.,
+      0.,
+      bField_z_);
+  propagator.propagateToEcalEntrance(false);
+  reco::Candidate::Point position;
+  if ( propagator.getSuccess() != 0 ) {
+    position = reco::Candidate::Point(propagator.particle().vertex().x(), propagator.particle().vertex().y(), propagator.particle().vertex().z());
+    success = true;
+  } else {
+    success = false;
+  }
+  return position;
+}


### PR DESCRIPTION
…n either AOD or miniAOD inputs

- use eta and phi of impact position of leadingPFChargedHadron on ECAL surface instead of eta and phi of tau at the vertex
 (taking bending of track in the magnetic field and the zVertex into account)