### PR TITLE
Phase 2 Tau Isolation MVA

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -339,57 +339,20 @@ def miniAOD_customizeCommon(process):
         updatedTauName = _updatedTauName,
         toKeep = ['deepTau2017v2p1']
     )
-    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase 2 Tau MVA
-    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase 2 Tau MVA
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase2 Tau MVA
+    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase2 Tau MVA
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
     process.deepTau2017v2p1.taus = _noUpdatedTauName
+    phase2_common.toModify(process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw, PATTauProducer=_noUpdatedTauName) #Phase2 Tau MVA
+    phase2_common.toModify(process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2, PATTauProducer=_noUpdatedTauName) #Phase2 Tau MVA
     process.slimmedTaus = getattr(process, _updatedTauName).clone(
         src = _noUpdatedTauName
     )
     process.deepTauIDTask = cms.Task(process.deepTau2017v2p1, process.slimmedTaus)
     task.add(process.deepTauIDTask)
-
-    #Phase 2 Tau MVA
-    from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1
-    from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
-    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-        PATTauProducer = cms.InputTag(_noUpdatedTauName),
-        Prediscriminants = noPrediscriminants,
-        loadMVAfromDB = cms.bool(True),
-        mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-        mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
-        verbosity = cms.int32(0)
-    )
-    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
-        PATTauProducer = cms.InputTag(_noUpdatedTauName),
-        Prediscriminants = noPrediscriminants,
-        toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
-        loadMVAfromDB = cms.bool(True),
-        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
-        mapping = cms.VPSet(
-            cms.PSet(
-                category = cms.uint32(0),
-                cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                variable = cms.string("pt"),
-               )
-            ),
-        workingPoints = cms.vstring(
-            "_WPEff95",
-            "_WPEff90",
-            "_WPEff80",
-            "_WPEff70",
-            "_WPEff60",
-            "_WPEff50",
-            "_WPEff40"
-        )
-    )
-    process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
-        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
-        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
-    )
-    phase2_common.toModify(task, func=lambda t: t.add(process.rerunIsolationMVADBnewDMwLTPhase2Task))
+    phase2_common.toModify(process.deepTauIDTask, func=lambda t: process.deepTauIDTask.add(process.rerunIsolationMVADBnewDMwLTPhase2Task)) #Phase2 Tau MVA
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -339,6 +339,8 @@ def miniAOD_customizeCommon(process):
         updatedTauName = _updatedTauName,
         toKeep = ['deepTau2017v2p1']
     )
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common #Phase 2 Tau MVA
+    phase2_common.toModify(tauIdEmbedder, tauIdEmbedder.toKeep.append('newDMwLTwGJPhase2')) #Phase 2 Tau MVA
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)
     delattr(process, 'slimmedTaus')
@@ -348,6 +350,46 @@ def miniAOD_customizeCommon(process):
     )
     process.deepTauIDTask = cms.Task(process.deepTau2017v2p1, process.slimmedTaus)
     task.add(process.deepTauIDTask)
+
+    #Phase 2 Tau MVA
+    from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import patDiscriminationByIsolationMVArun2v1raw, patDiscriminationByIsolationMVArun2v1
+    from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+        PATTauProducer = cms.InputTag(_noUpdatedTauName),
+        Prediscriminants = noPrediscriminants,
+        loadMVAfromDB = cms.bool(True),
+        mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+        mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
+        verbosity = cms.int32(0)
+    )
+    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
+        PATTauProducer = cms.InputTag(_noUpdatedTauName),
+        Prediscriminants = noPrediscriminants,
+        toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
+        loadMVAfromDB = cms.bool(True),
+        mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+        mapping = cms.VPSet(
+            cms.PSet(
+                category = cms.uint32(0),
+                cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+                variable = cms.string("pt"),
+               )
+            ),
+        workingPoints = cms.vstring(
+            "_WPEff95",
+            "_WPEff90",
+            "_WPEff80",
+            "_WPEff70",
+            "_WPEff60",
+            "_WPEff50",
+            "_WPEff40"
+        )
+    )
+    process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
+        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
+        process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
+    )
+    phase2_common.toModify(task, func=lambda t: t.add(process.rerunIsolationMVADBnewDMwLTPhase2Task))
 
     #-- Adding customization for 80X 2016 legacy reMiniAOD and 2018 heavy ions
     from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -329,7 +329,6 @@ def miniAOD_customizeCommon(process):
     (run2_miniAOD_94XFall17 | run2_miniAOD_UL).toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithRetrainedMVATauID
         )
-
     #-- Adding DeepTauID
     # deepTau v2p1
     _updatedTauName = 'slimmedTausDeepIDsv2p1'

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -337,10 +337,7 @@ def miniAOD_customizeCommon(process):
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(
         process, debug = False,
         updatedTauName = _updatedTauName,
-        #toKeep = ['deepTau2017v2p1', 'newDMwLTwGJPhase2']
-        #toKeep = ['deepTau2017v2p1', 'newDM2016v1']
         toKeep = ['deepTau2017v2p1']
-        #toKeep = ['newDMwLTwGJPhase2']
     )
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -329,6 +329,7 @@ def miniAOD_customizeCommon(process):
     (run2_miniAOD_94XFall17 | run2_miniAOD_UL).toReplaceWith(
         process.makePatTausTask, _makePatTausTaskWithRetrainedMVATauID
         )
+
     #-- Adding DeepTauID
     # deepTau v2p1
     _updatedTauName = 'slimmedTausDeepIDsv2p1'

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -337,7 +337,10 @@ def miniAOD_customizeCommon(process):
     tauIdEmbedder = tauIdConfig.TauIDEmbedder(
         process, debug = False,
         updatedTauName = _updatedTauName,
+        #toKeep = ['deepTau2017v2p1', 'newDMwLTwGJPhase2']
+        #toKeep = ['deepTau2017v2p1', 'newDM2016v1']
         toKeep = ['deepTau2017v2p1']
+        #toKeep = ['newDMwLTwGJPhase2']
     )
     tauIdEmbedder.runTauID()
     addToProcessAndTask(_noUpdatedTauName, process.slimmedTaus.clone(),process,task)

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -317,12 +317,12 @@ for ver2017 in tauIdDiscrMVA_2017_version:
 
 # MVAIso Phase2
 import os
-loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
-    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
-    toGet   = cms.VPSet()
-)
+#loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
+#    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
+#    toGet   = cms.VPSet()
+#)
 for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
-    loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(
             record = cms.string('GBRWrapperRcd'),
             tag = cms.string("RecoTauTag_%s" % (gbrForestName)),
@@ -330,14 +330,14 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
         )
     )
     for WP in tauIdDiscrMVA_WPs_phase2[training].keys():
-        loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+        loadRecoTauTagMVAsFromPrepDB.toGet.append(
             cms.PSet(
                 record = cms.string('PhysicsTGraphPayloadRcd'),
                 tag = cms.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP)),
                 label = cms.untracked.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP))
             )
          )
-    loadRecoTauTagMVAsFromSQLiteDB_phase2.toGet.append(
+    loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(
             record = cms.string('PhysicsTFormulaPayloadRcd'),
             tag = cms.string("RecoTauTag_%s_mvaOutput_normalization" % (gbrForestName)),

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -316,11 +316,6 @@ for ver2017 in tauIdDiscrMVA_2017_version:
         )
 
 # MVAIso Phase2
-import os
-#loadRecoTauTagMVAsFromSQLiteDB_phase2 = loadRecoTauTagMVAsFromPrepDB.clone(
-#    connect = 'sqlite_file:'+os.getenv('CMSSW_BASE')+'/src/RecoTauTag/RecoTau/data/RecoTauTag_MVAs_2020Mar25.db',
-#    toGet   = cms.VPSet()
-#)
 for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
     loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(

--- a/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
@@ -66,7 +66,7 @@ namespace reco {
       kPWnewDMwLT,
       kDBoldDMwLTwGJ,
       kDBnewDMwLTwGJ,
-      kPhase2
+      kDBnewDMwLTwGJPhase2
     };
     bool fillIsoMVARun2Inputs(float* mvaInput,
                               const pat::Tau& tau,

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -109,8 +109,8 @@ namespace reco {
           mvaOpt_ = kDBoldDMwLTwGJ;
         else if (mvaOpt_string == "DBnewDMwLTwGJ")
           mvaOpt_ = kDBnewDMwLTwGJ;
-        else if (mvaOpt_string == "Phase2")
-          mvaOpt_ = kPhase2;
+        else if (mvaOpt_string == "DBnewDMwLTwGJPhase2")
+          mvaOpt_ = kDBnewDMwLTwGJPhase2;
         else
           throw cms::Exception("PATTauDiscriminationByMVAIsolationRun2")
               << " Invalid Configuration Parameter 'mvaOpt' = " << mvaOpt_string << " !!\n";
@@ -122,7 +122,7 @@ namespace reco {
         else if (mvaOpt_ == kDBoldDMwLT || mvaOpt_ == kDBnewDMwLT || mvaOpt_ == kPWoldDMwLT || mvaOpt_ == kPWnewDMwLT ||
                  mvaOpt_ == kDBoldDMwLTwGJ || mvaOpt_ == kDBnewDMwLTwGJ)
           mvaInput_ = new float[23];
-        else if (mvaOpt_ == kPhase2)
+        else if (mvaOpt_ == kDBnewDMwLTwGJPhase2)
            mvaInput_ = new float[30];
         else
           assert(0);

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -12,7 +12,8 @@ class TauIDEmbedder(object):
         "2017v1", "2017v2", "newDM2017v2", "dR0p32017v2", "2016v1", "newDM2016v1",
         "deepTau2017v1", "deepTau2017v2", "deepTau2017v2p1",
         "DPFTau_2016_v0", "DPFTau_2016_v1",
-        "againstEle2018", "newDMwLTwGJPhase2"
+        "againstEle2018",
+        "newDMwLTwGJPhase2"
     ]
 
     def __init__(self, process, debug = False,
@@ -900,7 +901,7 @@ class TauIDEmbedder(object):
                     "_WPEff40"
                 )
             )
-            self.rerunIsolationMVADBnewDMwLTPhase2Task = self.cms.Task(
+            self.process.rerunIsolationMVADBnewDMwLTPhase2Task = self.cms.Task(
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
             )

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -867,33 +867,30 @@ class TauIDEmbedder(object):
         if "newDMwLTwGJPhase2" in self.toKeep:
             if self.debug: print ("Adding newDMwLTwGJPhase2 ID")
             def tauIDMVAinputs(module, wp):
-                return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
+                return cms.PSet(inputTag = cms.InputTag(module), workingPointIndex = cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
-#                PATTauProducer = self.cms.InputTag(self.updatedTauName),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                loadMVAfromDB = self.cms.bool(True),
-                mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                mvaOpt = self.cms.string("DBnewDMwLTwGJPhase2"),
-                verbosity = self.cms.int32(0)
+                loadMVAfromDB = cms.bool(True),
+                mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+                mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
+                verbosity = cms.int32(0)
             )
 
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
-                PATTauProducer = self.cms.InputTag('slimmedTaus'),
-                #PATTauProducer = self.cms.InputTag(self.updatedTauName),
+                PATTauProducer = cms.InputTag('slimmedTaus'),
                 Prediscriminants = noPrediscriminants,
-                #toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2'),
-                toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
-                loadMVAfromDB = self.cms.bool(True),
-                mvaOutput_normalization = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
-                mapping = self.cms.VPSet(
-                    self.cms.PSet(
-                        category = self.cms.uint32(0),
-                        cut = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-                        variable = self.cms.string("pt"),
+                toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
+                loadMVAfromDB = cms.bool(True),
+                mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoPhase2_mvaOutput_normalization"),
+                mapping = cms.VPSet(
+                    cms.PSet(
+                        category = cms.uint32(0),
+                        cut = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
+                        variable = cms.string("pt"),
                     )
                 ),
-                workingPoints = self.cms.vstring(
+                workingPoints = cms.vstring(
                     "_WPEff95",
                     "_WPEff90",
                     "_WPEff80",
@@ -903,12 +900,12 @@ class TauIDEmbedder(object):
                     "_WPEff40"
                 )
             )
-            self.process.rerunIsolationMVADBnewDMwLTPhase2Task = self.cms.Task(
+            self.process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
             )
             self.process.rerunMvaIsolationTask.add(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
+            self.process.rerunMvaIsolationSequence += cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
             tauIDSources.byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw")
             tauIDSources.byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95")

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -864,6 +864,7 @@ class TauIDEmbedder(object):
             tauIDSources =_tauIDSourcesWithAgainistEle.clone()
 
         if "newDMwLTwGJPhase2" in self.toKeep:
+            if self.debug: print ("Adding newDMwLTwGJPhase2 ID")
             def tauIDMVAinputs(module, wp):
                 return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -870,6 +870,7 @@ class TauIDEmbedder(object):
                 return self.cms.PSet(inputTag = self.cms.InputTag(module), workingPointIndex = self.cms.int32(-1 if wp=="raw" else -2 if wp=="category" else getattr(self.process, module).workingPoints.index(wp)))
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
                 PATTauProducer = self.cms.InputTag('slimmedTaus'),
+#                PATTauProducer = self.cms.InputTag(self.updatedTauName),
                 Prediscriminants = noPrediscriminants,
                 loadMVAfromDB = self.cms.bool(True),
                 mvaName = self.cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
@@ -879,6 +880,7 @@ class TauIDEmbedder(object):
 
             self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
                 PATTauProducer = self.cms.InputTag('slimmedTaus'),
+                #PATTauProducer = self.cms.InputTag(self.updatedTauName),
                 Prediscriminants = noPrediscriminants,
                 #toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2'),
                 toMultiplex = self.cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
@@ -905,8 +907,8 @@ class TauIDEmbedder(object):
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw,
                 self.process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
             )
-            self.process.rerunMvaIsolationTask.add(self.rerunIsolationMVADBnewDMwLTPhase2Task)
-            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.rerunIsolationMVADBnewDMwLTPhase2Task)
+            self.process.rerunMvaIsolationTask.add(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
+            self.process.rerunMvaIsolationSequence += self.cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
             tauIDSources.byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw")
             tauIDSources.byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95")

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -196,7 +196,7 @@ namespace reco {
             mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
-        
+
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -192,11 +192,10 @@ namespace reco {
       if (((mvaOpt == kOldDMwoLT || mvaOpt == kOldDMwLT || mvaOpt == kDBoldDMwLT || mvaOpt == kPWoldDMwLT ||
             mvaOpt == kDBoldDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 10)) ||
-          ((mvaOpt==kPhase2 || mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT ||
+          ((mvaOpt==kDBnewDMwLTwGJPhase2 || mvaOpt == kNewDMwoLT || mvaOpt == kNewDMwLT || mvaOpt == kDBnewDMwLT || mvaOpt == kPWnewDMwLT ||
             mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
-
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);
@@ -236,7 +235,7 @@ namespace reco {
           }
         }
 
-      if (mvaOpt == kPhase2) {
+      if (mvaOpt == kDBnewDMwLTwGJPhase2) {
          mvaInput[0] = tau.pt();
          mvaInput[1] = abs(tau.eta());
          mvaInput[2] = chargedIsoPtSum; //tauID("chargedIsoPtSum");

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -329,16 +329,16 @@ namespace reco {
          mvaInput[27] = 0;
          mvaInput[28] = 10.;
          mvaInput[29] = 10.;
-         const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand);
-         if (patcand->hasTrackDetails()) {
-            const float trackdxy = patcand->dxy();
-            const float trackdxyerr = patcand->dxyError();
-            mvaInput[27] = trackdxy>=0.?+1:-1;
-            mvaInput[28] = sqrt(std::abs(trackdxy));
-            mvaInput[29] = std::abs(trackdxy/trackdxyerror);
-         }
+         if (tau.leadChargedHadrCand().isNonnull()) {
+            if (tau.leadChargedHadrCand()->bestTrack()) {
+               const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
+               const float trackdxy_err = tau.leadChargedHadrCand()->bestTrack()->dxyError();
+               mvaInput[27] = trackdxy>=0.?+1:-1;
+               mvaInput[28] = sqrt(std::abs(trackdxy));
+               mvaInput[29] = std::abs(trackdxy/trackdxy_err);
+            }
+        }
       }
-
         if (mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT) {
           mvaInput[0] = std::log(std::max(1.f, (float)tau.pt()));
           mvaInput[1] = std::abs((float)tau.eta());

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -329,13 +329,13 @@ namespace reco {
          mvaInput[27] = 0;
          mvaInput[28] = 10.;
          mvaInput[29] = 10.;
-         if (tau.leadChargedHadrCand().isNonnull()) {
-            if (tau.leadChargedHadrCand()->bestTrack()) {
-               const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
-               mvaInput[27] = trackdxy>=0.?+1:-1;
-               mvaInput[28] = sqrt(std::abs(trackdxy));
-               mvaInput[29] = std::abs(trackdxy/tau.leadChargedHadrCand()->bestTrack()->dxyError());
-            }
+         const pat::PackedCandidate* patcand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand);
+         if (patcand->hasTrackDetails()) {
+            const float trackdxy = patcand->dxy();
+            const float trackdxyerr = patcand->dxyError();
+            mvaInput[27] = trackdxy>=0.?+1:-1;
+            mvaInput[28] = sqrt(std::abs(trackdxy));
+            mvaInput[29] = std::abs(trackdxy/trackdxyerror);
          }
       }
 

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -238,7 +238,7 @@ namespace reco {
 
       if (mvaOpt == kDBnewDMwLTwGJPhase2) {
          mvaInput[0] = tau.pt();
-         mvaInput[1] = abs(tau.eta());
+         mvaInput[1] = std::abs(tau.eta());
          mvaInput[2] = chargedIsoPtSum; //tauID("chargedIsoPtSum");
          mvaInput[3] = neutralIsoPtSum; //tauID("neutralIsoPtSum");
          mvaInput[4] = puCorrPtSum; //tauID("puCorrPtSum");
@@ -298,11 +298,11 @@ namespace reco {
          e>0. ? e=tau.ecalEnergy()/e : e=-1.;
          mvaInput[15] = e;
          mvaInput[16] = tau.dxy()>=0.?+1:-1;
-         mvaInput[17] = sqrt(abs(tau.dxy()));
-         mvaInput[18] = abs(tau.dxy_Sig());
+         mvaInput[17] = sqrt(std::abs(tau.dxy()));
+         mvaInput[18] = std::abs(tau.dxy_Sig());
          mvaInput[19] = tau.ip3d()>=0.?+1:-1;
-         mvaInput[20] = sqrt(abs(tau.ip3d()));
-         mvaInput[21] = abs(tau.ip3d_Sig());
+         mvaInput[20] = sqrt(std::abs(tau.ip3d()));
+         mvaInput[21] = std::abs(tau.ip3d_Sig());
          mvaInput[22] = tau.hasSecondaryVertex();
          mvaInput[23] = decayDistMag; //sqrt(tau.flightLength().Mag2());
          mvaInput[24] = tau.flightLengthSig();
@@ -333,10 +333,10 @@ namespace reco {
             if (tau.leadChargedHadrCand()->bestTrack()) {
                const float trackdxy = tau.leadChargedHadrCand()->bestTrack()->dxy();
                mvaInput[27] = trackdxy>=0.?+1:-1;
-               mvaInput[28] = sqrt(abs(trackdxy));
-               mvaInput[29] = abs(trackdxy/tau.leadChargedHadrCand()->bestTrack()->dxyError());
+               mvaInput[28] = sqrt(std::abs(trackdxy));
+               mvaInput[29] = std::abs(trackdxy/tau.leadChargedHadrCand()->bestTrack()->dxyError());
             }
-        }
+         }
       }
 
         if (mvaOpt == kOldDMwoLT || mvaOpt == kNewDMwoLT) {

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -196,6 +196,7 @@ namespace reco {
             mvaOpt == kDBnewDMwLTwGJ) &&
            (tauDecayMode == 0 || tauDecayMode == 1 || tauDecayMode == 2 || tauDecayMode == 5 || tauDecayMode == 6 ||
             tauDecayMode == 10 || tauDecayMode == 11))) {
+        
         float chargedIsoPtSum = tau.tauID(nameCharged);
         float neutralIsoPtSum = tau.tauID(nameNeutral);
         float puCorrPtSum = tau.tauID(namePu);

--- a/RecoTauTag/RecoTau/test/BuildFile.xml
+++ b/RecoTauTag/RecoTau/test/BuildFile.xml
@@ -18,6 +18,21 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<library name="rerunMVAIsolationOnMiniAOD_Phase2" file="rerunMVAIsolationOnMiniAOD_Phase2.cc">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="DataFormats/PatCandidates"/>
+  <use name="DataFormats/TauReco"/>
+  <use name="RecoTauTag/RecoTau"/>
+  <use name="PhysicsTools/PatAlgos"/>
+  <use name="PhysicsTools/UtilAlgos"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="clhep"/>
+  <use name="root"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
 <environment>
   <bin file="runtestRecoTauTagRecoTau.cpp">
     <flags TEST_RUNNER_ARGS=" /bin/bash RecoTauTag/RecoTau/test runtests.sh"/>

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -1,10 +1,10 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "DataFormats/JetReco/interface/GenJet.h"
 
 #include "TH1D.h"
 #include "TH2D.h"
@@ -16,6 +16,8 @@ public:
 private:
    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
    virtual void endJob() override;
+
+   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 
    TH1D *h_raw_bkg, *h_raw_sig;
  
@@ -33,7 +35,6 @@ private:
 
    bool haveGenJets;
    edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;   
-   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 };
 
 rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet& iConfig)

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.cc
@@ -1,11 +1,10 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-//#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 
 #include "TH1D.h"
 #include "TH2D.h"
@@ -18,8 +17,6 @@ private:
    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
    virtual void endJob() override;
 
-   edm::EDGetTokenT<pat::TauCollection> tauToken_;
- 
    TH1D *h_raw_bkg, *h_raw_sig;
  
    TH1D *h_pt_denom_bkg, *h_pt_denom_sig;
@@ -36,30 +33,17 @@ private:
 
    bool haveGenJets;
    edm::EDGetTokenT<std::vector<reco::GenJet>> genJetToken_;   
-   //bool haveGenVisTaus;
-   //edm::EDGetTokenT<pat::CompositeCandidateCollection> genVisTauToken_;
-   bool haveGenParticles;
-   edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticleToken_;
+   edm::EDGetTokenT<std::vector<pat::Tau>> tauToken_;
 };
 
 rerunMVAIsolationOnMiniAOD_Phase2::rerunMVAIsolationOnMiniAOD_Phase2(const edm::ParameterSet& iConfig)
 {
-   tauToken_ = consumes<pat::TauCollection>(edm::InputTag("newTauIDsEmbedded"));
+   tauToken_ = consumes<pat::TauCollection>(iConfig.getParameter<edm::InputTag>("tauCollection"));
  
    haveGenJets = false;
    if (iConfig.existsAs<edm::InputTag>("genJetCollection")) {  
       haveGenJets = true;
       genJetToken_ = consumes<std::vector<reco::GenJet>>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
-   }
-   //haveGenVisTaus = false;
-   //if (iConfig.existsAs<edm::InputTag>("genVisTauCollection")) {
-   //   haveGenVisTaus = true;
-   //   genVisTauToken_ = consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("genVisTauCollection"));
-   //}
-   haveGenParticles = false;
-   if (iConfig.existsAs<edm::InputTag>("genParticleCollection")) {
-      haveGenParticles = true;
-      genParticleToken_ = consumes<std::vector<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticleCollection"));
    }
 
    edm::Service<TFileService> fileService;
@@ -110,15 +94,15 @@ void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event& iEvent, const 
    edm::Handle<pat::TauCollection> taus;
    iEvent.getByToken(tauToken_, taus);
 
+   const bool isRealData = iEvent.isRealData();
+
    edm::Handle<std::vector<reco::GenJet>> genJets;
-   if (haveGenJets) iEvent.getByToken(genJetToken_, genJets);
-
-   //edm::Handle<pat::CompositeCandidateCollection> genVisTaus;
-   //if (haveGenVisTaus) iEvent.getByToken(genVisTauToken_, genVisTaus);
-
-   edm::Handle<std::vector<reco::GenParticle>> genParticles;
-   if (haveGenParticles) iEvent.getByToken(genParticleToken_, genParticles);
- 
+   if (!isRealData && haveGenJets) {
+      iEvent.getByToken(genJetToken_, genJets);
+   } else {
+      haveGenJets = false;
+   }
+   
    for (auto i = taus->begin(); i != taus->end(); ++i) {
       
       const double pt = i->pt();
@@ -138,41 +122,22 @@ void rerunMVAIsolationOnMiniAOD_Phase2::analyze(const edm::Event& iEvent, const 
       }
       if (isPU) continue;
 
-      //bool isSig = false;
-      //if (haveGenVisTaus) {
-      //   double mindr = 99.;
-      //   for (auto j = genVisTaus->begin(); j != genVisTaus->end(); ++j) {
-      //      if (std::abs(j->pdgId())==15 && reco::deltaR(*i, *j)<mindr) {
-      //         mindr = reco::deltaR(*i, *j);
-      //      }
-      //   }
-      //   if (mindr<0.4) isSig = true;
-      //}
-
       bool isSig = false;
-      if (haveGenParticles) {
-         double mindr_e = 99.;
-         double mindr_m = 99.;
-         double mindr_t = 99.;
-         for (auto j = genParticles->begin(); j != genParticles->end(); ++j) {
-            const double dr = reco::deltaR(*i, *j);
-            const int pdgid = std::abs(j->pdgId());
-            if (pdgid==11 && j->status()==1 && dr<mindr_e) mindr_e = dr;
-            if (pdgid==13 && j->status()==1 && dr<mindr_m) mindr_m = dr;
-            if (pdgid==15 && j->isLastCopy() && dr<mindr_t) mindr_t = dr;
+      if (!isRealData) {
+         if (i->genJet()) {
+            isSig = true;
          }
-         if (mindr_e>=0.4 && mindr_m>=0.4 && mindr_t<0.5) isSig = true;
       }
 
-      const double byIsolationMVAPhase2raw = i->tauID("byIsolationMVAPhase2raw");
+      const double byIsolationMVAPhase2raw = i->tauID("ByIsolationMVADBnewDMwLTPhase2raw");
       double wp[7];
-      wp[0] = i->tauID("byVVLooseIsolationMVAPhase2New");
-      wp[1] = i->tauID("byVLooseIsolationMVAPhase2New");
-      wp[2] = i->tauID("byLooseIsolationMVAPhase2New");
-      wp[3] = i->tauID("byMediumIsolationMVAPhase2New");
-      wp[4] = i->tauID("byTightIsolationMVAPhase2New");
-      wp[5] = i->tauID("byVTightIsolationMVAPhase2New");
-      wp[6] = i->tauID("byVVTightIsolationMVAPhase2New");
+      wp[0] = i->tauID("byVVLooseIsolationMVADBnewDMwLTPhase2");
+      wp[1] = i->tauID("byVLooseIsolationMVADBnewDMwLTPhase2");
+      wp[2] = i->tauID("byLooseIsolationMVADBnewDMwLTPhase2");
+      wp[3] = i->tauID("byMediumIsolationMVADBnewDMwLTPhase2");
+      wp[4] = i->tauID("byTightIsolationMVADBnewDMwLTPhase2");
+      wp[5] = i->tauID("byVTightIsolationMVADBnewDMwLTPhase2");
+      wp[6] = i->tauID("byVVTightIsolationMVADBnewDMwLTPhase2");
       
       if (isSig) {
          h_raw_sig->Fill(byIsolationMVAPhase2raw);

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -8,22 +8,24 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2023_realistic_v2')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
+#process.Tracer = cms.Service("Tracer")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10000)
+    input = cms.untracked.int32(1000)
 )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
-        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
+        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
+        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
     )
 )
 
 process.TFileService = cms.Service("TFileService",
-    #fileName = cms.string('output_QCD_Phase2.root')
-    fileName = cms.string('output_VBFHToTauTau_Phase2.root')
+    fileName = cms.string('output_QCD_Phase2.root')
+    #fileName = cms.string('output_VBFHToTauTau_Phase2.root')
 )
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
@@ -31,21 +33,22 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
-process.rerunDiscriminationByIsolationMVAPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
+
+process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
     PATTauProducer = cms.InputTag('slimmedTaus'),
     Prediscriminants = noPrediscriminants,
     loadMVAfromDB = cms.bool(True),
     #loadMVAfromDB = cms.bool(False),
     #inputFileName = cms.FileInPath("gbrDiscriminationByIsolationMVAPhase2.root"),
     mvaName = cms.string("RecoTauTag_tauIdMVAIsoPhase2"),
-    mvaOpt = cms.string("Phase2"),
+    mvaOpt = cms.string("DBnewDMwLTwGJPhase2"),
     verbosity = cms.int32(0)
 )
 
-process.rerunDiscriminationByIsolationMVAPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
+process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByIsolationMVArun2v1.clone(
     PATTauProducer = cms.InputTag('slimmedTaus'),
     Prediscriminants = noPrediscriminants,
-    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVAPhase2raw'),
+    toMultiplex = cms.InputTag('rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw'),
     loadMVAfromDB = cms.bool(True),
     #loadMVAfromDB = cms.bool(False),
     #inputFileName = cms.FileInPath("wpDiscriminationByIsolationMVAPhase2_tauIdMVAIsoPhase2.root"),
@@ -69,8 +72,8 @@ process.rerunDiscriminationByIsolationMVAPhase2 = patDiscriminationByIsolationMV
 )
 
 process.rerunMvaIsolation2Seq_Phase2 = cms.Sequence(
-    process.rerunDiscriminationByIsolationMVAPhase2raw
-    * process.rerunDiscriminationByIsolationMVAPhase2
+   process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw
+   *process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
 )
 
 # embed new id's into tau
@@ -79,49 +82,27 @@ def tauIDMVAinputs(module, wp):
 embedID = cms.EDProducer("PATTauIDEmbedder",
     src = cms.InputTag('slimmedTaus'),
     tauIDSources = cms.PSet(
-        byIsolationMVAPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "raw"),
-        byVVLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff95"),
-        byVLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff90"),
-        byLooseIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff80"),
-        byMediumIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff70"),
-        byTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff60"),
-        byVTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff50"),
-        byVVTightIsolationMVAPhase2New = tauIDMVAinputs("rerunDiscriminationByIsolationMVAPhase2", "_WPEff40")
+        ByIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw"),
+        byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95"),
+        byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff90"),
+        byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff80"),
+        byMediumIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff70"),
+        byTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff60"),
+        byVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff50"),
+        byVVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff40")
     ),
 )
 setattr(process, "newTauIDsEmbedded", embedID)
 
-## added for mvaIsolation on miniAOD testing
-#process.out = cms.OutputModule("PoolOutputModule",
-#    fileName = cms.untracked.string(filetag+'_miniaod.root'),
-#    ## save only events passing the full path
-#    SelectEvents = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
-#    ## save PAT output; you need a '*' to unpack the list of commands
-#    ##'patEventContent'
-#    outputCommands = cms.untracked.vstring(
-#        'drop *',
-#        'keep *_newTauIDsEmbedded_*_*',
-#        'keep *_prunedGenParticles_*_*'
-#    )
-#)
-
-#process.genVisTauProducer = cms.EDProducer("GenVisTauProducer",
-#    genParticleCollection = cms.InputTag("prunedGenParticles")
-#)
-
 process.rerunMVAIsolationOnMiniAOD_Phase2 = cms.EDAnalyzer(
     'rerunMVAIsolationOnMiniAOD_Phase2',
+    tauCollection = cms.InputTag("newTauIDsEmbedded"),
     genJetCollection = cms.InputTag("slimmedGenJets"), #comment out to run on data
-    #genVisTauCollection = cms.InputTag("genVisTauProducer:genVisTaus"), #comment out if running on data
-    genParticleCollection  = cms.InputTag("prunedGenParticles") #comment out to run on data
 )
 
 process.p = cms.Path(
     process.rerunMvaIsolation2Seq_Phase2
-    *process.newTauIDsEmbedded
-    #*process.genVisTauProducer
-    *process.rerunMVAIsolationOnMiniAOD_Phase2
+    * process.newTauIDsEmbedded
+    * process.rerunMVAIsolationOnMiniAOD_Phase2
 )
-
-#process.outpath = cms.EndPath(process.out)
 

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -32,7 +32,6 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
-
 process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
     PATTauProducer = cms.InputTag('slimmedTaus'),
     Prediscriminants = noPrediscriminants,

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -10,22 +10,22 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 
 #process.Tracer = cms.Service("Tracer")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(10000)
 )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
-        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
+        #'/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/QCD_Pt-15To7000_TuneCP5_Flat_14TeV-pythia8/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/40000/FFE6B9AD-6109-FA47-9273-24C908EC90EE.root',
+        '/store/mc/PhaseIIMTDTDRAutumn18MiniAOD/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack/MINIAODSIM/PU200_103X_upgrade2023_realistic_v2-v1/120000/2AD029AA-54C4-3D44-B934-24F19454A6FD.root',
     )
 )
 
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string('output_QCD_Phase2.root')
-    #fileName = cms.string('output_VBFHToTauTau_Phase2.root')
+    #fileName = cms.string('output_QCD_Phase2.root')
+    fileName = cms.string('output_VBFHToTauTau_Phase2.root')
 )
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -11,7 +11,6 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 #process.Tracer = cms.Service("Tracer")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10000)
 )
@@ -72,8 +71,8 @@ process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByI
 )
 
 process.rerunMvaIsolation2Seq_Phase2 = cms.Sequence(
-   process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw
-   *process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
+    process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw
+    * process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2
 )
 
 # embed new id's into tau


### PR DESCRIPTION
Add Phase 2 Tau Isolation MVA into official CMSSW workflow.

This PR follows that of an initial PR found here:
https://github.com/cms-tau-pog/cmssw/pull/135
Where all discussion has taken place.

A test to show that this PR does not break CMSSW:
`cmsDriver.py miniAOD2026 --filein root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_11_1_0_pre6/RelValTTbar_14TeV/GEN-SIM-RECO/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/FF9B5B74-B6D3-0746-92FB-C2F57C4DF6DC.root --fileout file:MiniAOD2026.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions auto:phase2_realistic_T14 --step PAT --nThreads 4 --geometry Extended2026D49 --scenario pp --era Phase2C8 -n 2`

A test to show how to calculate and embed the the new BDT in the taus would use the test script found here:
`cmsRun RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py`

