### PR TITLE
Changed DeepTau modules so that they can use either AOD or RECO input

### DIFF
--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -180,7 +180,7 @@ def update(process):
     VSjetWP = cms.vstring(working_points)
     )		
 
-    #Add DeepTauProducer
+    # Add DeepTauProducer
     process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.deepTauProducer)
 
     return process

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoTauTag.RecoTau.pfRecoTauDiscriminationByIsolation_cfi import *
+# from RecoTauTag.RecoTau.pfRecoTauDiscriminationByIsolation_cfi import *
+from RecoTauTag.RecoTau.PFRecoTauDiscriminationByIsolation_cfi import *
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
-
 
 from RecoTauTag.RecoTau.PFTauPrimaryVertexProducer_cfi      import *
 from RecoTauTag.RecoTau.PFTauSecondaryVertexProducer_cfi    import *
 from RecoTauTag.RecoTau.PFTauTransverseImpactParameters_cfi import *
-
 
 def update(process):
     process.options.wantSummary = cms.untracked.bool(True)
@@ -20,209 +19,58 @@ def update(process):
 
     PFTauQualityCuts.primaryVertexSrc = cms.InputTag("hltPixelVertices")
 
-    process.chargedIsoPtSum = pfRecoTauDiscriminationByIsolation.clone(
+    ## Cut based isolations dR=0.5
+    process.hpsPFTauBasicDiscriminators = pfRecoTauDiscriminationByIsolation.clone(
         PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
         particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
         vertexSrc = PFTauQualityCuts.primaryVertexSrc,
         Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(True),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(True),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        storeRawPUsumPt = cms.bool(False),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
+        customOuterCone = 0.5,
+        isoConeSizeForDeltaBeta = 0.8,
+        IDdefinitions = cms.VPSet(
+            cms.PSet(
+                IDname = cms.string("ChargedIsoPtSum"),
+                ApplyDiscriminationByTrackerIsolation = cms.bool(True),
+                storeRawSumPt = cms.bool(True)
+            ),
+            cms.PSet(
+                IDname = cms.string("NeutralIsoPtSum"),
+                ApplyDiscriminationByECALIsolation = cms.bool(True),
+                storeRawSumPt = cms.bool(True)
+            ),
+            cms.PSet(
+                IDname = cms.string("NeutralIsoPtSumWeight"),
+                ApplyDiscriminationByWeightedECALIsolation = cms.bool(True),
+                storeRawSumPt = cms.bool(True),
+                UseAllPFCandsForWeights = cms.bool(True)
+            ),
+            cms.PSet(
+                IDname = cms.string("TauFootprintCorrection"),
+                applyDeltaBetaCorrection = cms.bool(True),
+                storeRawFootprintCorrection = cms.bool(True)
+            ),
+            cms.PSet(
+                IDname = cms.string("PhotonPtSumOutsideSignalCone"),
+                storeRawPhotonSumPt_outsideSignalCone = cms.bool(True)
+            ),
+            cms.PSet(
+                IDname = cms.string("PUcorrPtSum"),
+                applyDeltaBetaCorrection = cms.bool(True),
+                storeRawPUsumPt = cms.bool(True)
+            ),
+            cms.PSet(
+                IDname = cms.string("ByRawCombinedIsolationDBSumPtCorr3Hits"),
+                ApplyDiscriminationByTrackerIsolation = cms.bool(True),
+                ApplyDiscriminationByECALIsolation = cms.bool(True),
+                applyDeltaBetaCorrection = cms.bool(True),
+                storeRawSumPt = cms.bool(True)
+            )
+        ),
     )
 
-    process.chargedIsoPtSumdR03 = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = PFTauQualityCuts.primaryVertexSrc,
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(True),
-        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(True),
-        storeRawPUsumPt = cms.bool(False),
-        customOuterCone = cms.double(0.3),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-    process.neutralIsoPtSum = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        ApplyDiscriminationByECALIsolation = cms.bool(True),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(True),
-        storeRawPUsumPt = cms.bool(False),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-    process.neutralIsoPtSumdR03 = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        ApplyDiscriminationByECALIsolation = cms.bool(True),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(True),
-        storeRawPUsumPt = cms.bool(False),
-        customOuterCone = cms.double(0.3),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-    process.puCorrPtSum = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(True),
-        storeRawSumPt = cms.bool(False),
-        storeRawPUsumPt = cms.bool(True),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-    requireDecayMode = cms.PSet(
-        BooleanOperator = cms.string("and"),
-        decayMode = cms.PSet(
-            Producer = cms.InputTag('hltHpsPFTauDiscriminationByDecayModeFindingNewDMsReg'),
-            cut = cms.double(0.5)
-        )
-    )
-    process.footprintCorrection = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        Prediscriminants = requireDecayMode.clone(),
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(True),
-        storeRawSumPt = cms.bool(False),
-        storeRawPUsumPt = cms.bool(False),
-        storeRawFootprintCorrection = cms.bool(True),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-    process.footprintCorrectiondR03 = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        Prediscriminants = requireDecayMode.clone(),
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(True),
-        storeRawSumPt = cms.bool(False),
-        storeRawPUsumPt = cms.bool(False),
-        storeRawFootprintCorrection = cms.bool(True),
-        customOuterCone = cms.double(0.3),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-
-    process.neutralIsoPtSumWeight = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        Prediscriminants = requireDecayMode.clone(),
-        ApplyDiscriminationByECALIsolation = cms.bool(True),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        UseAllPFCandsForWeights = cms.bool(True),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(True),
-        storeRawPUsumPt = cms.bool(False),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-
-    process.neutralIsoPtSumWeightdR03 = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        Prediscriminants = requireDecayMode.clone(),
-        ApplyDiscriminationByECALIsolation = cms.bool(True),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        UseAllPFCandsForWeights = cms.bool(True),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(True),
-        storeRawPUsumPt = cms.bool(False),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-
-    process.photonPtSumOutsideSignalCone = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        Prediscriminants = requireDecayMode.clone(),
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(False),
-        storeRawPUsumPt = cms.bool(False),
-        storeRawPhotonSumPt_outsideSignalCone = cms.bool(True),
-        customOuterCone = cms.double(0.5),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
-    )
-    process.photonPtSumOutsideSignalConedR03 = pfRecoTauDiscriminationByIsolation.clone(
-        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
-        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
-        vertexSrc = cms.InputTag("hltPixelVertices"),
-        Prediscriminants = requireDecayMode.clone(),
-        ApplyDiscriminationByECALIsolation = cms.bool(False),
-        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
-        applyOccupancyCut = cms.bool(False),
-        applySumPtCut = cms.bool(False),
-        applyDeltaBetaCorrection = cms.bool(False),
-        storeRawSumPt = cms.bool(False),
-        storeRawPUsumPt = cms.bool(False),
-        storeRawPhotonSumPt_outsideSignalCone = cms.bool(True),
-        customOuterCone = cms.double(0.3),
-        isoConeSizeForDeltaBeta = cms.double(0.8),
-        verbosity = cms.int32(0),
-        qualityCuts = PFTauQualityCuts
+    ## Cut based isolations dR=0.3
+    process.hpsPFTauBasicDiscriminatorsdR03 = process.hpsPFTauBasicDiscriminators.clone(
+        customOuterCone = cms.double(0.3)
     )
 
     process.hpsPFTauPrimaryVertexProducer = PFTauPrimaryVertexProducer.clone(
@@ -232,10 +80,10 @@ def update(process):
         PVTag = cms.InputTag("hltPixelVertices"),
         beamSpot = cms.InputTag("hltOnlineBeamSpot"),
         Algorithm = cms.int32(0),
-        useBeamSpot = cms.bool(True),
-        RemoveMuonTracks = cms.bool(False),
-        RemoveElectronTracks = cms.bool(False),
-        useSelectedTaus = cms.bool(False),
+        useBeamSpot = True,
+        RemoveMuonTracks = False,
+        RemoveElectronTracks = False,
+        useSelectedTaus = False,
         discriminators = cms.VPSet(
             cms.PSet(
                 discriminator = cms.InputTag('hltHpsPFTauDiscriminationByDecayModeFindingNewDMsReg'),
@@ -289,7 +137,7 @@ def update(process):
         PFTauTag = cms.InputTag("hltHpsPFTauProducerReg"),
         PFTauPVATag = cms.InputTag("hpsPFTauPrimaryVertexProducer"),
         PFTauSVATag = cms.InputTag("hpsPFTauSecondaryVertexProducer"),
-        useFullCalculation = cms.bool(True)
+        useFullCalculation = True
     )
 
 
@@ -297,19 +145,9 @@ def update(process):
     process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauPrimaryVertexProducer)
     process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauSecondaryVertexProducer)
     process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauTransverseImpactParameters)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.chargedIsoPtSum)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.chargedIsoPtSumdR03)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSum)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSumdR03)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.puCorrPtSum)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.footprintCorrection)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.footprintCorrectiondR03)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSumWeight)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSumWeightdR03)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.photonPtSumOutsideSignalCone)
-    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.photonPtSumOutsideSignalConedR03)
     process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hltFixedGridRhoFastjetAll)
-
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauBasicDiscriminators)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauBasicDiscriminatorsdR03)
 
     file_names = [
     				'core:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_core.pb',
@@ -320,27 +158,25 @@ def update(process):
     wp_names = ["0.", "0."]
 
     process.deepTauProducer = cms.EDProducer("DeepTauId",
-    taus                            = cms.InputTag("hltHpsPFTauProducerReg"),
-    pfcands                         = cms.InputTag('hltParticleFlowReg'),
-    vertices                        = cms.InputTag('hltPixelVertices'),
-    rho                             = cms.InputTag('hltFixedGridRhoFastjetAll'),
-    graph_file                      = cms.vstring(file_names),
-    mem_mapped                      = cms.bool(False),
-    version                         = cms.uint32(2),
-    debug_level                     = cms.int32(0),
-    disable_dxy_pca                 = cms.bool(True),
-    is_online                 		  = cms.bool(True),
-    pfTauTransverseImpactParameters = cms.InputTag('hpsPFTauTransverseImpactParameters'),
-    chargedIsoPtSum                 = cms.InputTag('chargedIsoPtSum'),
-    chargedIsoPtSumdR03             = cms.InputTag('chargedIsoPtSumdR03'),
-    neutralIsoPtSum                 = cms.InputTag('neutralIsoPtSum'),
-    neutralIsoPtSumdR03             = cms.InputTag('neutralIsoPtSumdR03'),
-    puCorrPtSum                     = cms.InputTag('puCorrPtSum'),
-    footprintCorrection             = cms.InputTag('footprintCorrection'),
-    neutralIsoPtSumWeight           = cms.InputTag('neutralIsoPtSumWeight'),
-    neutralIsoPtSumWeightdR03       = cms.InputTag('neutralIsoPtSumWeightdR03'),
-    photonPtSumOutsideSignalCone    = cms.InputTag('photonPtSumOutsideSignalCone'),
-    photonPtSumOutsideSignalConedR03 = cms.InputTag('photonPtSumOutsideSignalConedR03'),
+    taus                                = cms.InputTag("hltHpsPFTauProducerReg"),
+    pfcands                             = cms.InputTag('hltParticleFlowReg'),
+    vertices                            = cms.InputTag('hltPixelVertices'),
+    rho                                 = cms.InputTag('hltFixedGridRhoFastjetAll'),
+    graph_file                          = cms.vstring(file_names),
+    mem_mapped                          = cms.bool(False),
+    version                             = cms.uint32(2),
+    debug_level                         = cms.int32(0),
+    disable_dxy_pca                     = cms.bool(True),
+    is_online                 		    = cms.bool(True),
+    pfTauTransverseImpactParameters     = cms.InputTag('hpsPFTauTransverseImpactParameters'),
+    chargedIsoPtSum_index               = cms.uint32(0),
+    neutralIsoPtSum_index               = cms.uint32(1),
+    puCorrPtSum_index                   = cms.uint32(5),
+    tauFootPrintCorrection_index        = cms.uint32(3),
+    neutralIsoPtSumWeight_index         = cms.uint32(2),
+    photonPtSumOutsideSignalCone_index  = cms.uint32(4),
+    basicTauDiscriminators              = cms.InputTag('hpsPFTauBasicDiscriminators'),
+    basicTauDiscriminatorsdR03          = cms.InputTag('hpsPFTauBasicDiscriminatorsdR03'),
 
     VSeWP = cms.vstring(wp_names),
     VSmuWP = cms.vstring(wp_names),
@@ -349,9 +185,5 @@ def update(process):
 
     #Add DeepTauProducer
     process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.deepTauProducer)
- 
-    process.maxEvents = cms.untracked.PSet(
-        input = cms.untracked.int32(200)
-    )
 
     return process

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -8,6 +8,10 @@ from RecoTauTag.RecoTau.PFTauPrimaryVertexProducer_cfi      import *
 from RecoTauTag.RecoTau.PFTauSecondaryVertexProducer_cfi    import *
 from RecoTauTag.RecoTau.PFTauTransverseImpactParameters_cfi import *
 
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+## DeltaBeta correction factor
+ak4dBetaCorrection = 0.20
+
 def update(process):
     process.options.wantSummary = cms.untracked.bool(True)
 
@@ -32,10 +36,14 @@ def update(process):
     process.hpsPFTauBasicDiscriminators = pfRecoTauDiscriminationByIsolation.clone(
         PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
         Prediscriminants = requireDecayMode.clone(),
+        deltaBetaPUTrackPtCutOverride     = True, # Set the boolean = True to override.
+        deltaBetaPUTrackPtCutOverride_val = 0.5,  # Set the value for new value.
         particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
         vertexSrc = PFTauQualityCuts.primaryVertexSrc,
-        customOuterCone = 0.5,
+        customOuterCone = PFRecoTauPFJetInputs.isolationConeSize,
         isoConeSizeForDeltaBeta = 0.8,
+        deltaBetaFactor = "%0.4f"%(ak4dBetaCorrection),
+        qualityCuts = dict(isolationQualityCuts = dict(minTrackHits = 3, minGammaEt = 1.0, minTrackPt = 0.5)),
         IDdefinitions = cms.VPSet(
             cms.PSet(
                 IDname = cms.string("ChargedIsoPtSum"),
@@ -55,7 +63,6 @@ def update(process):
             ),
             cms.PSet(
                 IDname = cms.string("TauFootprintCorrection"),
-                applyDeltaBetaCorrection = cms.bool(True),
                 storeRawFootprintCorrection = cms.bool(True)
             ),
             cms.PSet(

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -1,0 +1,357 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTauTag.RecoTau.pfRecoTauDiscriminationByIsolation_cfi import *
+from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
+
+
+from RecoTauTag.RecoTau.PFTauPrimaryVertexProducer_cfi      import *
+from RecoTauTag.RecoTau.PFTauSecondaryVertexProducer_cfi    import *
+from RecoTauTag.RecoTau.PFTauTransverseImpactParameters_cfi import *
+
+
+def update(process):
+    process.options.wantSummary = cms.untracked.bool(True)
+
+    process.hltFixedGridRhoFastjetAll = cms.EDProducer( "FixedGridRhoProducerFastjet",
+        gridSpacing = cms.double( 0.55 ),
+        maxRapidity = cms.double( 5.0 ),
+        pfCandidatesTag = cms.InputTag( "hltParticleFlowReg" )
+    )
+
+    PFTauQualityCuts.primaryVertexSrc = cms.InputTag("hltPixelVertices")
+
+    process.chargedIsoPtSum = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = PFTauQualityCuts.primaryVertexSrc,
+        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(True),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(True),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        storeRawPUsumPt = cms.bool(False),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+
+    process.chargedIsoPtSumdR03 = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = PFTauQualityCuts.primaryVertexSrc,
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(True),
+        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(True),
+        storeRawPUsumPt = cms.bool(False),
+        customOuterCone = cms.double(0.3),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+    process.neutralIsoPtSum = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        ApplyDiscriminationByECALIsolation = cms.bool(True),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(True),
+        storeRawPUsumPt = cms.bool(False),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+    process.neutralIsoPtSumdR03 = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        ApplyDiscriminationByECALIsolation = cms.bool(True),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(True),
+        storeRawPUsumPt = cms.bool(False),
+        customOuterCone = cms.double(0.3),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+    process.puCorrPtSum = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(True),
+        storeRawSumPt = cms.bool(False),
+        storeRawPUsumPt = cms.bool(True),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+    requireDecayMode = cms.PSet(
+        BooleanOperator = cms.string("and"),
+        decayMode = cms.PSet(
+            Producer = cms.InputTag('hltHpsPFTauDiscriminationByDecayModeFindingNewDMsReg'),
+            cut = cms.double(0.5)
+        )
+    )
+    process.footprintCorrection = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        Prediscriminants = requireDecayMode.clone(),
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(True),
+        storeRawSumPt = cms.bool(False),
+        storeRawPUsumPt = cms.bool(False),
+        storeRawFootprintCorrection = cms.bool(True),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+    process.footprintCorrectiondR03 = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        Prediscriminants = requireDecayMode.clone(),
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(True),
+        storeRawSumPt = cms.bool(False),
+        storeRawPUsumPt = cms.bool(False),
+        storeRawFootprintCorrection = cms.bool(True),
+        customOuterCone = cms.double(0.3),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+
+    process.neutralIsoPtSumWeight = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        Prediscriminants = requireDecayMode.clone(),
+        ApplyDiscriminationByECALIsolation = cms.bool(True),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        UseAllPFCandsForWeights = cms.bool(True),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(True),
+        storeRawPUsumPt = cms.bool(False),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+
+    process.neutralIsoPtSumWeightdR03 = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        Prediscriminants = requireDecayMode.clone(),
+        ApplyDiscriminationByECALIsolation = cms.bool(True),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        UseAllPFCandsForWeights = cms.bool(True),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(True),
+        storeRawPUsumPt = cms.bool(False),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+
+    process.photonPtSumOutsideSignalCone = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        Prediscriminants = requireDecayMode.clone(),
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(False),
+        storeRawPUsumPt = cms.bool(False),
+        storeRawPhotonSumPt_outsideSignalCone = cms.bool(True),
+        customOuterCone = cms.double(0.5),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+    process.photonPtSumOutsideSignalConedR03 = pfRecoTauDiscriminationByIsolation.clone(
+        PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
+        vertexSrc = cms.InputTag("hltPixelVertices"),
+        Prediscriminants = requireDecayMode.clone(),
+        ApplyDiscriminationByECALIsolation = cms.bool(False),
+        ApplyDiscriminationByTrackerIsolation = cms.bool(False),
+        applyOccupancyCut = cms.bool(False),
+        applySumPtCut = cms.bool(False),
+        applyDeltaBetaCorrection = cms.bool(False),
+        storeRawSumPt = cms.bool(False),
+        storeRawPUsumPt = cms.bool(False),
+        storeRawPhotonSumPt_outsideSignalCone = cms.bool(True),
+        customOuterCone = cms.double(0.3),
+        isoConeSizeForDeltaBeta = cms.double(0.8),
+        verbosity = cms.int32(0),
+        qualityCuts = PFTauQualityCuts
+    )
+
+    process.hpsPFTauPrimaryVertexProducer = PFTauPrimaryVertexProducer.clone(
+        PFTauTag = cms.InputTag("hltHpsPFTauProducerReg"),
+        ElectronTag = cms.InputTag("hltEgammaCandidates"),
+        MuonTag = cms.InputTag("hltMuonsReg"),
+        PVTag = cms.InputTag("hltPixelVertices"),
+        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+        Algorithm = cms.int32(0),
+        useBeamSpot = cms.bool(True),
+        RemoveMuonTracks = cms.bool(False),
+        RemoveElectronTracks = cms.bool(False),
+        useSelectedTaus = cms.bool(False),
+        discriminators = cms.VPSet(
+            cms.PSet(
+                discriminator = cms.InputTag('hltHpsPFTauDiscriminationByDecayModeFindingNewDMsReg'),
+                selectionCut = cms.double(0.5)
+            )
+        ),
+        cut = cms.string("pt > 18.0 & abs(eta) < 2.4"),
+        qualityCuts = cms.PSet(
+            isolationQualityCuts = cms.PSet(
+                maxDeltaZ = cms.double(0.2),
+                maxTrackChi2 = cms.double(100.0),
+                maxTransverseImpactParameter = cms.double(0.03),
+                minGammaEt = cms.double(1.5),
+                minTrackHits = cms.uint32(8),
+                minTrackPixelHits = cms.uint32(0),
+                minTrackPt = cms.double(1.0),
+                minTrackVertexWeight = cms.double(-1.0)
+            ),
+            leadingTrkOrPFCandOption = cms.string('leadPFCand'),
+            primaryVertexSrc = cms.InputTag("hltPixelVertices"),
+            pvFindingAlgo = cms.string('closestInDeltaZ'),
+            recoverLeadingTrk = cms.bool(False),
+            signalQualityCuts = cms.PSet(
+                maxDeltaZ = cms.double(0.4),
+                maxTrackChi2 = cms.double(100.0),
+                maxTransverseImpactParameter = cms.double(0.1),
+                minGammaEt = cms.double(1.0),
+                minNeutralHadronEt = cms.double(30.0),
+                minTrackHits = cms.uint32(3),
+                minTrackPixelHits = cms.uint32(0),
+                minTrackPt = cms.double(0.5),
+                minTrackVertexWeight = cms.double(-1.0)
+            ),
+            vertexTrackFiltering = cms.bool(False),
+            vxAssocQualityCuts = cms.PSet(
+                maxTrackChi2 = cms.double(100.0),
+                maxTransverseImpactParameter = cms.double(0.1),
+                minGammaEt = cms.double(1.0),
+                minTrackHits = cms.uint32(3),
+                minTrackPixelHits = cms.uint32(0),
+                minTrackPt = cms.double(0.5),
+                minTrackVertexWeight = cms.double(-1.0)
+            )
+        )
+    )
+
+    process.hpsPFTauSecondaryVertexProducer = PFTauSecondaryVertexProducer.clone(
+        PFTauTag = cms.InputTag("hltHpsPFTauProducerReg")
+    )
+    process.hpsPFTauTransverseImpactParameters = PFTauTransverseImpactParameters.clone(
+        PFTauTag = cms.InputTag("hltHpsPFTauProducerReg"),
+        PFTauPVATag = cms.InputTag("hpsPFTauPrimaryVertexProducer"),
+        PFTauSVATag = cms.InputTag("hpsPFTauSecondaryVertexProducer"),
+        useFullCalculation = cms.bool(True)
+    )
+
+
+    #Add all sums and corrections for deepTauProducer
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauPrimaryVertexProducer)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauSecondaryVertexProducer)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hpsPFTauTransverseImpactParameters)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.chargedIsoPtSum)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.chargedIsoPtSumdR03)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSum)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSumdR03)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.puCorrPtSum)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.footprintCorrection)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.footprintCorrectiondR03)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSumWeight)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.neutralIsoPtSumWeightdR03)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.photonPtSumOutsideSignalCone)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.photonPtSumOutsideSignalConedR03)
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.hltFixedGridRhoFastjetAll)
+
+
+    file_names = [
+    				'core:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_core.pb',
+    				'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
+    				'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
+    			]
+
+    wp_names = ["0.", "0."]
+
+    process.deepTauProducer = cms.EDProducer("DeepTauId",
+    taus                            = cms.InputTag("hltHpsPFTauProducerReg"),
+    pfcands                         = cms.InputTag('hltParticleFlowReg'),
+    vertices                        = cms.InputTag('hltPixelVertices'),
+    rho                             = cms.InputTag('hltFixedGridRhoFastjetAll'),
+    graph_file                      = cms.vstring(file_names),
+    mem_mapped                      = cms.bool(False),
+    version                         = cms.uint32(2),
+    debug_level                     = cms.int32(0),
+    disable_dxy_pca                 = cms.bool(True),
+    is_online                 		  = cms.bool(True),
+    pfTauTransverseImpactParameters = cms.InputTag('hpsPFTauTransverseImpactParameters'),
+    chargedIsoPtSum                 = cms.InputTag('chargedIsoPtSum'),
+    chargedIsoPtSumdR03             = cms.InputTag('chargedIsoPtSumdR03'),
+    neutralIsoPtSum                 = cms.InputTag('neutralIsoPtSum'),
+    neutralIsoPtSumdR03             = cms.InputTag('neutralIsoPtSumdR03'),
+    puCorrPtSum                     = cms.InputTag('puCorrPtSum'),
+    footprintCorrection             = cms.InputTag('footprintCorrection'),
+    neutralIsoPtSumWeight           = cms.InputTag('neutralIsoPtSumWeight'),
+    neutralIsoPtSumWeightdR03       = cms.InputTag('neutralIsoPtSumWeightdR03'),
+    photonPtSumOutsideSignalCone    = cms.InputTag('photonPtSumOutsideSignalCone'),
+    photonPtSumOutsideSignalConedR03 = cms.InputTag('photonPtSumOutsideSignalConedR03'),
+
+    VSeWP = cms.vstring(wp_names),
+    VSmuWP = cms.vstring(wp_names),
+    VSjetWP = cms.vstring(wp_names)
+    )		
+
+    #Add DeepTauProducer
+    process.HLTHPSMediumChargedIsoPFTauSequenceReg.insert(-1, process.deepTauProducer)
+ 
+    process.maxEvents = cms.untracked.PSet(
+        input = cms.untracked.int32(200)
+    )
+
+    return process

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -68,13 +68,6 @@ def update(process):
                 applyDeltaBetaCorrection = cms.bool(True),
                 storeRawPUsumPt = cms.bool(True)
             ),
-            cms.PSet(
-                IDname = cms.string("ByRawCombinedIsolationDBSumPtCorr3Hits"),
-                ApplyDiscriminationByTrackerIsolation = cms.bool(True),
-                ApplyDiscriminationByECALIsolation = cms.bool(True),
-                applyDeltaBetaCorrection = cms.bool(True),
-                storeRawSumPt = cms.bool(True)
-            )
         ),
     )
 
@@ -179,15 +172,9 @@ def update(process):
     disable_dxy_pca                     = cms.bool(True),
     is_online                 		    = cms.bool(True),
     pfTauTransverseImpactParameters     = cms.InputTag('hpsPFTauTransverseImpactParameters'),
-    chargedIsoPtSum_index               = cms.uint32(0),
-    neutralIsoPtSum_index               = cms.uint32(1),
-    puCorrPtSum_index                   = cms.uint32(5),
-    tauFootPrintCorrection_index        = cms.uint32(3),
-    neutralIsoPtSumWeight_index         = cms.uint32(2),
-    photonPtSumOutsideSignalCone_index  = cms.uint32(4),
-    basicTauDiscriminators              = cms.InputTag('hpsPFTauBasicDiscriminators'),
-    basicTauDiscriminatorsdR03          = cms.InputTag('hpsPFTauBasicDiscriminatorsdR03'),
-    Prediscriminants = requireDecayMode.clone(),
+    basicTauDiscriminators              = cms.untracked.InputTag('hpsPFTauBasicDiscriminators'),
+    basicTauDiscriminatorsdR03          = cms.untracked.InputTag('hpsPFTauBasicDiscriminatorsdR03'),
+    Prediscriminants                    = requireDecayMode.clone(),
 
     VSeWP = cms.vstring(wp_names),
     VSmuWP = cms.vstring(wp_names),

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# from RecoTauTag.RecoTau.pfRecoTauDiscriminationByIsolation_cfi import *
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByIsolation_cfi import *
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
 

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -8,20 +8,6 @@ from RecoTauTag.RecoTau.PFTauPrimaryVertexProducer_cfi      import *
 from RecoTauTag.RecoTau.PFTauSecondaryVertexProducer_cfi    import *
 from RecoTauTag.RecoTau.PFTauTransverseImpactParameters_cfi import *
 
-def processDeepProducer(self, producer_name, tauIDSources, workingPoints_):
-    for target,points in six.iteritems(workingPoints_):
-        setattr(tauIDSources, 'by{}VS{}raw'.format(producer_name[0].upper()+producer_name[1:], target),
-                    cms.PSet(inputTag = cms.InputTag(producer_name, 'VS{}'.format(target)), workingPointIndex = cms.int32(-1)))
-        
-        cut_expressions = []
-        for index, (point,cut) in enumerate(six.iteritems(points)):
-            cut_expressions.append(str(cut))
-
-            setattr(tauIDSources, 'by{}{}VS{}'.format(point, producer_name[0].upper()+producer_name[1:], target),
-                    cms.PSet(inputTag = cms.InputTag(producer_name, 'VS{}'.format(target)), workingPointIndex = cms.int32(index)))
-
-        setattr(getattr(self.process, producer_name), 'VS{}WP'.format(target), cms.vstring(*cut_expressions))
-
 def update(process):
     process.options.wantSummary = cms.untracked.bool(True)
 

--- a/HLTrigger/Configuration/python/deepTauAtHLT.py
+++ b/HLTrigger/Configuration/python/deepTauAtHLT.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByIsolation_cfi import *
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
+from RecoTauTag.RecoTau.PFRecoTauDiscriminationByHPSSelection_cfi import hpsSelectionDiscriminator, decayMode_1Prong0Pi0, decayMode_1Prong1Pi0, decayMode_1Prong2Pi0, decayMode_2Prong0Pi0, decayMode_2Prong1Pi0, decayMode_3Prong0Pi0, decayMode_3Prong1Pi0
 
 from RecoTauTag.RecoTau.PFTauPrimaryVertexProducer_cfi      import *
 from RecoTauTag.RecoTau.PFTauSecondaryVertexProducer_cfi    import *
@@ -18,12 +19,22 @@ def update(process):
 
     PFTauQualityCuts.primaryVertexSrc = cms.InputTag("hltPixelVertices")
 
+    ## Decay mode prediscriminant
+    requireDecayMode = cms.PSet(
+        BooleanOperator = cms.string("and"),
+        decayMode = cms.PSet(
+            Producer = cms.InputTag('hltHpsPFTauDiscriminationByDecayModeFindingNewDMsReg'),
+            cut = cms.double(0.5)
+        )
+    )
+
     ## Cut based isolations dR=0.5
     process.hpsPFTauBasicDiscriminators = pfRecoTauDiscriminationByIsolation.clone(
         PFTauProducer = cms.InputTag('hltHpsPFTauProducerReg'),
+        Prediscriminants = requireDecayMode.clone(),
+        # Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
         particleFlowSrc = cms.InputTag("hltParticleFlowReg"),
         vertexSrc = PFTauQualityCuts.primaryVertexSrc,
-        Prediscriminants = cms.PSet(  BooleanOperator = cms.string( "and" ) ),
         customOuterCone = 0.5,
         isoConeSizeForDeltaBeta = 0.8,
         IDdefinitions = cms.VPSet(
@@ -176,6 +187,7 @@ def update(process):
     photonPtSumOutsideSignalCone_index  = cms.uint32(4),
     basicTauDiscriminators              = cms.InputTag('hpsPFTauBasicDiscriminators'),
     basicTauDiscriminatorsdR03          = cms.InputTag('hpsPFTauBasicDiscriminatorsdR03'),
+    Prediscriminants = requireDecayMode.clone(),
 
     VSeWP = cms.vstring(wp_names),
     VSmuWP = cms.vstring(wp_names),

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -115,6 +115,28 @@ namespace deep_tau {
     std::vector<TauDiscInfo<pat::PATTauDiscriminator>> patPrediscriminants_;
     std::vector<TauDiscInfo<reco::PFTauDiscriminator>> recoPrediscriminants_;
 
+    enum BasicDiscriminator {
+      ChargedIsoPtSum,
+      NeutralIsoPtSum,
+      NeutralIsoPtSumWeight,
+      FootprintCorrection,
+      PhotonPtSumOutsideSignalCone,
+      PUcorrPtSum
+    };
+
+    std::map<BasicDiscriminator, std::string> stringFromDiscriminator_{
+        {ChargedIsoPtSum, "ChargedIsoPtSum"},
+        {NeutralIsoPtSum, "NeutralIsoPtSum"},
+        {NeutralIsoPtSumWeight, "NeutralIsoPtSumWeight"},
+        {FootprintCorrection, "TauFootprintCorrection"},
+        {PhotonPtSumOutsideSignalCone, "PhotonPtSumOutsideSignalCone"},
+        {PUcorrPtSum, "PUcorrPtSum"}};
+
+    std::vector<BasicDiscriminator> requiredBasicDiscriminators = {
+        ChargedIsoPtSum, NeutralIsoPtSum, NeutralIsoPtSumWeight, PhotonPtSumOutsideSignalCone, PUcorrPtSum};
+    std::vector<BasicDiscriminator> requiredBasicDiscriminatorsdR03 = {
+        ChargedIsoPtSum, NeutralIsoPtSum, NeutralIsoPtSumWeight, PhotonPtSumOutsideSignalCone, FootprintCorrection};
+
   private:
     virtual tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) = 0;
     virtual void createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -30,7 +30,11 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Provenance/interface/ProductProvenance.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "FWCore/Common/interface/Provenance.h"
 #include <TF1.h>
+#include <map>
 
 namespace deep_tau {
 

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -20,6 +20,7 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/TauReco/interface/TauDiscriminatorContainer.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "DataFormats/PatCandidates/interface/PATTauDiscriminator.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterFwd.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameter.h"
@@ -28,6 +29,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/RefToBase.h"
 #include <TF1.h>
 
 namespace deep_tau {
@@ -94,6 +96,20 @@ namespace deep_tau {
 
     static std::unique_ptr<DeepTauCache> initializeGlobalCache(const edm::ParameterSet& cfg);
     static void globalEndJob(const DeepTauCache* cache) {}
+
+    template <typename ConsumeType>
+    struct TauDiscInfo {
+      edm::InputTag label;
+      edm::Handle<ConsumeType> handle;
+      edm::EDGetTokenT<ConsumeType> disc_token;
+      double cut;
+      void fill(const edm::Event& evt) { evt.getByToken(disc_token, handle); };
+    };
+
+    // select boolean operation on prediscriminants (and = 0x01, or = 0x00)
+    uint8_t andPrediscriminants_;
+    std::vector<TauDiscInfo<pat::PATTauDiscriminator>> patPrediscriminants_;
+    std::vector<TauDiscInfo<reco::PFTauDiscriminator>> recoPrediscriminants_;
 
   private:
     virtual tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) = 0;

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -133,13 +133,13 @@ namespace deep_tau {
     edm::EDGetTokenT<CandidateType> pfcandToken_;
     edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
     std::map<std::string, WPList> workingPoints_;
-    const bool is_online;
+    const bool is_online_;
     OutputCollection outputs_;
     const DeepTauCache* cache_;
 
     static const std::map<BasicDiscriminator, std::string> stringFromDiscriminator_;
-    static const std::vector<BasicDiscriminator> requiredBasicDiscriminators;
-    static const std::vector<BasicDiscriminator> requiredBasicDiscriminatorsdR03;
+    static const std::vector<BasicDiscriminator> requiredBasicDiscriminators_;
+    static const std::vector<BasicDiscriminator> requiredBasicDiscriminatorsdR03_;
   };
 
 }  // namespace deep_tau

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -62,9 +62,8 @@ namespace deep_tau {
 
   class DeepTauBase : public edm::stream::EDProducer<edm::GlobalCache<DeepTauCache>> {
   public:
-    using TauType = edm::View<reco::BaseTau>;
     using TauDiscriminator = reco::TauDiscriminatorContainer;
-    using TauCollection = TauType;
+    using TauCollection = edm::View<reco::BaseTau>;
     using CandidateType = edm::View<reco::Candidate>;
     using TauRef = edm::Ref<TauCollection>;
     using TauRefProd = edm::RefProd<TauCollection>;

--- a/RecoTauTag/RecoTau/interface/DeepTauBase.h
+++ b/RecoTauTag/RecoTau/interface/DeepTauBase.h
@@ -124,19 +124,6 @@ namespace deep_tau {
       PUcorrPtSum
     };
 
-    std::map<BasicDiscriminator, std::string> stringFromDiscriminator_{
-        {ChargedIsoPtSum, "ChargedIsoPtSum"},
-        {NeutralIsoPtSum, "NeutralIsoPtSum"},
-        {NeutralIsoPtSumWeight, "NeutralIsoPtSumWeight"},
-        {FootprintCorrection, "TauFootprintCorrection"},
-        {PhotonPtSumOutsideSignalCone, "PhotonPtSumOutsideSignalCone"},
-        {PUcorrPtSum, "PUcorrPtSum"}};
-
-    std::vector<BasicDiscriminator> requiredBasicDiscriminators = {
-        ChargedIsoPtSum, NeutralIsoPtSum, NeutralIsoPtSumWeight, PhotonPtSumOutsideSignalCone, PUcorrPtSum};
-    std::vector<BasicDiscriminator> requiredBasicDiscriminatorsdR03 = {
-        ChargedIsoPtSum, NeutralIsoPtSum, NeutralIsoPtSumWeight, PhotonPtSumOutsideSignalCone, FootprintCorrection};
-
   private:
     virtual tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) = 0;
     virtual void createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus);
@@ -149,6 +136,10 @@ namespace deep_tau {
     const bool is_online;
     OutputCollection outputs_;
     const DeepTauCache* cache_;
+
+    static const std::map<BasicDiscriminator, std::string> stringFromDiscriminator_;
+    static const std::vector<BasicDiscriminator> requiredBasicDiscriminators;
+    static const std::vector<BasicDiscriminator> requiredBasicDiscriminatorsdR03;
   };
 
 }  // namespace deep_tau

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -428,102 +428,102 @@ namespace {
 
     const float getChargedIsoPtSum(const reco::PFTau& tau,
                                    const size_t tau_index,
-                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                   const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(chargedIsoPtSum_index);
     }
     const float getChargedIsoPtSum(const pat::Tau& tau,
                                    const size_t tau_index,
-                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                   const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("chargedIsoPtSum");
     }
     const float getChargedIsoPtSumdR03(const reco::PFTau& tau,
                                        const size_t tau_index,
-                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                       const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(chargedIsoPtSum_index);
     }
     const float getChargedIsoPtSumdR03(const pat::Tau& tau,
                                        const size_t tau_index,
-                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                       const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("chargedIsoPtSumdR03");
     }
     const float getFootprintCorrectiondR03(const reco::PFTau& tau,
                                            const size_t tau_index,
-                                           const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                           const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(tauFootPrintCorrection_index);
     }
     const float getFootprintCorrectiondR03(const pat::Tau& tau,
                                            const size_t tau_index,
-                                           const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                           const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("footprintCorrectiondR03");
     }
     const float getNeutralIsoPtSum(const reco::PFTau& tau,
                                    const size_t tau_index,
-                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                   const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(neutralIsoPtSum_index);
     }
     const float getNeutralIsoPtSum(const pat::Tau& tau,
                                    const size_t tau_index,
-                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                   const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("neutralIsoPtSum");
     }
     const float getNeutralIsoPtSumdR03(const reco::PFTau& tau,
                                        const size_t tau_index,
-                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                       const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(neutralIsoPtSum_index);
     }
     const float getNeutralIsoPtSumdR03(const pat::Tau& tau,
                                        const size_t tau_index,
-                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                       const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("neutralIsoPtSumdR03");
     }
     const float getNeutralIsoPtSumWeight(const reco::PFTau& tau,
                                          const size_t tau_index,
-                                         const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                         const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(neutralIsoPtSumWeight_index);
     }
     const float getNeutralIsoPtSumWeight(const pat::Tau& tau,
                                          const size_t tau_index,
-                                         const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                         const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("neutralIsoPtSumWeight");
     }
     const float getNeutralIsoPtSumdR03Weight(const reco::PFTau& tau,
                                              const size_t tau_index,
-                                             const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                             const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(neutralIsoPtSumWeight_index);
     }
     const float getNeutralIsoPtSumdR03Weight(const pat::Tau& tau,
                                              const size_t tau_index,
-                                             const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                             const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("neutralIsoPtSumWeightdR03");
     }
     const float getPhotonPtSumOutsideSignalCone(const reco::PFTau& tau,
                                                 const size_t tau_index,
-                                                const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                                const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(photonPtSumOutsideSignalCone_index);
     }
     const float getPhotonPtSumOutsideSignalCone(const pat::Tau& tau,
                                                 const size_t tau_index,
-                                                const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                                const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("photonPtSumOutsideSignalCone");
     }
     const float getPhotonPtSumOutsideSignalConedR03(const reco::PFTau& tau,
                                                     const size_t tau_index,
-                                                    const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                                    const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(photonPtSumOutsideSignalCone_index);
     }
     const float getPhotonPtSumOutsideSignalConedR03(const pat::Tau& tau,
                                                     const size_t tau_index,
-                                                    const deep_tau::DeepTauBase::TauRef tau_ref) {
+                                                    const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("photonPtSumOutsideSignalConedR03");
     }
     const float getPuCorrPtSum(const reco::PFTau& tau,
                                const size_t tau_index,
-                               const deep_tau::DeepTauBase::TauRef tau_ref) {
+                               const edm::RefToBase<reco::BaseTau> tau_ref) {
       return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(puCorrPtSum_index);
     }
     const float getPuCorrPtSum(const pat::Tau& tau,
                                const size_t tau_index,
-                               const deep_tau::DeepTauBase::TauRef tau_ref) {
+                               const edm::RefToBase<reco::BaseTau> tau_ref) {
       return tau.tauID("puCorrPtSum");
     }
 
@@ -629,6 +629,42 @@ namespace {
       return leadChargedHadrCand->hcalEnergy();
     }
     auto getHcalEnergyLeadingChargedHadr(const pat::Tau& tau) { return tau.hcalEnergyLeadChargedHadrCand(); }
+
+    template <typename PreDiscrType>
+    bool passPrediscriminants(const PreDiscrType prediscriminants,
+                              const size_t andPrediscriminants,
+                              const edm::RefToBase<reco::BaseTau> tau_ref) {
+      bool passesPrediscriminants = (andPrediscriminants ? 1 : 0);
+      // check tau passes prediscriminants
+      size_t nPrediscriminants = prediscriminants.size();
+      for (size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc) {
+        // current discriminant result for this tau
+        double discResult = (*prediscriminants[iDisc].handle)[tau_ref];
+        uint8_t thisPasses = (discResult > prediscriminants[iDisc].cut) ? 1 : 0;
+
+        // if we are using the AND option, as soon as one fails,
+        // the result is FAIL and we can quit looping.
+        // if we are using the OR option as soon as one passes,
+        // the result is pass and we can quit looping
+
+        // truth table
+        //        |   result (thisPasses)
+        //        |     F     |     T
+        //-----------------------------------
+        // AND(T) | res=fails |  continue
+        //        |  break    |
+        //-----------------------------------
+        // OR (F) |  continue | res=passes
+        //        |           |  break
+
+        if (thisPasses ^ andPrediscriminants)  //XOR
+        {
+          passesPrediscriminants = (andPrediscriminants ? 0 : 1);  //NOR
+          break;
+        }
+      }
+      return passesPrediscriminants;
+    }
   };
 
   struct lightLepFunc {
@@ -1166,6 +1202,18 @@ public:
     desc.add<edm::InputTag>("basicTauDiscriminatorsdR03", edm::InputTag("basicTauDiscriminatorsdR03"));
     desc.add<edm::InputTag>("pfTauTransverseImpactParameters", edm::InputTag("hpsPFTauTransverseImpactParameters"));
 
+    {
+      edm::ParameterSetDescription pset_Prediscriminants;
+      pset_Prediscriminants.add<std::string>("BooleanOperator", "and");
+      {
+        edm::ParameterSetDescription psd1;
+        psd1.add<double>("cut");
+        psd1.add<edm::InputTag>("Producer");
+        pset_Prediscriminants.addOptional<edm::ParameterSetDescription>("decayMode", psd1);
+      }
+      desc.add<edm::ParameterSetDescription>("Prediscriminants", pset_Prediscriminants);
+    }
+
     descriptions.add("DeepTau", desc);
   }
 
@@ -1324,15 +1372,17 @@ private:
       event.getByToken(basicTauDiscriminatorsdR03_inputToken, basicTauDiscriminatorsdR03);
     }
 
-    tauFunc tauIDs = {basicTauDiscriminators,
-                      basicTauDiscriminatorsdR03,
-                      PFTauTransverseImpactParameters,
-                      chargedIsoPtSum_index,
-                      neutralIsoPtSum_index,
-                      neutralIsoPtSumWeight_index,
-                      tauFootPrintCorrection_index,
-                      photonPtSumOutsideSignalCone_index,
-                      puCorrPtSum_index};
+    tauFunc tauIDs = {
+        basicTauDiscriminators,
+        basicTauDiscriminatorsdR03,
+        PFTauTransverseImpactParameters,
+        chargedIsoPtSum_index,
+        neutralIsoPtSum_index,
+        neutralIsoPtSumWeight_index,
+        tauFootPrintCorrection_index,
+        photonPtSumOutsideSignalCone_index,
+        puCorrPtSum_index,
+    };
 
     lightLepFunc lightlep = {tmp_electrons, tmp_muons};
 
@@ -1349,49 +1399,63 @@ private:
     event.getByToken(rho_token_, rho);
 
     tensorflow::Tensor predictions(tensorflow::DT_FLOAT, {static_cast<int>(taus->size()), deep_tau::NumberOfOutputs});
+
     for (size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
+      const edm::RefToBase<reco::BaseTau> tauRef = taus->refAt(tau_index);
+
       std::vector<tensorflow::Tensor> pred_vector;
-      const deep_tau::DeepTauBase::TauRef tauRef(taus, tau_index);
-      if (version == 1) {
-        if (is_online)
-          getPredictionsV1<reco::PFCandidate, reco::PFTau>(
-              taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
-        else
-          getPredictionsV1<pat::PackedCandidate, pat::Tau>(
-              taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
-      } else if (version == 2) {
-        if (is_online) {
-          getPredictionsV2<reco::PFCandidate, reco::PFTau>(taus->at(tau_index),
-                                                           tau_index,
-                                                           tauRef,
-                                                           electrons,
-                                                           muons,
-                                                           *pfCands,
-                                                           vertices->at(0),
-                                                           *rho,
-                                                           pred_vector,
-                                                           tauIDs);
-        } else
-          getPredictionsV2<pat::PackedCandidate, pat::Tau>(taus->at(tau_index),
-                                                           tau_index,
-                                                           tauRef,
-                                                           electrons,
-                                                           muons,
-                                                           *pfCands,
-                                                           vertices->at(0),
-                                                           *rho,
-                                                           pred_vector,
-                                                           tauIDs);
+
+      bool passesPrediscriminants;
+      if (is_online) {
+        passesPrediscriminants = tauIDs.passPrediscriminants<std::vector<TauDiscInfo<reco::PFTauDiscriminator>>>(
+            recoPrediscriminants_, andPrediscriminants_, tauRef);
       } else {
-        throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+        passesPrediscriminants = tauIDs.passPrediscriminants<std::vector<TauDiscInfo<pat::PATTauDiscriminator>>>(
+            patPrediscriminants_, andPrediscriminants_, tauRef);
       }
 
-      for (int k = 0; k < deep_tau::NumberOfOutputs; ++k) {
-        const float pred = pred_vector[0].flat<float>()(k);
-        if (!(pred >= 0 && pred <= 1))
-          throw cms::Exception("DeepTauId")
-              << "invalid prediction = " << pred << " for tau_index = " << tau_index << ", pred_index = " << k;
-        predictions.matrix<float>()(tau_index, k) = pred;
+      if (passesPrediscriminants) {
+        if (version == 1) {
+          if (is_online)
+            getPredictionsV1<reco::PFCandidate, reco::PFTau>(
+                taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
+          else
+            getPredictionsV1<pat::PackedCandidate, pat::Tau>(
+                taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
+        } else if (version == 2) {
+          if (is_online) {
+            getPredictionsV2<reco::PFCandidate, reco::PFTau>(taus->at(tau_index),
+                                                             tau_index,
+                                                             tauRef,
+                                                             electrons,
+                                                             muons,
+                                                             *pfCands,
+                                                             vertices->at(0),
+                                                             *rho,
+                                                             pred_vector,
+                                                             tauIDs);
+          } else
+            getPredictionsV2<pat::PackedCandidate, pat::Tau>(taus->at(tau_index),
+                                                             tau_index,
+                                                             tauRef,
+                                                             electrons,
+                                                             muons,
+                                                             *pfCands,
+                                                             vertices->at(0),
+                                                             *rho,
+                                                             pred_vector,
+                                                             tauIDs);
+        } else {
+          throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+        }
+
+        for (int k = 0; k < deep_tau::NumberOfOutputs; ++k) {
+          const float pred = pred_vector[0].flat<float>()(k);
+          if (!(pred >= 0 && pred <= 1))
+            throw cms::Exception("DeepTauId")
+                << "invalid prediction = " << pred << " for tau_index = " << tau_index << ", pred_index = " << k;
+          predictions.matrix<float>()(tau_index, k) = pred;
+        }
       }
     }
     return predictions;
@@ -1400,7 +1464,7 @@ private:
   template <typename CandidateCastType, typename TauCastType>
   void getPredictionsV1(const TauCollection::const_reference& tau,
                         const size_t tau_index,
-                        const deep_tau::DeepTauBase::TauRef tau_ref,
+                        const edm::RefToBase<reco::BaseTau> tau_ref,
                         const std::vector<pat::Electron>& electrons,
                         const std::vector<pat::Muon>& muons,
                         std::vector<tensorflow::Tensor>& pred_vector,
@@ -1413,7 +1477,7 @@ private:
   template <typename CandidateCastType, typename TauCastType>
   void getPredictionsV2(const TauCollection::const_reference& tau,
                         const size_t tau_index,
-                        const deep_tau::DeepTauBase::TauRef tau_ref,
+                        const edm::RefToBase<reco::BaseTau> tau_ref,
                         const std::vector<pat::Electron>& electrons,
                         const std::vector<pat::Muon>& muons,
                         const edm::View<reco::Candidate>& pfCands,
@@ -1524,7 +1588,7 @@ private:
   template <typename CandidateCastType, typename TauCastType>
   void createConvFeatures(const TauCastType& tau,
                           const size_t tau_index,
-                          const deep_tau::DeepTauBase::TauRef tau_ref,
+                          const edm::RefToBase<reco::BaseTau> tau_ref,
                           const reco::Vertex& pv,
                           double rho,
                           const std::vector<pat::Electron>& electrons,
@@ -1600,7 +1664,7 @@ private:
   template <typename CandidateCastType, typename TauCastType>
   void createTauBlockInputs(const TauCastType& tau,
                             const size_t& tau_index,
-                            const deep_tau::DeepTauBase::TauRef tau_ref,
+                            const edm::RefToBase<reco::BaseTau> tau_ref,
                             const reco::Vertex& pv,
                             double rho,
                             tauFunc tau_funcs) {
@@ -1711,7 +1775,7 @@ private:
   void createEgammaBlockInputs(unsigned idx,
                                const TauCastType& tau,
                                const size_t tau_index,
-                               const deep_tau::DeepTauBase::TauRef tau_ref,
+                               const edm::RefToBase<reco::BaseTau> tau_ref,
                                const reco::Vertex& pv,
                                double rho,
                                const std::vector<pat::Electron>& electrons,
@@ -1952,7 +2016,7 @@ private:
   void createMuonBlockInputs(unsigned idx,
                              const TauCastType& tau,
                              const size_t tau_index,
-                             const deep_tau::DeepTauBase::TauRef tau_ref,
+                             const edm::RefToBase<reco::BaseTau> tau_ref,
                              const reco::Vertex& pv,
                              double rho,
                              const std::vector<pat::Muon>& muons,
@@ -2103,7 +2167,7 @@ private:
   void createHadronsBlockInputs(unsigned idx,
                                 const TauCastType& tau,
                                 const size_t tau_index,
-                                const deep_tau::DeepTauBase::TauRef tau_ref,
+                                const edm::RefToBase<reco::BaseTau> tau_ref,
                                 const reco::Vertex& pv,
                                 double rho,
                                 const edm::View<reco::Candidate>& pfCands,
@@ -2222,7 +2286,7 @@ private:
   template <typename dnn, typename CandidateCastType, typename TauCastType>
   tensorflow::Tensor createInputsV1(const TauCastType& tau,
                                     const size_t tau_index,
-                                    const deep_tau::DeepTauBase::TauRef tau_ref,
+                                    const edm::RefToBase<reco::BaseTau> tau_ref,
                                     const std::vector<pat::Electron>& electrons,
                                     const std::vector<pat::Muon>& muons,
                                     tauFunc tau_funcs) const {

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -414,90 +414,171 @@ namespace {
     }
   }  // namespace dnn_inputs_2017_v2
 
-  struct tauFunc{
+  struct tauFunc {
+    edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminatorCollection;
+    edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminatordR03Collection;
+    edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
+        PFTauTransverseImpactParameters;
+    const unsigned chargedIsoPtSum_index;
+    const unsigned neutralIsoPtSum_index;
+    const unsigned neutralIsoPtSumWeight_index;
+    const unsigned tauFootPrintCorrection_index;
+    const unsigned photonPtSumOutsideSignalCone_index;
+    const unsigned puCorrPtSum_index;
 
-    const reco::PFTauDiscriminator& chargedIsoPtSumCollection;
-    const reco::PFTauDiscriminator& chargedIsoPtSumdR03Collection;
-    const reco::PFTauDiscriminator& neutralIsoPtSumCollection;
-    const reco::PFTauDiscriminator& neutralIsoPtSumdR03Collection;
-    const reco::PFTauDiscriminator& puCorrPtSumCollection;
-    const reco::PFTauDiscriminator& footprintCorrectionCollection;
-    const reco::PFTauDiscriminator& neutralIsoPtSumWeightCollection;
-    const reco::PFTauDiscriminator& neutralIsoPtSumWeightdR03Collection;
-    const reco::PFTauDiscriminator& photonPtSumOutsideSignalConeCollection;
-    const reco::PFTauDiscriminator& photonPtSumOutsideSignalConedR03Collection;
-    edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>> PFTauTransverseImpactParameters;
+    const float getChargedIsoPtSum(const reco::PFTau& tau,
+                                   const size_t tau_index,
+                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(chargedIsoPtSum_index);
+    }
+    const float getChargedIsoPtSum(const pat::Tau& tau,
+                                   const size_t tau_index,
+                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("chargedIsoPtSum");
+    }
+    const float getChargedIsoPtSumdR03(const reco::PFTau& tau,
+                                       const size_t tau_index,
+                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(chargedIsoPtSum_index);
+    }
+    const float getChargedIsoPtSumdR03(const pat::Tau& tau,
+                                       const size_t tau_index,
+                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("chargedIsoPtSumdR03");
+    }
+    const float getFootprintCorrectiondR03(const reco::PFTau& tau,
+                                           const size_t tau_index,
+                                           const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(tauFootPrintCorrection_index);
+    }
+    const float getFootprintCorrectiondR03(const pat::Tau& tau,
+                                           const size_t tau_index,
+                                           const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("footprintCorrectiondR03");
+    }
+    const float getNeutralIsoPtSum(const reco::PFTau& tau,
+                                   const size_t tau_index,
+                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(neutralIsoPtSum_index);
+    }
+    const float getNeutralIsoPtSum(const pat::Tau& tau,
+                                   const size_t tau_index,
+                                   const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("neutralIsoPtSum");
+    }
+    const float getNeutralIsoPtSumdR03(const reco::PFTau& tau,
+                                       const size_t tau_index,
+                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(neutralIsoPtSum_index);
+    }
+    const float getNeutralIsoPtSumdR03(const pat::Tau& tau,
+                                       const size_t tau_index,
+                                       const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("neutralIsoPtSumdR03");
+    }
+    const float getNeutralIsoPtSumWeight(const reco::PFTau& tau,
+                                         const size_t tau_index,
+                                         const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(neutralIsoPtSumWeight_index);
+    }
+    const float getNeutralIsoPtSumWeight(const pat::Tau& tau,
+                                         const size_t tau_index,
+                                         const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("neutralIsoPtSumWeight");
+    }
+    const float getNeutralIsoPtSumdR03Weight(const reco::PFTau& tau,
+                                             const size_t tau_index,
+                                             const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(neutralIsoPtSumWeight_index);
+    }
+    const float getNeutralIsoPtSumdR03Weight(const pat::Tau& tau,
+                                             const size_t tau_index,
+                                             const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("neutralIsoPtSumWeightdR03");
+    }
+    const float getPhotonPtSumOutsideSignalCone(const reco::PFTau& tau,
+                                                const size_t tau_index,
+                                                const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(photonPtSumOutsideSignalCone_index);
+    }
+    const float getPhotonPtSumOutsideSignalCone(const pat::Tau& tau,
+                                                const size_t tau_index,
+                                                const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("photonPtSumOutsideSignalCone");
+    }
+    const float getPhotonPtSumOutsideSignalConedR03(const reco::PFTau& tau,
+                                                    const size_t tau_index,
+                                                    const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(photonPtSumOutsideSignalCone_index);
+    }
+    const float getPhotonPtSumOutsideSignalConedR03(const pat::Tau& tau,
+                                                    const size_t tau_index,
+                                                    const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("photonPtSumOutsideSignalConedR03");
+    }
+    const float getPuCorrPtSum(const reco::PFTau& tau,
+                               const size_t tau_index,
+                               const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(puCorrPtSum_index);
+    }
+    const float getPuCorrPtSum(const pat::Tau& tau,
+                               const size_t tau_index,
+                               const deep_tau::DeepTauBase::TauRef tau_ref) {
+      return tau.tauID("puCorrPtSum");
+    }
 
-    const float getChargedIsoPtSum(const reco::PFTau& tau, size_t tau_index) {return chargedIsoPtSumCollection.value(tau_index);}
-    const float getChargedIsoPtSum(const pat::Tau& tau, size_t tau_index)  {return tau.tauID("chargedIsoPtSum");}
-
-    const float getChargedIsoPtSumdR03(const reco::PFTau& tau, size_t tau_index) {  return chargedIsoPtSumdR03Collection.value(tau_index);}
-    const float getChargedIsoPtSumdR03(const pat::Tau& tau, size_t tau_index) {  return tau.tauID("chargedIsoPtSumdR03");}
-
-    const float getFootprintCorrectiondR03(const reco::PFTau& tau, size_t tau_index) {  return footprintCorrectionCollection.value(tau_index);}
-    const float getFootprintCorrectiondR03(const pat::Tau& tau, size_t tau_index) {     return tau.tauID("footprintCorrectiondR03");}
-
-
-    const float getNeutralIsoPtSum(const reco::PFTau& tau, size_t tau_index) {  return neutralIsoPtSumCollection.value(tau_index);}
-    const float getNeutralIsoPtSum(const pat::Tau& tau, size_t tau_index) {  return tau.tauID("neutralIsoPtSum");}
-
-    const float getNeutralIsoPtSumdR03(const reco::PFTau& tau, size_t tau_index) {  return neutralIsoPtSumdR03Collection.value(tau_index);}
-    const float getNeutralIsoPtSumdR03(const pat::Tau& tau, size_t tau_index)   {return tau.tauID("neutralIsoPtSumdR03");}
-
-
-    const float getNeutralIsoPtSumWeight(const reco::PFTau& tau, size_t tau_index) { return neutralIsoPtSumWeightCollection.value(tau_index);}
-    const float getNeutralIsoPtSumWeight(const pat::Tau& tau, size_t tau_index) {return tau.tauID("neutralIsoPtSumWeight");}
-
-
-    const float getNeutralIsoPtSumdR03Weight(const reco::PFTau& tau, size_t tau_index) { return neutralIsoPtSumWeightdR03Collection.value(tau_index);}
-    const float getNeutralIsoPtSumdR03Weight(const pat::Tau& tau, size_t tau_index) {return tau.tauID("neutralIsoPtSumWeightdR03");}
-
-
-    const float getPhotonPtSumOutsideSignalCone(const reco::PFTau& tau, size_t tau_index) { return photonPtSumOutsideSignalConeCollection.value(tau_index);}
-    const float getPhotonPtSumOutsideSignalCone(const pat::Tau& tau, size_t tau_index) {return tau.tauID("photonPtSumOutsideSignalCone");}
-
-
-    const float getPhotonPtSumOutsideSignalConedR03(const reco::PFTau& tau, size_t tau_index) {  return photonPtSumOutsideSignalConedR03Collection.value(tau_index);}
-    const float getPhotonPtSumOutsideSignalConedR03(const pat::Tau& tau, size_t tau_index) {return tau.tauID("photonPtSumOutsideSignalConedR03");}
-
-
-    const float getPuCorrPtSum(const reco::PFTau& tau, size_t tau_index) { return puCorrPtSumCollection.value(tau_index);}
-    const float getPuCorrPtSum(const pat::Tau& tau, size_t tau_index) { return tau.tauID("puCorrPtSum");}
-
-    auto getdxyPCA(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy_PCA();}
-    auto getdxyPCA(const pat::Tau& tau, size_t tau_index) {return tau.dxy_PCA();}
-    auto getdxy(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy();}
-    auto getdxy(const pat::Tau& tau, size_t tau_index) {return tau.dxy();}
-    auto getdxyError(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy_error();}
-    auto getdxyError(const pat::Tau& tau, size_t tau_index) {return tau.dxy_error();}
-    auto getdxySig(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy_Sig();}
-    auto getdxySig(const pat::Tau& tau, size_t tau_index) {return tau.dxy_Sig();}
-    auto getip3d(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->ip3d();}
-    auto getip3d(const pat::Tau& tau, size_t tau_index) {return tau.ip3d();}
-    auto getip3dError(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->ip3d_error();}
-    auto getip3dError(const pat::Tau& tau, size_t tau_index) {return tau.ip3d_error();}
-    auto getip3dSig(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->ip3d_Sig();}
-    auto getip3dSig(const pat::Tau& tau, size_t tau_index) {return tau.ip3d_Sig();}
-    auto getHasSecondaryVertex(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->hasSecondaryVertex();}
-    auto getHasSecondaryVertex(const pat::Tau& tau, size_t tau_index) {return tau.hasSecondaryVertex();}
-    auto getFlightLength(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->flightLength();}
-    auto getFlightLength(const pat::Tau& tau, size_t tau_index) {return tau.flightLength();}
-    auto getFlightLengthSig(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->flightLengthSig();}
-    auto getFlightLengthSig(const pat::Tau& tau, size_t tau_index) {return tau.flightLengthSig();}
-
-    auto getLeadingTrackNormChi2(const reco::PFTau& tau) {return reco::tau::lead_track_chi2(tau);}
-    auto getLeadingTrackNormChi2(const pat::Tau& tau) {return tau.leadingTrackNormChi2();}
-
-    auto getEmFraction(const pat::Tau& tau) {return tau.emFraction_MVA();}
+    auto getdxyPCA(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->dxy_PCA();
+    }
+    auto getdxyPCA(const pat::Tau& tau, const size_t tau_index) { return tau.dxy_PCA(); }
+    auto getdxy(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->dxy();
+    }
+    auto getdxy(const pat::Tau& tau, const size_t tau_index) { return tau.dxy(); }
+    auto getdxyError(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->dxy_error();
+    }
+    auto getdxyError(const pat::Tau& tau, const size_t tau_index) { return tau.dxy_error(); }
+    auto getdxySig(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->dxy_Sig();
+    }
+    auto getdxySig(const pat::Tau& tau, const size_t tau_index) { return tau.dxy_Sig(); }
+    auto getip3d(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->ip3d();
+    }
+    auto getip3d(const pat::Tau& tau, const size_t tau_index) { return tau.ip3d(); }
+    auto getip3dError(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->ip3d_error();
+    }
+    auto getip3dError(const pat::Tau& tau, const size_t tau_index) { return tau.ip3d_error(); }
+    auto getip3dSig(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->ip3d_Sig();
+    }
+    auto getip3dSig(const pat::Tau& tau, const size_t tau_index) { return tau.ip3d_Sig(); }
+    auto getHasSecondaryVertex(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->hasSecondaryVertex();
+    }
+    auto getHasSecondaryVertex(const pat::Tau& tau, const size_t tau_index) { return tau.hasSecondaryVertex(); }
+    auto getFlightLength(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->flightLength();
+    }
+    auto getFlightLength(const pat::Tau& tau, const size_t tau_index) { return tau.flightLength(); }
+    auto getFlightLengthSig(const reco::PFTau& tau, const size_t tau_index) {
+      return PFTauTransverseImpactParameters->value(tau_index)->flightLengthSig();
+    }
+    auto getFlightLengthSig(const pat::Tau& tau, const size_t tau_index) { return tau.flightLengthSig(); }
+    auto getLeadingTrackNormChi2(const reco::PFTau& tau) { return reco::tau::lead_track_chi2(tau); }
+    auto getLeadingTrackNormChi2(const pat::Tau& tau) { return tau.leadingTrackNormChi2(); }
+    auto getEmFraction(const pat::Tau& tau) { return tau.emFraction_MVA(); }
     auto getEmFraction(const reco::PFTau& tau) {
       auto leadChargedHadrCand = dynamic_cast<const reco::PFCandidate*>(tau.leadChargedHadrCand().get());
       float emFraction = -1.;
       float myHCALenergy = 0.;
       float myECALenergy = 0.;
-      if(leadChargedHadrCand && leadChargedHadrCand->bestTrack() != nullptr){
+      if (leadChargedHadrCand && leadChargedHadrCand->bestTrack() != nullptr) {
         for (const auto& isoPFCand : tau.isolationPFCands()) {
-            myHCALenergy += isoPFCand->hcalEnergy();
-            myECALenergy += isoPFCand->ecalEnergy();
+          myHCALenergy += isoPFCand->hcalEnergy();
+          myECALenergy += isoPFCand->ecalEnergy();
         }
         for (const auto& signalPFCand : tau.signalPFCands()) {
           myHCALenergy += signalPFCand->hcalEnergy();
@@ -509,7 +590,7 @@ namespace {
       }
       return emFraction;
     }
-    auto getEtaAtEcalEntrance(const pat::Tau& tau) {return tau.etaAtEcalEntranceLeadChargedCand();}
+    auto getEtaAtEcalEntrance(const pat::Tau& tau) { return tau.etaAtEcalEntranceLeadChargedCand(); }
     auto getEtaAtEcalEntrance(const reco::PFTau& tau) {
       const std::vector<reco::CandidatePtr>& signalCands = tau.signalCands();
       float leadChargedCandPt = -99;
@@ -542,75 +623,99 @@ namespace {
       auto leadChargedHadrCand = dynamic_cast<const reco::PFCandidate*>(tau.leadChargedHadrCand().get());
       return leadChargedHadrCand->ecalEnergy();
     }
-    auto getEcalEnergyLeadingChargedHadr(const pat::Tau& tau) {return tau.ecalEnergyLeadChargedHadrCand();} 
+    auto getEcalEnergyLeadingChargedHadr(const pat::Tau& tau) { return tau.ecalEnergyLeadChargedHadrCand(); }
     auto getHcalEnergyLeadingChargedHadr(const reco::PFTau& tau) {
       auto leadChargedHadrCand = dynamic_cast<const reco::PFCandidate*>(tau.leadChargedHadrCand().get());
       return leadChargedHadrCand->hcalEnergy();
     }
-    auto getHcalEnergyLeadingChargedHadr(const pat::Tau& tau) {return tau.hcalEnergyLeadChargedHadrCand();} 
+    auto getHcalEnergyLeadingChargedHadr(const pat::Tau& tau) { return tau.hcalEnergyLeadChargedHadrCand(); }
   };
 
-  struct lightLepFunc{
-
+  struct lightLepFunc {
     const std::vector<pat::Electron>& electron_collection;
     const std::vector<pat::Muon>& muon_collection;
- 
-    const std::vector<pat::Electron> getElectrons(bool online){
-      if (!online) return electron_collection;
-      else{
+
+    const std::vector<pat::Electron> getElectrons(bool online) {
+      if (!online)
+        return electron_collection;
+      else {
         const std::vector<pat::Electron> out_electrons;
         return out_electrons;
       }
     }
-    const std::vector<pat::Muon> getMuons(bool online){
-      if (!online) return muon_collection;
-      else{
+    const std::vector<pat::Muon> getMuons(bool online) {
+      if (!online)
+        return muon_collection;
+      else {
         const std::vector<pat::Muon> out_muons;
         return out_muons;
       }
     }
   };
 
-
-  namespace candFunc{
-    auto getTauDz(const reco::PFCandidate* cand, float default_value) {return cand->bestTrack() != nullptr ? cand->bestTrack()->dz() : default_value;}
-    auto getTauDz(const pat::PackedCandidate* cand, float default_value) {return cand->dz();}    
-    auto getTauDzError(const reco::PFCandidate* cand, float default_value) {return cand->bestTrack() != nullptr ? cand->dzError() : default_value;}
-    auto getTauDzError(const pat::PackedCandidate* cand, float default_value) {return cand->hasTrackDetails() ? cand->dzError() : default_value;}  
-    auto getTauDz(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->dz() : default_value;}
-    auto getTauDz(const pat::PackedCandidate& cand, float default_value) {return cand.dz();}    
-    auto getTauDzError(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.dzError() : default_value;}
-    auto getTauDzError(const pat::PackedCandidate& cand, float default_value) {return cand.hasTrackDetails() ? cand.dzError() : default_value;}       
+  namespace candFunc {
+    auto getTauDz(const reco::PFCandidate* cand, float default_value) {
+      return cand->bestTrack() != nullptr ? cand->bestTrack()->dz() : default_value;
+    }
+    auto getTauDz(const pat::PackedCandidate* cand, float default_value) { return cand->dz(); }
+    auto getTauDzError(const reco::PFCandidate* cand, float default_value) {
+      return cand->bestTrack() != nullptr ? cand->dzError() : default_value;
+    }
+    auto getTauDzError(const pat::PackedCandidate* cand, float default_value) {
+      return cand->hasTrackDetails() ? cand->dzError() : default_value;
+    }
+    auto getTauDz(const reco::PFCandidate& cand, float default_value) {
+      return cand.bestTrack() != nullptr ? cand.bestTrack()->dz() : default_value;
+    }
+    auto getTauDz(const pat::PackedCandidate& cand, float default_value) { return cand.dz(); }
+    auto getTauDzError(const reco::PFCandidate& cand, float default_value) {
+      return cand.bestTrack() != nullptr ? cand.dzError() : default_value;
+    }
+    auto getTauDzError(const pat::PackedCandidate& cand, float default_value) {
+      return cand.hasTrackDetails() ? cand.dzError() : default_value;
+    }
     auto getTauDZSigValid(const reco::PFCandidate* cand) {
-      return cand->bestTrack() != nullptr && 
-      std::isnormal(cand->bestTrack()->dz())&& 
-      std::isnormal(cand->dzError()) && cand->dzError() > 0;
-      }
+      return cand->bestTrack() != nullptr && std::isnormal(cand->bestTrack()->dz()) && std::isnormal(cand->dzError()) &&
+             cand->dzError() > 0;
+    }
     auto getTauDZSigValid(const pat::PackedCandidate* cand) {
-      return cand->hasTrackDetails() &&
-      std::isnormal(cand->dz()) &&
-      std::isnormal(cand->dzError()) && cand->dzError() > 0;
-    }    
-    auto getTauDxy(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->dxy() : default_value;}
-    auto getTauDxy(const pat::PackedCandidate& cand, float default_value) {return cand.dxy();}     
-    auto getPvAssocationQuality(const reco::PFCandidate& cand) {return 0.7013f;}
-    auto getPvAssocationQuality(const pat::PackedCandidate& cand) {return cand.pvAssociationQuality();}    
-    auto getPuppiWeight(const reco::PFCandidate& cand) {return 0.9907f;}
-    auto getPuppiWeight(const pat::PackedCandidate& cand) {return cand.puppiWeight();}    
-    auto getPuppiWeightNoLep(const reco::PFCandidate& cand) {return 0.8858f;}
-    auto getPuppiWeightNoLep(const pat::PackedCandidate& cand) {return cand.puppiWeightNoLep();}    
-    auto getLostInnerHits(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) : default_value;}
-    auto getLostInnerHits(const pat::PackedCandidate& cand, float default_value) {return cand.lostInnerHits();}    
-    auto getNumberOfPixelHits(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) : default_value;}
-    auto getNumberOfPixelHits(const pat::PackedCandidate& cand, float default_value) {return cand.numberOfPixelHits();}    
-    auto getHasTrackDetails(const reco::PFCandidate& cand) {return cand.bestTrack() != nullptr;}
-    auto getHasTrackDetails(const pat::PackedCandidate& cand) {return cand.hasTrackDetails();}    
-    auto getPseudoTrack(const reco::PFCandidate& cand) {return *cand.bestTrack();}
-    auto getPseudoTrack(const pat::PackedCandidate& cand) {return cand.pseudoTrack();}    
-    auto getFromPV(const reco::PFCandidate& cand) {return 0.9994f;}
-    auto getFromPV(const pat::PackedCandidate& cand) {return cand.fromPV();}    
-    auto getHCalFraction(const reco::PFCandidate& cand) { return cand.rawHcalEnergy()/(cand.rawHcalEnergy()+cand.rawEcalEnergy());}
-    auto getHCalFraction(const pat::PackedCandidate& cand) { 
+      return cand->hasTrackDetails() && std::isnormal(cand->dz()) && std::isnormal(cand->dzError()) &&
+             cand->dzError() > 0;
+    }
+    auto getTauDxy(const reco::PFCandidate& cand, float default_value) {
+      return cand.bestTrack() != nullptr ? cand.bestTrack()->dxy() : default_value;
+    }
+    auto getTauDxy(const pat::PackedCandidate& cand, float default_value) { return cand.dxy(); }
+    auto getPvAssocationQuality(const reco::PFCandidate& cand) { return 0.7013f; }
+    auto getPvAssocationQuality(const pat::PackedCandidate& cand) { return cand.pvAssociationQuality(); }
+    auto getPuppiWeight(const reco::PFCandidate& cand) { return 0.9907f; }
+    auto getPuppiWeight(const pat::PackedCandidate& cand) { return cand.puppiWeight(); }
+    auto getPuppiWeightNoLep(const reco::PFCandidate& cand) { return 0.8858f; }
+    auto getPuppiWeightNoLep(const pat::PackedCandidate& cand) { return cand.puppiWeightNoLep(); }
+    auto getLostInnerHits(const reco::PFCandidate& cand, float default_value) {
+      return cand.bestTrack() != nullptr
+                 ? cand.bestTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
+                 : default_value;
+    }
+    auto getLostInnerHits(const pat::PackedCandidate& cand, float default_value) { return cand.lostInnerHits(); }
+    auto getNumberOfPixelHits(const reco::PFCandidate& cand, float default_value) {
+      return cand.bestTrack() != nullptr
+                 ? cand.bestTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
+                 : default_value;
+    }
+    auto getNumberOfPixelHits(const pat::PackedCandidate& cand, float default_value) {
+      return cand.numberOfPixelHits();
+    }
+    auto getHasTrackDetails(const reco::PFCandidate& cand) { return cand.bestTrack() != nullptr; }
+    auto getHasTrackDetails(const pat::PackedCandidate& cand) { return cand.hasTrackDetails(); }
+    auto getPseudoTrack(const reco::PFCandidate& cand) { return *cand.bestTrack(); }
+    auto getPseudoTrack(const pat::PackedCandidate& cand) { return cand.pseudoTrack(); }
+    auto getFromPV(const reco::PFCandidate& cand) { return 0.9994f; }
+    auto getFromPV(const pat::PackedCandidate& cand) { return cand.fromPV(); }
+    auto getHCalFraction(const reco::PFCandidate& cand) {
+      return cand.rawHcalEnergy() / (cand.rawHcalEnergy() + cand.rawEcalEnergy());
+    }
+    auto getHCalFraction(const pat::PackedCandidate& cand) {
       float hcal_fraction = 0.;
       if (cand.pdgId() == 1 || cand.pdgId() == 130) {
         hcal_fraction = cand.hcalFraction();
@@ -619,12 +724,11 @@ namespace {
       }
       return hcal_fraction;
     }
-    auto getRawCaloFraction(const reco::PFCandidate& cand) { return (cand.rawEcalEnergy()+cand.rawHcalEnergy())/cand.energy();}
-    auto getRawCaloFraction(const pat::PackedCandidate& cand) { return cand.rawCaloFraction();    }
-    
-  };
-
-
+    auto getRawCaloFraction(const reco::PFCandidate& cand) {
+      return (cand.rawEcalEnergy() + cand.rawHcalEnergy()) / cand.energy();
+    }
+    auto getRawCaloFraction(const pat::PackedCandidate& cand) { return cand.rawCaloFraction(); }
+  };  // namespace candFunc
 
   template <typename LVector1, typename LVector2>
   float dEta(const LVector1& p4, const LVector2& tau_p4) {
@@ -1044,6 +1148,12 @@ public:
                                        {"RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6.pb"});
     desc.add<bool>("mem_mapped", false);
     desc.add<unsigned>("version", 2);
+    desc.add<unsigned>("chargedIsoPtSum_index", 0);
+    desc.add<unsigned>("neutralIsoPtSum_index", 1);
+    desc.add<unsigned>("neutralIsoPtSumWeight_index", 2);
+    desc.add<unsigned>("tauFootPrintCorrection_index", 3);
+    desc.add<unsigned>("photonPtSumOutsideSignalCone_index", 4);
+    desc.add<unsigned>("puCorrPtSum_index", 5);
     desc.add<int>("debug_level", 0);
     desc.add<bool>("disable_dxy_pca", false);
     desc.add<bool>("is_online", false);
@@ -1052,16 +1162,8 @@ public:
     desc.add<std::vector<std::string>>("VSmuWP");
     desc.add<std::vector<std::string>>("VSjetWP");
 
-    desc.add<edm::InputTag>("chargedIsoPtSum", edm::InputTag("chargedIsoPtSum"));
-    desc.add<edm::InputTag>("chargedIsoPtSumdR03", edm::InputTag("chargedIsoPtSumdR03"));
-    desc.add<edm::InputTag>("neutralIsoPtSum", edm::InputTag("neutralIsoPtSum"));
-    desc.add<edm::InputTag>("neutralIsoPtSumdR03", edm::InputTag("neutralIsoPtSumdR03"));
-    desc.add<edm::InputTag>("puCorrPtSum", edm::InputTag("puCorrPtSum"));
-    desc.add<edm::InputTag>("footprintCorrection", edm::InputTag("footprintCorrection"));
-    desc.add<edm::InputTag>("neutralIsoPtSumWeight", edm::InputTag("neutralIsoPtSumWeight"));
-    desc.add<edm::InputTag>("neutralIsoPtSumWeightdR03", edm::InputTag("neutralIsoPtSumWeightdR03"));
-    desc.add<edm::InputTag>("photonPtSumOutsideSignalCone", edm::InputTag("photonPtSumOutsideSignalCone"));
-    desc.add<edm::InputTag>("photonPtSumOutsideSignalConedR03", edm::InputTag("photonPtSumOutsideSignalConedr03"));
+    desc.add<edm::InputTag>("basicTauDiscriminators", edm::InputTag("basicTauDiscriminators"));
+    desc.add<edm::InputTag>("basicTauDiscriminatorsdR03", edm::InputTag("basicTauDiscriminatorsdR03"));
     desc.add<edm::InputTag>("pfTauTransverseImpactParameters", edm::InputTag("hpsPFTauTransverseImpactParameters"));
 
     descriptions.add("DeepTau", desc);
@@ -1073,19 +1175,20 @@ public:
         electrons_token_(consumes<std::vector<pat::Electron>>(cfg.getParameter<edm::InputTag>("electrons"))),
         muons_token_(consumes<std::vector<pat::Muon>>(cfg.getParameter<edm::InputTag>("muons"))),
         rho_token_(consumes<double>(cfg.getParameter<edm::InputTag>("rho"))),
-        chargedIsoPtSum_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("chargedIsoPtSum"))),
-        chargedIsoPtSumdR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("chargedIsoPtSumdR03"))),
-        neutralIsoPtSum_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSum"))),
-        neutralIsoPtSumdR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSumdR03"))),
-        puCorrPtSum_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("puCorrPtSum"))),
-        footprintCorrection_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("footprintCorrection"))),
-        neutralIsoPtSumWeight_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSumWeight"))),
-        neutralIsoPtSumWeightdR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSumWeightdR03"))),
-        photonPtSumOutsideSignalCone_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("photonPtSumOutsideSignalCone"))),
-        photonPtSumOutsideSignalConedR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("photonPtSumOutsideSignalConedR03"))),
-        PFTauTransverseImpactParameters_token(consumes<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>(cfg.getParameter<edm::InputTag>("pfTauTransverseImpactParameters"))),
-
+        basicTauDiscriminators_inputToken(
+            consumes<reco::TauDiscriminatorContainer>(cfg.getParameter<edm::InputTag>("basicTauDiscriminators"))),
+        basicTauDiscriminatorsdR03_inputToken(
+            consumes<reco::TauDiscriminatorContainer>(cfg.getParameter<edm::InputTag>("basicTauDiscriminatorsdR03"))),
+        PFTauTransverseImpactParameters_token(
+            consumes<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>(
+                cfg.getParameter<edm::InputTag>("pfTauTransverseImpactParameters"))),
         version(cfg.getParameter<unsigned>("version")),
+        chargedIsoPtSum_index(cfg.getParameter<unsigned>("chargedIsoPtSum_index")),
+        neutralIsoPtSum_index(cfg.getParameter<unsigned>("neutralIsoPtSum_index")),
+        neutralIsoPtSumWeight_index(cfg.getParameter<unsigned>("neutralIsoPtSumWeight_index")),
+        tauFootPrintCorrection_index(cfg.getParameter<unsigned>("tauFootPrintCorrection_index")),
+        photonPtSumOutsideSignalCone_index(cfg.getParameter<unsigned>("photonPtSumOutsideSignalCone_index")),
+        puCorrPtSum_index(cfg.getParameter<unsigned>("puCorrPtSum_index")),
         debug_level(cfg.getParameter<int>("debug_level")),
         disable_dxy_pca_(cfg.getParameter<bool>("disable_dxy_pca")) {
     if (version == 1) {
@@ -1205,57 +1308,33 @@ private:
 
 private:
   tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) override {
-
     edm::Handle<std::vector<pat::Electron>> tmp_electrons;
     edm::Handle<std::vector<pat::Muon>> tmp_muons;
-    edm::Handle<reco::PFTauDiscriminator> chargedIsoPtSumCollection;
-    edm::Handle<reco::PFTauDiscriminator> chargedIsoPtSumdR03Collection;
-    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumCollection;
-    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumdR03Collection;
-    edm::Handle<reco::PFTauDiscriminator> puCorrPtSumCollection;
-    edm::Handle<reco::PFTauDiscriminator> footprintCorrectionCollection;
-    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumWeightCollection;
-    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumWeightdR03Collection;
-    edm::Handle<reco::PFTauDiscriminator> photonPtSumOutsideSignalConeCollection;
-    edm::Handle<reco::PFTauDiscriminator> photonPtSumOutsideSignalConedR03Collection;
-    edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>> PFTauTransverseImpactParameters;
+    edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminators;
+    edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminatorsdR03;
+    edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
+        PFTauTransverseImpactParameters;
 
-
-    if (!is_online){
+    if (!is_online) {
       event.getByToken(electrons_token_, tmp_electrons);
       event.getByToken(muons_token_, tmp_muons);
     } else {
-      event.getByToken(chargedIsoPtSum_inputToken, chargedIsoPtSumCollection);
-      event.getByToken(chargedIsoPtSumdR03_inputToken, chargedIsoPtSumdR03Collection);
-      event.getByToken(neutralIsoPtSum_inputToken, neutralIsoPtSumCollection);
-      event.getByToken(neutralIsoPtSumdR03_inputToken, neutralIsoPtSumdR03Collection);
-      event.getByToken(puCorrPtSum_inputToken, puCorrPtSumCollection);
-      event.getByToken(footprintCorrection_inputToken, footprintCorrectionCollection);
-      event.getByToken(neutralIsoPtSumWeight_inputToken, neutralIsoPtSumWeightCollection);
-      event.getByToken(neutralIsoPtSumWeightdR03_inputToken, neutralIsoPtSumWeightdR03Collection);
-      event.getByToken(photonPtSumOutsideSignalCone_inputToken, photonPtSumOutsideSignalConeCollection);
-      event.getByToken(photonPtSumOutsideSignalConedR03_inputToken, photonPtSumOutsideSignalConedR03Collection);
       event.getByToken(PFTauTransverseImpactParameters_token, PFTauTransverseImpactParameters);
+      event.getByToken(basicTauDiscriminators_inputToken, basicTauDiscriminators);
+      event.getByToken(basicTauDiscriminatorsdR03_inputToken, basicTauDiscriminatorsdR03);
     }
 
-    tauFunc tauIDs = {
-      *chargedIsoPtSumCollection,
-      *chargedIsoPtSumdR03Collection,
-      *neutralIsoPtSumCollection,
-      *neutralIsoPtSumdR03Collection,
-      *puCorrPtSumCollection,
-      *footprintCorrectionCollection,
-      *neutralIsoPtSumWeightCollection,
-      *neutralIsoPtSumWeightdR03Collection,
-      *photonPtSumOutsideSignalConeCollection,
-      *photonPtSumOutsideSignalConedR03Collection,
-      PFTauTransverseImpactParameters
-    };
+    tauFunc tauIDs = {basicTauDiscriminators,
+                      basicTauDiscriminatorsdR03,
+                      PFTauTransverseImpactParameters,
+                      chargedIsoPtSum_index,
+                      neutralIsoPtSum_index,
+                      neutralIsoPtSumWeight_index,
+                      tauFootPrintCorrection_index,
+                      photonPtSumOutsideSignalCone_index,
+                      puCorrPtSum_index};
 
-    lightLepFunc lightlep = {
-      *tmp_electrons,
-      *tmp_muons
-    };
+    lightLepFunc lightlep = {*tmp_electrons, *tmp_muons};
 
     std::vector<pat::Electron> electrons = lightlep.getElectrons(is_online);
     std::vector<pat::Muon> muons = lightlep.getMuons(is_online);
@@ -1270,26 +1349,41 @@ private:
     event.getByToken(rho_token_, rho);
 
     tensorflow::Tensor predictions(tensorflow::DT_FLOAT, {static_cast<int>(taus->size()), deep_tau::NumberOfOutputs});
-
-
     for (size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
-
       std::vector<tensorflow::Tensor> pred_vector;
-      if (is_online){
-        if (version == 1)
-          getPredictionsV1<reco::PFCandidate, reco::PFTau>(taus->at(tau_index), tau_index, electrons, muons, pred_vector, tauIDs);
-        else if (version == 2){
-          getPredictionsV2<reco::PFCandidate, reco::PFTau>(taus->at(tau_index), tau_index, electrons, muons, *pfCands, vertices->at(0), *rho, pred_vector, tauIDs);
-        }
+      const deep_tau::DeepTauBase::TauRef tauRef(taus, tau_index);
+      if (version == 1) {
+        if (is_online)
+          getPredictionsV1<reco::PFCandidate, reco::PFTau>(
+              taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
         else
-          throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+          getPredictionsV1<pat::PackedCandidate, pat::Tau>(
+              taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
+      } else if (version == 2) {
+        if (is_online) {
+          getPredictionsV2<reco::PFCandidate, reco::PFTau>(taus->at(tau_index),
+                                                           tau_index,
+                                                           tauRef,
+                                                           electrons,
+                                                           muons,
+                                                           *pfCands,
+                                                           vertices->at(0),
+                                                           *rho,
+                                                           pred_vector,
+                                                           tauIDs);
+        } else
+          getPredictionsV2<pat::PackedCandidate, pat::Tau>(taus->at(tau_index),
+                                                           tau_index,
+                                                           tauRef,
+                                                           electrons,
+                                                           muons,
+                                                           *pfCands,
+                                                           vertices->at(0),
+                                                           *rho,
+                                                           pred_vector,
+                                                           tauIDs);
       } else {
-        if (version == 1)
-          getPredictionsV1<pat::PackedCandidate, pat::Tau>(taus->at(tau_index), tau_index, electrons, muons, pred_vector, tauIDs);
-        else if (version == 2)
-          getPredictionsV2<pat::PackedCandidate, pat::Tau>(taus->at(tau_index), tau_index, electrons, muons, *pfCands, vertices->at(0), *rho, pred_vector, tauIDs);
-        else
-          throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+        throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
       }
 
       for (int k = 0; k < deep_tau::NumberOfOutputs; ++k) {
@@ -1304,19 +1398,22 @@ private:
   }
 
   template <typename CandidateCastType, typename TauCastType>
-  void getPredictionsV1(const TauType::const_reference& tau,
-                        size_t tau_index,
+  void getPredictionsV1(const TauCollection::const_reference& tau,
+                        const size_t tau_index,
+                        const deep_tau::DeepTauBase::TauRef tau_ref,
                         const std::vector<pat::Electron>& electrons,
                         const std::vector<pat::Muon>& muons,
                         std::vector<tensorflow::Tensor>& pred_vector,
                         tauFunc tau_funcs) {
-    const tensorflow::Tensor& inputs = createInputsV1<dnn_inputs_2017v1, const CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, electrons, muons, tau_funcs);
+    const tensorflow::Tensor& inputs = createInputsV1<dnn_inputs_2017v1, const CandidateCastType>(
+        dynamic_cast<const TauCastType&>(tau), tau_index, tau_ref, electrons, muons, tau_funcs);
     tensorflow::run(&(cache_->getSession()), {{input_layer_, inputs}}, {output_layer_}, &pred_vector);
   }
 
   template <typename CandidateCastType, typename TauCastType>
-  void getPredictionsV2(const TauType::const_reference& tau,
-                        size_t tau_index,
+  void getPredictionsV2(const TauCollection::const_reference& tau,
+                        const size_t tau_index,
+                        const deep_tau::DeepTauBase::TauRef tau_ref,
                         const std::vector<pat::Electron>& electrons,
                         const std::vector<pat::Muon>& muons,
                         const edm::View<reco::Candidate>& pfCands,
@@ -1324,16 +1421,36 @@ private:
                         double rho,
                         std::vector<tensorflow::Tensor>& pred_vector,
                         tauFunc tau_funcs) {
-
     CellGrid inner_grid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell, 0.02, 0.02);
     CellGrid outer_grid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell, 0.05, 0.05);
     fillGrids(dynamic_cast<const TauCastType&>(tau), electrons, inner_grid, outer_grid);
     fillGrids(dynamic_cast<const TauCastType&>(tau), muons, inner_grid, outer_grid);
     fillGrids(dynamic_cast<const TauCastType&>(tau), pfCands, inner_grid, outer_grid);
 
-    createTauBlockInputs<CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, pv, rho, tau_funcs);
-    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, pv, rho, electrons, muons, pfCands, inner_grid, tau_funcs, true);
-    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, pv, rho, electrons, muons, pfCands, outer_grid, tau_funcs, false);
+    createTauBlockInputs<CandidateCastType>(
+        dynamic_cast<const TauCastType&>(tau), tau_index, tau_ref, pv, rho, tau_funcs);
+    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau),
+                                          tau_index,
+                                          tau_ref,
+                                          pv,
+                                          rho,
+                                          electrons,
+                                          muons,
+                                          pfCands,
+                                          inner_grid,
+                                          tau_funcs,
+                                          true);
+    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau),
+                                          tau_index,
+                                          tau_ref,
+                                          pv,
+                                          rho,
+                                          electrons,
+                                          muons,
+                                          pfCands,
+                                          outer_grid,
+                                          tau_funcs,
+                                          false);
 
     tensorflow::run(&(cache_->getSession("core")),
                     {{"input_tau", *tauBlockTensor_},
@@ -1378,7 +1495,6 @@ private:
       if (dR2 < outer_dR2)
         addObject(n, deta, dphi, outer_grid);
     }
-
   }
 
   tensorflow::Tensor getPartialPredictions(bool is_inner) {
@@ -1402,13 +1518,13 @@ private:
                       {"outer_all_dropout_4/Identity"},
                       &pred_vector);
     }
-
     return pred_vector.at(0);
   }
 
   template <typename CandidateCastType, typename TauCastType>
   void createConvFeatures(const TauCastType& tau,
-                          size_t tau_index,
+                          const size_t tau_index,
+                          const deep_tau::DeepTauBase::TauRef tau_ref,
                           const reco::Vertex& pv,
                           double rho,
                           const std::vector<pat::Electron>& electrons,
@@ -1442,9 +1558,12 @@ private:
         const auto cell_iter = grid.find(cell_index);
         if (cell_iter != grid.end()) {
           const Cell& cell = cell_iter->second;
-          createEgammaBlockInputs<CandidateCastType>(idx, tau, tau_index, pv, rho, electrons, pfCands, cell, tau_funcs, is_inner);
-          createMuonBlockInputs<CandidateCastType>(idx, tau, tau_index, pv, rho, muons, pfCands, cell, tau_funcs, is_inner);
-          createHadronsBlockInputs<CandidateCastType>(idx, tau, tau_index, pv, rho, pfCands, cell, tau_funcs, is_inner);
+          createEgammaBlockInputs<CandidateCastType>(
+              idx, tau, tau_index, tau_ref, pv, rho, electrons, pfCands, cell, tau_funcs, is_inner);
+          createMuonBlockInputs<CandidateCastType>(
+              idx, tau, tau_index, tau_ref, pv, rho, muons, pfCands, cell, tau_funcs, is_inner);
+          createHadronsBlockInputs<CandidateCastType>(
+              idx, tau, tau_index, tau_ref, pv, rho, pfCands, cell, tau_funcs, is_inner);
           idx += 1;
         }
       }
@@ -1479,7 +1598,12 @@ private:
   }
 
   template <typename CandidateCastType, typename TauCastType>
-  void createTauBlockInputs(const TauCastType& tau, size_t& tau_index, const reco::Vertex& pv, double rho, tauFunc tau_funcs) {
+  void createTauBlockInputs(const TauCastType& tau,
+                            const size_t& tau_index,
+                            const deep_tau::DeepTauBase::TauRef tau_ref,
+                            const reco::Vertex& pv,
+                            double rho,
+                            tauFunc tau_funcs) {
     namespace dnn = dnn_inputs_2017_v2::TauBlockInputs;
 
     tensorflow::Tensor& inputs = *tauBlockTensor_;
@@ -1498,18 +1622,23 @@ private:
     get(dnn::tau_charge) = getValue(tau.charge());
     get(dnn::tau_n_charged_prongs) = getValueLinear(tau.decayMode() / 5 + 1, 1, 3, true);
     get(dnn::tau_n_neutral_prongs) = getValueLinear(tau.decayMode() % 5, 0, 2, true);
-    get(dnn::chargedIsoPtSum) = getValueNorm(tau_funcs.getChargedIsoPtSum(tau, tau_index), 47.78f, 123.5f);
-    get(dnn::chargedIsoPtSumdR03_over_dR05) = getValue(tau_funcs.getChargedIsoPtSumdR03(tau, tau_index) / tau_funcs.getChargedIsoPtSum(tau, tau_index));
-    get(dnn::footprintCorrection) = getValueNorm(tau_funcs.getFootprintCorrectiondR03(tau, tau_index), 9.029f, 26.42f);
-    get(dnn::neutralIsoPtSum) = getValueNorm(tau_funcs.getNeutralIsoPtSum(tau, tau_index), 57.59f, 155.3f);
+    get(dnn::chargedIsoPtSum) = getValueNorm(tau_funcs.getChargedIsoPtSum(tau, tau_index, tau_ref), 47.78f, 123.5f);
+    get(dnn::chargedIsoPtSumdR03_over_dR05) = getValue(tau_funcs.getChargedIsoPtSumdR03(tau, tau_index, tau_ref) /
+                                                       tau_funcs.getChargedIsoPtSum(tau, tau_index, tau_ref));
+    get(dnn::footprintCorrection) =
+        getValueNorm(tau_funcs.getFootprintCorrectiondR03(tau, tau_index, tau_ref), 9.029f, 26.42f);
+    get(dnn::neutralIsoPtSum) = getValueNorm(tau_funcs.getNeutralIsoPtSum(tau, tau_index, tau_ref), 57.59f, 155.3f);
     get(dnn::neutralIsoPtSumWeight_over_neutralIsoPtSum) =
-        getValue(tau_funcs.getNeutralIsoPtSumWeight(tau, tau_index) / tau_funcs.getNeutralIsoPtSum(tau, tau_index));
+        getValue(tau_funcs.getNeutralIsoPtSumWeight(tau, tau_index, tau_ref) /
+                 tau_funcs.getNeutralIsoPtSum(tau, tau_index, tau_ref));
     get(dnn::neutralIsoPtSumWeightdR03_over_neutralIsoPtSum) =
-        getValue(tau_funcs.getNeutralIsoPtSumdR03Weight(tau, tau_index) / tau_funcs.getNeutralIsoPtSum(tau, tau_index));
-    get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau_funcs.getNeutralIsoPtSumdR03(tau, tau_index) / tau_funcs.getNeutralIsoPtSum(tau, tau_index));
+        getValue(tau_funcs.getNeutralIsoPtSumdR03Weight(tau, tau_index, tau_ref) /
+                 tau_funcs.getNeutralIsoPtSum(tau, tau_index, tau_ref));
+    get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau_funcs.getNeutralIsoPtSumdR03(tau, tau_index, tau_ref) /
+                                                       tau_funcs.getNeutralIsoPtSum(tau, tau_index, tau_ref));
     get(dnn::photonPtSumOutsideSignalCone) =
-        getValueNorm(tau_funcs.getPhotonPtSumOutsideSignalCone(tau, tau_index), 1.731f, 6.846f);
-    get(dnn::puCorrPtSum) = getValueNorm(tau_funcs.getPuCorrPtSum(tau, tau_index), 22.38f, 16.34f);
+        getValueNorm(tau_funcs.getPhotonPtSumOutsideSignalCone(tau, tau_index, tau_ref), 1.731f, 6.846f);
+    get(dnn::puCorrPtSum) = getValueNorm(tau_funcs.getPuCorrPtSum(tau, tau_index, tau_ref), 22.38f, 16.34f);
     // The global PCA coordinates were used as inputs during the NN training, but it was decided to disable
     // them for the inference, because modeling of dxy_PCA in MC poorly describes the data, and x and y coordinates
     // in data results outside of the expected 5 std. dev. input validity range. On the other hand,
@@ -1524,24 +1653,29 @@ private:
       get(dnn::tau_dxy_pca_z) = 0;
     }
     const bool tau_dxy_valid =
-        std::isnormal(tau_funcs.getdxy(tau, tau_index)) && tau_funcs.getdxy(tau, tau_index) > -10 && std::isnormal(tau_funcs.getdxyError(tau, tau_index)) && tau_funcs.getdxyError(tau, tau_index) > 0;
+        std::isnormal(tau_funcs.getdxy(tau, tau_index)) && tau_funcs.getdxy(tau, tau_index) > -10 &&
+        std::isnormal(tau_funcs.getdxyError(tau, tau_index)) && tau_funcs.getdxyError(tau, tau_index) > 0;
     if (tau_dxy_valid) {
       get(dnn::tau_dxy_valid) = tau_dxy_valid;
       get(dnn::tau_dxy) = getValueNorm(tau_funcs.getdxy(tau, tau_index), 0.0018f, 0.0085f);
-      get(dnn::tau_dxy_sig) = getValueNorm(std::abs(tau_funcs.getdxy(tau, tau_index)) / tau_funcs.getdxyError(tau, tau_index), 2.26f, 4.191f);
+      get(dnn::tau_dxy_sig) = getValueNorm(
+          std::abs(tau_funcs.getdxy(tau, tau_index)) / tau_funcs.getdxyError(tau, tau_index), 2.26f, 4.191f);
     }
     const bool tau_ip3d_valid =
-        std::isnormal(tau_funcs.getip3d(tau, tau_index)) && tau_funcs.getip3d(tau, tau_index) > -10 && std::isnormal(tau_funcs.getip3dError(tau, tau_index)) && tau_funcs.getip3dError(tau, tau_index) > 0;
+        std::isnormal(tau_funcs.getip3d(tau, tau_index)) && tau_funcs.getip3d(tau, tau_index) > -10 &&
+        std::isnormal(tau_funcs.getip3dError(tau, tau_index)) && tau_funcs.getip3dError(tau, tau_index) > 0;
     if (tau_ip3d_valid) {
       get(dnn::tau_ip3d_valid) = tau_ip3d_valid;
       get(dnn::tau_ip3d) = getValueNorm(tau_funcs.getip3d(tau, tau_index), 0.0026f, 0.0114f);
-      get(dnn::tau_ip3d_sig) = getValueNorm(std::abs(tau_funcs.getip3d(tau, tau_index)) / tau_funcs.getip3dError(tau, tau_index), 2.928f, 4.466f);
+      get(dnn::tau_ip3d_sig) = getValueNorm(
+          std::abs(tau_funcs.getip3d(tau, tau_index)) / tau_funcs.getip3dError(tau, tau_index), 2.928f, 4.466f);
     }
     if (leadChargedHadrCand) {
       get(dnn::tau_dz) = getValueNorm(candFunc::getTauDz(leadChargedHadrCand, default_value), 0.f, 0.0190f);
       get(dnn::tau_dz_sig_valid) = candFunc::getTauDZSigValid(leadChargedHadrCand);
       const double dzError = candFunc::getTauDzError(leadChargedHadrCand, default_value);
-      get(dnn::tau_dz_sig) = getValueNorm(std::abs(candFunc::getTauDz(leadChargedHadrCand, default_value)) / dzError, 4.717f, 11.78f);
+      get(dnn::tau_dz_sig) =
+          getValueNorm(std::abs(candFunc::getTauDz(leadChargedHadrCand, default_value)) / dzError, 4.717f, 11.78f);
     }
     get(dnn::tau_flightLength_x) = getValueNorm(tau_funcs.getFlightLength(tau, tau_index).x(), -0.0003f, 0.7362f);
     get(dnn::tau_flightLength_y) = getValueNorm(tau_funcs.getFlightLength(tau, tau_index).y(), -0.0009f, 0.7354f);
@@ -1576,7 +1710,8 @@ private:
   template <typename CandidateCastType, typename TauCastType>
   void createEgammaBlockInputs(unsigned idx,
                                const TauCastType& tau,
-                               size_t tau_index,
+                               const size_t tau_index,
+                               const deep_tau::DeepTauBase::TauRef tau_ref,
                                const reco::Vertex& pv,
                                double rho,
                                const std::vector<pat::Electron>& electrons,
@@ -1593,7 +1728,6 @@ private:
     const bool valid_index_pf_ele = cell_map.count(CellObjectType::PfCand_electron);
     const bool valid_index_pf_gamma = cell_map.count(CellObjectType::PfCand_gamma);
     const bool valid_index_ele = cell_map.count(CellObjectType::Electron);
-
 
     if (!cell_map.empty()) {
       get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
@@ -1631,25 +1765,33 @@ private:
       get(dnn::pfCand_ele_vertex_dz) =
           getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z(), 0.001f, 1.024f);
       get(dnn::pfCand_ele_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_pf_ele).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), 0.f, 0.3411f);
+          pfCands.at(index_pf_ele).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(),
+          0.f,
+          0.3411f);
       get(dnn::pfCand_ele_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_pf_ele).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0003f, 0.3385f);
-      get(dnn::pfCand_ele_vertex_dz_tauFL) =
-          getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), 0.f, 1.307f);
+          pfCands.at(index_pf_ele).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(),
+          0.0003f,
+          0.3385f);
+      get(dnn::pfCand_ele_vertex_dz_tauFL) = getValueNorm(
+          pfCands.at(index_pf_ele).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(),
+          0.f,
+          1.307f);
 
       const bool hasTrackDetails = candFunc::getHasTrackDetails(ele_cand);
       if (hasTrackDetails) {
         get(dnn::pfCand_ele_hasTrackDetails) = hasTrackDetails;
         get(dnn::pfCand_ele_dxy) = getValueNorm(candFunc::getTauDxy(ele_cand, default_value), 0.f, 0.171f);
         get(dnn::pfCand_ele_dxy_sig) =
-            getValueNorm(std::abs(candFunc::getTauDxy(ele_cand, default_value)) / pfCands.at(index_pf_ele).dxyError(), 1.634f, 6.45f);
+            getValueNorm(std::abs(candFunc::getTauDxy(ele_cand, default_value)) / pfCands.at(index_pf_ele).dxyError(),
+                         1.634f,
+                         6.45f);
         get(dnn::pfCand_ele_dz) = getValueNorm(candFunc::getTauDz(ele_cand, default_value), 0.001f, 1.02f);
-        get(dnn::pfCand_ele_dz_sig) =
-            getValueNorm(std::abs(candFunc::getTauDz(ele_cand, default_value)) / candFunc::getTauDzError(ele_cand, default_value), 24.56f, 210.4f);
-        get(dnn::pfCand_ele_track_chi2_ndof) =
-            getValueNorm(candFunc::getPseudoTrack(ele_cand).chi2() / candFunc::getPseudoTrack(ele_cand).ndof(),
-                         2.272f,
-                         8.439f);
+        get(dnn::pfCand_ele_dz_sig) = getValueNorm(
+            std::abs(candFunc::getTauDz(ele_cand, default_value)) / candFunc::getTauDzError(ele_cand, default_value),
+            24.56f,
+            210.4f);
+        get(dnn::pfCand_ele_track_chi2_ndof) = getValueNorm(
+            candFunc::getPseudoTrack(ele_cand).chi2() / candFunc::getPseudoTrack(ele_cand).ndof(), 2.272f, 8.439f);
         get(dnn::pfCand_ele_track_ndof) = getValueNorm(candFunc::getPseudoTrack(ele_cand).ndof(), 15.18f, 3.203f);
       }
     }
@@ -1684,11 +1826,17 @@ private:
       get(dnn::pfCand_gamma_vertex_dz) =
           getValueNorm(pfCands.at(index_pf_gamma).vertex().z() - pv.position().z(), 0.f, 0.0578f);
       get(dnn::pfCand_gamma_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_pf_gamma).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), 0.001f, 0.9565f);
+          pfCands.at(index_pf_gamma).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(),
+          0.001f,
+          0.9565f);
       get(dnn::pfCand_gamma_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_pf_gamma).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0008f, 0.9592f);
+          pfCands.at(index_pf_gamma).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(),
+          0.0008f,
+          0.9592f);
       get(dnn::pfCand_gamma_vertex_dz_tauFL) = getValueNorm(
-          pfCands.at(index_pf_gamma).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), 0.0038f, 2.154f);
+          pfCands.at(index_pf_gamma).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(),
+          0.0038f,
+          2.154f);
       const bool hasTrackDetails = candFunc::getHasTrackDetails(gamma_cand);
       if (hasTrackDetails) {
         get(dnn::pfCand_gamma_hasTrackDetails) = hasTrackDetails;
@@ -1696,8 +1844,10 @@ private:
         get(dnn::pfCand_gamma_dxy_sig) = getValueNorm(
             std::abs(candFunc::getTauDxy(gamma_cand, default_value)) / gamma_cand.dxyError(), 4.271f, 63.78f);
         get(dnn::pfCand_gamma_dz) = getValueNorm(candFunc::getTauDz(gamma_cand, default_value), 0.0071f, 5.285f);
-        get(dnn::pfCand_gamma_dz_sig) = getValueNorm(
-            std::abs(candFunc::getTauDz(gamma_cand, default_value)) / candFunc::getTauDzError(gamma_cand, default_value), 162.1f, 622.4f);
+        get(dnn::pfCand_gamma_dz_sig) = getValueNorm(std::abs(candFunc::getTauDz(gamma_cand, default_value)) /
+                                                         candFunc::getTauDzError(gamma_cand, default_value),
+                                                     162.1f,
+                                                     622.4f);
         get(dnn::pfCand_gamma_track_chi2_ndof) = candFunc::getPseudoTrack(gamma_cand).ndof() > 0
                                                      ? getValueNorm(candFunc::getPseudoTrack(gamma_cand).chi2() /
                                                                         candFunc::getPseudoTrack(gamma_cand).ndof(),
@@ -1794,14 +1944,15 @@ private:
             getValueNorm(closestCtfTrack->numberOfValidHits(), 15.16f, 5.26f);
       }
     }
-    if (valid_index_ele or valid_index_pf_ele or valid_index_pf_gamma) checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
-
+    if (valid_index_ele or valid_index_pf_ele or valid_index_pf_gamma)
+      checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
   }
 
   template <typename CandidateCastType, typename TauCastType>
   void createMuonBlockInputs(unsigned idx,
                              const TauCastType& tau,
-                             size_t tau_index, 
+                             const size_t tau_index,
+                             const deep_tau::DeepTauBase::TauRef tau_ref,
                              const reco::Vertex& pv,
                              double rho,
                              const std::vector<pat::Muon>& muons,
@@ -1855,11 +2006,17 @@ private:
       get(dnn::pfCand_muon_vertex_dz) =
           getValueNorm(pfCands.at(index_pf_muon).vertex().z() - pv.position().z(), -0.0117f, 4.097f);
       get(dnn::pfCand_muon_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_pf_muon).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), -0.0001f, 0.8642f);
+          pfCands.at(index_pf_muon).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(),
+          -0.0001f,
+          0.8642f);
       get(dnn::pfCand_muon_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_pf_muon).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0004f, 0.8561f);
+          pfCands.at(index_pf_muon).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(),
+          0.0004f,
+          0.8561f);
       get(dnn::pfCand_muon_vertex_dz_tauFL) = getValueNorm(
-          pfCands.at(index_pf_muon).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), -0.0118f, 4.405f);
+          pfCands.at(index_pf_muon).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(),
+          -0.0118f,
+          4.405f);
 
       const bool hasTrackDetails = candFunc::getHasTrackDetails(muon_cand);
       if (hasTrackDetails) {
@@ -1869,11 +2026,11 @@ private:
             std::abs(candFunc::getTauDxy(muon_cand, default_value)) / muon_cand.dxyError(), 4.575f, 42.36f);
         get(dnn::pfCand_muon_dz) = getValueNorm(candFunc::getTauDz(muon_cand, default_value), -0.0117f, 4.097f);
         get(dnn::pfCand_muon_dz_sig) = getValueNorm(
-            std::abs(candFunc::getTauDz(muon_cand, default_value)) / candFunc::getTauDz(muon_cand, default_value), 80.37f, 343.3f);
+            std::abs(candFunc::getTauDz(muon_cand, default_value)) / candFunc::getTauDz(muon_cand, default_value),
+            80.37f,
+            343.3f);
         get(dnn::pfCand_muon_track_chi2_ndof) = getValueNorm(
-            candFunc::getPseudoTrack(muon_cand).chi2() / candFunc::getPseudoTrack(muon_cand).ndof(),
-            0.69f,
-            1.711f);
+            candFunc::getPseudoTrack(muon_cand).chi2() / candFunc::getPseudoTrack(muon_cand).ndof(), 0.69f, 1.711f);
         get(dnn::pfCand_muon_track_ndof) = getValueNorm(candFunc::getPseudoTrack(muon_cand).ndof(), 17.5f, 5.11f);
       }
     }
@@ -1945,7 +2102,8 @@ private:
   template <typename CandidateCastType, typename TauCastType>
   void createHadronsBlockInputs(unsigned idx,
                                 const TauCastType& tau,
-                                size_t tau_index,
+                                const size_t tau_index,
+                                const deep_tau::DeepTauBase::TauRef tau_ref,
                                 const reco::Vertex& pv,
                                 double rho,
                                 const edm::View<reco::Candidate>& pfCands,
@@ -1983,8 +2141,8 @@ private:
                                                    is_inner ? -0.1f : -0.5f,
                                                    is_inner ? 0.1f : 0.5f,
                                                    false);
-      get(dnn::pfCand_chHad_leadChargedHadrCand) = getValue(
-          &chH_cand == dynamic_cast<const CandidateCastType*>(tau.leadChargedHadrCand().get()));
+      get(dnn::pfCand_chHad_leadChargedHadrCand) =
+          getValue(&chH_cand == dynamic_cast<const CandidateCastType*>(tau.leadChargedHadrCand().get()));
       get(dnn::pfCand_chHad_pvAssociationQuality) =
           getValueLinear<int>(candFunc::getPvAssocationQuality(chH_cand), 0, 7, true);
       get(dnn::pfCand_chHad_fromPV) = getValueLinear<int>(candFunc::getFromPV(chH_cand), 0, 3, true);
@@ -1992,7 +2150,8 @@ private:
       get(dnn::pfCand_chHad_puppiWeightNoLep) = getValue(candFunc::getPuppiWeightNoLep(chH_cand));
       get(dnn::pfCand_chHad_charge) = getValue(chH_cand.charge());
       get(dnn::pfCand_chHad_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(chH_cand, default_value));
-      get(dnn::pfCand_chHad_numberOfPixelHits) = getValueLinear(candFunc::getNumberOfPixelHits(chH_cand, default_value), 0, 12, true);
+      get(dnn::pfCand_chHad_numberOfPixelHits) =
+          getValueLinear(candFunc::getNumberOfPixelHits(chH_cand, default_value), 0, 12, true);
       get(dnn::pfCand_chHad_vertex_dx) =
           getValueNorm(pfCands.at(index_chH).vertex().x() - pv.position().x(), 0.0005f, 1.735f);
       get(dnn::pfCand_chHad_vertex_dy) =
@@ -2000,11 +2159,17 @@ private:
       get(dnn::pfCand_chHad_vertex_dz) =
           getValueNorm(pfCands.at(index_chH).vertex().z() - pv.position().z(), -0.0201f, 8.333f);
       get(dnn::pfCand_chHad_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_chH).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), -0.0014f, 1.93f);
+          pfCands.at(index_chH).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(),
+          -0.0014f,
+          1.93f);
       get(dnn::pfCand_chHad_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_chH).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0022f, 1.948f);
+          pfCands.at(index_chH).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(),
+          0.0022f,
+          1.948f);
       get(dnn::pfCand_chHad_vertex_dz_tauFL) = getValueNorm(
-          pfCands.at(index_chH).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), -0.0138f, 8.622f);
+          pfCands.at(index_chH).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(),
+          -0.0138f,
+          8.622f);
 
       const bool hasTrackDetails = candFunc::getHasTrackDetails(chH_cand);
       if (hasTrackDetails) {
@@ -2013,8 +2178,10 @@ private:
         get(dnn::pfCand_chHad_dxy_sig) =
             getValueNorm(std::abs(candFunc::getTauDxy(chH_cand, default_value)) / chH_cand.dxyError(), 6.417f, 36.28f);
         get(dnn::pfCand_chHad_dz) = getValueNorm(candFunc::getTauDz(chH_cand, default_value), -0.0246f, 7.618f);
-        get(dnn::pfCand_chHad_dz_sig) =
-            getValueNorm(std::abs(candFunc::getTauDz(chH_cand, default_value)) / candFunc::getTauDzError(chH_cand, default_value), 301.3f, 491.1f);
+        get(dnn::pfCand_chHad_dz_sig) = getValueNorm(
+            std::abs(candFunc::getTauDz(chH_cand, default_value)) / candFunc::getTauDzError(chH_cand, default_value),
+            301.3f,
+            491.1f);
         get(dnn::pfCand_chHad_track_chi2_ndof) =
             candFunc::getPseudoTrack(chH_cand).ndof() > 0
                 ? getValueNorm(candFunc::getPseudoTrack(chH_cand).chi2() / candFunc::getPseudoTrack(chH_cand).ndof(),
@@ -2026,7 +2193,7 @@ private:
                 ? getValueNorm(candFunc::getPseudoTrack(chH_cand).ndof(), 13.92f, 6.581f)
                 : 0;
       }
-      float hcal_fraction = candFunc::getHCalFraction(chH_cand) ;
+      float hcal_fraction = candFunc::getHCalFraction(chH_cand);
       get(dnn::pfCand_chHad_hcalFraction) = getValue(hcal_fraction);
       get(dnn::pfCand_chHad_rawCaloFraction) = getValueLinear(candFunc::getRawCaloFraction(chH_cand), 0.f, 2.6f, true);
     }
@@ -2054,7 +2221,8 @@ private:
 
   template <typename dnn, typename CandidateCastType, typename TauCastType>
   tensorflow::Tensor createInputsV1(const TauCastType& tau,
-                                    size_t tau_index,
+                                    const size_t tau_index,
+                                    const deep_tau::DeepTauBase::TauRef tau_ref,
                                     const std::vector<pat::Electron>& electrons,
                                     const std::vector<pat::Muon>& muons,
                                     tauFunc tau_funcs) const {
@@ -2075,11 +2243,11 @@ private:
     get(dnn::eta) = tau.p4().eta();
     get(dnn::mass) = tau.p4().mass();
     get(dnn::decayMode) = tau.decayMode();
-    get(dnn::chargedIsoPtSum) = tau_funcs.getChargedIsoPtSum(tau, tau_index);
-    get(dnn::neutralIsoPtSum) = tau_funcs.getNeutralIsoPtSum(tau, tau_index);
-    get(dnn::neutralIsoPtSumWeight) = tau_funcs.getNeutralIsoPtSumWeight(tau, tau_index);
-    get(dnn::photonPtSumOutsideSignalCone) = tau_funcs.getPhotonPtSumOutsideSignalCone(tau, tau_index);
-    get(dnn::puCorrPtSum) = tau_funcs.getPuCorrPtSum(tau, tau_index);
+    get(dnn::chargedIsoPtSum) = tau_funcs.getChargedIsoPtSum(tau, tau_index, tau_ref);
+    get(dnn::neutralIsoPtSum) = tau_funcs.getNeutralIsoPtSum(tau, tau_index, tau_ref);
+    get(dnn::neutralIsoPtSumWeight) = tau_funcs.getNeutralIsoPtSumWeight(tau, tau_index, tau_ref);
+    get(dnn::photonPtSumOutsideSignalCone) = tau_funcs.getPhotonPtSumOutsideSignalCone(tau, tau_index, tau_ref);
+    get(dnn::puCorrPtSum) = tau_funcs.getPuCorrPtSum(tau, tau_index, tau_ref);
     get(dnn::dxy) = tau_funcs.getdxy(tau, tau_index);
     get(dnn::dxy_sig) = tau_funcs.getdxySig(tau, tau_index);
     get(dnn::dz) = leadChargedHadrCand ? candFunc::getTauDz(leadChargedHadrCand, default_value) : default_value;
@@ -2153,8 +2321,10 @@ private:
     get(dnn::leadChargedHadrCand_HoP) = default_value;
     get(dnn::leadChargedHadrCand_EoP) = default_value;
     if (tau.leadChargedHadrCand()->pt() > 0) {
-      get(dnn::leadChargedHadrCand_HoP) = tau_funcs.getEcalEnergyLeadingChargedHadr(tau) / tau.leadChargedHadrCand()->pt();
-      get(dnn::leadChargedHadrCand_EoP) = tau_funcs.getHcalEnergyLeadingChargedHadr(tau) / tau.leadChargedHadrCand()->pt();
+      get(dnn::leadChargedHadrCand_HoP) =
+          tau_funcs.getEcalEnergyLeadingChargedHadr(tau) / tau.leadChargedHadrCand()->pt();
+      get(dnn::leadChargedHadrCand_EoP) =
+          tau_funcs.getHcalEnergyLeadingChargedHadr(tau) / tau.leadChargedHadrCand()->pt();
     }
 
     MuonHitMatchV1 muon_hit_match;
@@ -2350,14 +2520,17 @@ private:
 
   // Copied from https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc#L218
   template <typename TauCastType>
-  static bool calculateGottfriedJacksonAngleDifference(const TauCastType& tau, size_t tau_index, double& gj_diff, tauFunc tau_funcs) {
+  static bool calculateGottfriedJacksonAngleDifference(const TauCastType& tau,
+                                                       const size_t tau_index,
+                                                       double& gj_diff,
+                                                       tauFunc tau_funcs) {
     if (tau_funcs.getHasSecondaryVertex(tau, tau_index)) {
       static constexpr double mTau = 1.77682;
       const double mAOne = tau.p4().M();
       const double pAOneMag = tau.p();
       const double argumentThetaGJmax = (std::pow(mTau, 2) - std::pow(mAOne, 2)) / (2 * mTau * pAOneMag);
-      const double argumentThetaGJmeasured =
-          tau.p4().Vect().Dot(tau_funcs.getFlightLength(tau, tau_index)) / (pAOneMag * tau_funcs.getFlightLength(tau, tau_index).R());
+      const double argumentThetaGJmeasured = tau.p4().Vect().Dot(tau_funcs.getFlightLength(tau, tau_index)) /
+                                             (pAOneMag * tau_funcs.getFlightLength(tau, tau_index).R());
       if (std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1.) {
         double thetaGJmax = std::asin(argumentThetaGJmax);
         double thetaGJmeasured = std::acos(argumentThetaGJmeasured);
@@ -2369,7 +2542,9 @@ private:
   }
 
   template <typename TauCastType>
-  static float calculateGottfriedJacksonAngleDifference(const TauCastType& tau, size_t tau_index, tauFunc tau_funcs) {
+  static float calculateGottfriedJacksonAngleDifference(const TauCastType& tau,
+                                                        const size_t tau_index,
+                                                        tauFunc tau_funcs) {
     double gj_diff;
     if (calculateGottfriedJacksonAngleDifference(tau, tau_index, gj_diff, tau_funcs))
       return static_cast<float>(gj_diff);
@@ -2399,21 +2574,18 @@ private:
   edm::EDGetTokenT<std::vector<pat::Electron>> electrons_token_;
   edm::EDGetTokenT<std::vector<pat::Muon>> muons_token_;
   edm::EDGetTokenT<double> rho_token_;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSum_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSumdR03_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSum_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumdR03_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> puCorrPtSum_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> footprintCorrection_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumWeight_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumWeightdR03_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> photonPtSumOutsideSignalCone_inputToken;
-  edm::EDGetTokenT<reco::PFTauDiscriminator> photonPtSumOutsideSignalConedR03_inputToken;
-  edm::EDGetTokenT<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>> PFTauTransverseImpactParameters_token;
-
-
+  edm::EDGetTokenT<reco::TauDiscriminatorContainer> basicTauDiscriminators_inputToken;
+  edm::EDGetTokenT<reco::TauDiscriminatorContainer> basicTauDiscriminatorsdR03_inputToken;
+  edm::EDGetTokenT<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
+      PFTauTransverseImpactParameters_token;
   std::string input_layer_, output_layer_;
   const unsigned version;
+  const unsigned chargedIsoPtSum_index;
+  const unsigned neutralIsoPtSum_index;
+  const unsigned neutralIsoPtSumWeight_index;
+  const unsigned tauFootPrintCorrection_index;
+  const unsigned photonPtSumOutsideSignalCone_index;
+  const unsigned puCorrPtSum_index;
   const int debug_level;
   const bool disable_dxy_pca_;
   std::unique_ptr<tensorflow::Tensor> tauBlockTensor_;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1160,6 +1160,25 @@ namespace {
 
 }  // anonymous namespace
 
+using bd = deep_tau::DeepTauBase::BasicDiscriminator;
+const std::map<bd, std::string> deep_tau::DeepTauBase::stringFromDiscriminator_{
+    {bd::ChargedIsoPtSum, "ChargedIsoPtSum"},
+    {bd::NeutralIsoPtSum, "NeutralIsoPtSum"},
+    {bd::NeutralIsoPtSumWeight, "NeutralIsoPtSumWeight"},
+    {bd::FootprintCorrection, "TauFootprintCorrection"},
+    {bd::PhotonPtSumOutsideSignalCone, "PhotonPtSumOutsideSignalCone"},
+    {bd::PUcorrPtSum, "PUcorrPtSum"}};
+const std::vector<bd> deep_tau::DeepTauBase::requiredBasicDiscriminators = {bd::ChargedIsoPtSum,
+                                                                            bd::NeutralIsoPtSum,
+                                                                            bd::NeutralIsoPtSumWeight,
+                                                                            bd::PhotonPtSumOutsideSignalCone,
+                                                                            bd::PUcorrPtSum};
+const std::vector<bd> deep_tau::DeepTauBase::requiredBasicDiscriminatorsdR03 = {bd::ChargedIsoPtSum,
+                                                                                bd::NeutralIsoPtSum,
+                                                                                bd::NeutralIsoPtSumWeight,
+                                                                                bd::PhotonPtSumOutsideSignalCone,
+                                                                                bd::FootprintCorrection};
+
 class DeepTauId : public deep_tau::DeepTauBase {
 public:
   static constexpr float default_value = -999.;
@@ -1197,11 +1216,12 @@ public:
     //translate to a map of <BasicDiscriminator, index> and check if all discriminators are present
     std::map<BasicDiscriminator, size_t> discrIndexMap;
     for (size_t i = 0; i < requiredDiscr.size(); i++) {
-      if (discrIndexMapStr.find(stringFromDiscriminator_[requiredDiscr[i]]) == discrIndexMapStr.end())
-        throw cms::Exception("DeepTauId") << "Basic Discriminator " << stringFromDiscriminator_[requiredDiscr[i]]
+      std::cout << stringFromDiscriminator_.at(requiredDiscr[i]) << std::endl;
+      if (discrIndexMapStr.find(stringFromDiscriminator_.at(requiredDiscr[i])) == discrIndexMapStr.end())
+        throw cms::Exception("DeepTauId") << "Basic Discriminator " << stringFromDiscriminator_.at(requiredDiscr[i])
                                           << " was not provided in the config file.";
       else
-        discrIndexMap[requiredDiscr[i]] = discrIndexMapStr[stringFromDiscriminator_[requiredDiscr[i]]];
+        discrIndexMap[requiredDiscr[i]] = discrIndexMapStr[stringFromDiscriminator_.at(requiredDiscr[i])];
     }
     return discrIndexMap;
   }

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -414,38 +414,20 @@ namespace {
     }
   }  // namespace dnn_inputs_2017_v2
 
-  const std::map<std::string, size_t> matchDiscriminatorIndices(
-      edm::Event& event, edm::EDGetTokenT<reco::TauDiscriminatorContainer> discriminatorContainerToken) {
-    std::map<std::string, size_t> discrIndexMap;
-    auto const aHandle = event.getHandle(discriminatorContainerToken);
-    auto const aProv = aHandle.provenance();
-    if (aProv == nullptr)
-      aHandle.whyFailed()->raise();
-    const auto& psetsFromProvenance = edm::parameterSet(*aProv, event.processHistory());
-    auto const idlist = psetsFromProvenance.getParameter<std::vector<edm::ParameterSet>>("IDdefinitions");
-    for (size_t j = 0; j < idlist.size(); ++j) {
-      std::string idname = idlist[j].getParameter<std::string>("IDname");
-      if (discrIndexMap.count(idname)) {
-        throw cms::Exception("DeepTauId")
-            << "basic discriminator " << idname << " appears more than once in the input.";
-      }
-      discrIndexMap[idname] = j;
-    }
-    return discrIndexMap;
-  }
-
   struct tauFunc {
     edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminatorCollection;
     edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminatordR03Collection;
     edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
         PFTauTransverseImpactParameters;
-    std::map<std::string, size_t> indexMap;
-    std::map<std::string, size_t> indexMapdR03;
+
+    using basicDiscr = deep_tau::DeepTauBase::BasicDiscriminator;
+    std::map<basicDiscr, size_t> indexMap;
+    std::map<basicDiscr, size_t> indexMapdR03;
 
     const float getChargedIsoPtSum(const reco::PFTau& tau,
                                    const size_t tau_index,
                                    const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap["ChargedIsoPtSum"]);
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap[basicDiscr::ChargedIsoPtSum]);
     }
     const float getChargedIsoPtSum(const pat::Tau& tau,
                                    const size_t tau_index,
@@ -455,7 +437,7 @@ namespace {
     const float getChargedIsoPtSumdR03(const reco::PFTau& tau,
                                        const size_t tau_index,
                                        const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03["ChargedIsoPtSum"]);
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03[basicDiscr::ChargedIsoPtSum]);
     }
     const float getChargedIsoPtSumdR03(const pat::Tau& tau,
                                        const size_t tau_index,
@@ -465,7 +447,8 @@ namespace {
     const float getFootprintCorrectiondR03(const reco::PFTau& tau,
                                            const size_t tau_index,
                                            const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03["TauFootprintCorrection"]);
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(
+          indexMapdR03[basicDiscr::FootprintCorrection]);
     }
     const float getFootprintCorrectiondR03(const pat::Tau& tau,
                                            const size_t tau_index,
@@ -475,7 +458,7 @@ namespace {
     const float getNeutralIsoPtSum(const reco::PFTau& tau,
                                    const size_t tau_index,
                                    const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap["NeutralIsoPtSum"]);
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap[basicDiscr::NeutralIsoPtSum]);
     }
     const float getNeutralIsoPtSum(const pat::Tau& tau,
                                    const size_t tau_index,
@@ -485,7 +468,7 @@ namespace {
     const float getNeutralIsoPtSumdR03(const reco::PFTau& tau,
                                        const size_t tau_index,
                                        const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03["NeutralIsoPtSum"]);
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03[basicDiscr::NeutralIsoPtSum]);
     }
     const float getNeutralIsoPtSumdR03(const pat::Tau& tau,
                                        const size_t tau_index,
@@ -495,7 +478,7 @@ namespace {
     const float getNeutralIsoPtSumWeight(const reco::PFTau& tau,
                                          const size_t tau_index,
                                          const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap["NeutralIsoPtSumWeight"]);
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap[basicDiscr::NeutralIsoPtSumWeight]);
     }
     const float getNeutralIsoPtSumWeight(const pat::Tau& tau,
                                          const size_t tau_index,
@@ -505,7 +488,8 @@ namespace {
     const float getNeutralIsoPtSumdR03Weight(const reco::PFTau& tau,
                                              const size_t tau_index,
                                              const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03["NeutralIsoPtSumWeight"]);
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(
+          indexMapdR03[basicDiscr::NeutralIsoPtSumWeight]);
     }
     const float getNeutralIsoPtSumdR03Weight(const pat::Tau& tau,
                                              const size_t tau_index,
@@ -515,7 +499,8 @@ namespace {
     const float getPhotonPtSumOutsideSignalCone(const reco::PFTau& tau,
                                                 const size_t tau_index,
                                                 const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap["PhotonPtSumOutsideSignalCone"]);
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(
+          indexMap[basicDiscr::PhotonPtSumOutsideSignalCone]);
     }
     const float getPhotonPtSumOutsideSignalCone(const pat::Tau& tau,
                                                 const size_t tau_index,
@@ -525,7 +510,8 @@ namespace {
     const float getPhotonPtSumOutsideSignalConedR03(const reco::PFTau& tau,
                                                     const size_t tau_index,
                                                     const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(indexMapdR03["PhotonPtSumOutsideSignalCone"]);
+      return (*basicTauDiscriminatordR03Collection)[tau_ref].rawValues.at(
+          indexMapdR03[basicDiscr::PhotonPtSumOutsideSignalCone]);
     }
     const float getPhotonPtSumOutsideSignalConedR03(const pat::Tau& tau,
                                                     const size_t tau_index,
@@ -535,7 +521,7 @@ namespace {
     const float getPuCorrPtSum(const reco::PFTau& tau,
                                const size_t tau_index,
                                const edm::RefToBase<reco::BaseTau> tau_ref) {
-      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap["PUcorrPtSum"]);
+      return (*basicTauDiscriminatorCollection)[tau_ref].rawValues.at(indexMap[basicDiscr::PUcorrPtSum]);
     }
     const float getPuCorrPtSum(const pat::Tau& tau,
                                const size_t tau_index,
@@ -1188,6 +1174,38 @@ public:
     return outputs_;
   }
 
+  const std::map<BasicDiscriminator, size_t> matchDiscriminatorIndices(
+      edm::Event& event,
+      edm::EDGetTokenT<reco::TauDiscriminatorContainer> discriminatorContainerToken,
+      std::vector<BasicDiscriminator> requiredDiscr) {
+    std::map<std::string, size_t> discrIndexMapStr;
+    auto const aHandle = event.getHandle(discriminatorContainerToken);
+    auto const aProv = aHandle.provenance();
+    if (aProv == nullptr)
+      aHandle.whyFailed()->raise();
+    const auto& psetsFromProvenance = edm::parameterSet(*aProv, event.processHistory());
+    auto const idlist = psetsFromProvenance.getParameter<std::vector<edm::ParameterSet>>("IDdefinitions");
+    for (size_t j = 0; j < idlist.size(); ++j) {
+      std::string idname = idlist[j].getParameter<std::string>("IDname");
+      if (discrIndexMapStr.count(idname)) {
+        throw cms::Exception("DeepTauId")
+            << "basic discriminator " << idname << " appears more than once in the input.";
+      }
+      discrIndexMapStr[idname] = j;
+    }
+
+    //translate to a map of <BasicDiscriminator, index> and check if all discriminators are present
+    std::map<BasicDiscriminator, size_t> discrIndexMap;
+    for (size_t i = 0; i < requiredDiscr.size(); i++) {
+      if (discrIndexMapStr.find(stringFromDiscriminator_[requiredDiscr[i]]) == discrIndexMapStr.end())
+        throw cms::Exception("DeepTauId") << "Basic Discriminator " << stringFromDiscriminator_[requiredDiscr[i]]
+                                          << " was not provided in the config file.";
+      else
+        discrIndexMap[requiredDiscr[i]] = discrIndexMapStr[stringFromDiscriminator_[requiredDiscr[i]]];
+    }
+    return discrIndexMap;
+  }
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("electrons", edm::InputTag("slimmedElectrons"));
@@ -1366,8 +1384,6 @@ private:
     edm::Handle<reco::TauDiscriminatorContainer> basicTauDiscriminatorsdR03;
     edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
         PFTauTransverseImpactParameters;
-    std::map<std::string, size_t> basicDiscrIndexMap;
-    std::map<std::string, size_t> basicDiscrdR03IndexMap;
 
     if (!is_online) {
       event.getByToken(electrons_token_, tmp_electrons);
@@ -1378,15 +1394,20 @@ private:
       event.getByToken(basicTauDiscriminatorsdR03_inputToken, basicTauDiscriminatorsdR03);
 
       // Get indices for discriminators
-      basicDiscrIndexMap = matchDiscriminatorIndices(event, basicTauDiscriminators_inputToken);
-      basicDiscrdR03IndexMap = matchDiscriminatorIndices(event, basicTauDiscriminatorsdR03_inputToken);
+      if (!discrIndicesMapped_) {
+        basicDiscrIndexMap_ =
+            matchDiscriminatorIndices(event, basicTauDiscriminators_inputToken, requiredBasicDiscriminators);
+        basicDiscrdR03IndexMap_ =
+            matchDiscriminatorIndices(event, basicTauDiscriminatorsdR03_inputToken, requiredBasicDiscriminatorsdR03);
+        discrIndicesMapped_ = true;
+      }
     }
 
     tauFunc tauIDs = {basicTauDiscriminators,
                       basicTauDiscriminatorsdR03,
                       PFTauTransverseImpactParameters,
-                      basicDiscrIndexMap,
-                      basicDiscrdR03IndexMap};
+                      basicDiscrIndexMap_,
+                      basicDiscrdR03IndexMap_};
 
     lightLepFunc lightlep = {tmp_electrons, tmp_muons};
 
@@ -2653,6 +2674,11 @@ private:
   std::unique_ptr<tensorflow::Tensor> tauBlockTensor_;
   std::array<std::unique_ptr<tensorflow::Tensor>, 2> eGammaTensor_, muonTensor_, hadronsTensor_, convTensor_,
       zeroOutputTensor_;
+
+  //boolean to check if discriminator indices are already mapped
+  bool discrIndicesMapped_ = false;
+  std::map<BasicDiscriminator, size_t> basicDiscrIndexMap_;
+  std::map<BasicDiscriminator, size_t> basicDiscrdR03IndexMap_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -414,6 +414,218 @@ namespace {
     }
   }  // namespace dnn_inputs_2017_v2
 
+  struct tauFunc{
+
+    const reco::PFTauDiscriminator& chargedIsoPtSumCollection;
+    const reco::PFTauDiscriminator& chargedIsoPtSumdR03Collection;
+    const reco::PFTauDiscriminator& neutralIsoPtSumCollection;
+    const reco::PFTauDiscriminator& neutralIsoPtSumdR03Collection;
+    const reco::PFTauDiscriminator& puCorrPtSumCollection;
+    const reco::PFTauDiscriminator& footprintCorrectionCollection;
+    const reco::PFTauDiscriminator& neutralIsoPtSumWeightCollection;
+    const reco::PFTauDiscriminator& neutralIsoPtSumWeightdR03Collection;
+    const reco::PFTauDiscriminator& photonPtSumOutsideSignalConeCollection;
+    const reco::PFTauDiscriminator& photonPtSumOutsideSignalConedR03Collection;
+    edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>> PFTauTransverseImpactParameters;
+
+    const float getChargedIsoPtSum(const reco::PFTau& tau, size_t tau_index) {return chargedIsoPtSumCollection.value(tau_index);}
+    const float getChargedIsoPtSum(const pat::Tau& tau, size_t tau_index)  {return tau.tauID("chargedIsoPtSum");}
+
+    const float getChargedIsoPtSumdR03(const reco::PFTau& tau, size_t tau_index) {  return chargedIsoPtSumdR03Collection.value(tau_index);}
+    const float getChargedIsoPtSumdR03(const pat::Tau& tau, size_t tau_index) {  return tau.tauID("chargedIsoPtSumdR03");}
+
+    const float getFootprintCorrectiondR03(const reco::PFTau& tau, size_t tau_index) {  return footprintCorrectionCollection.value(tau_index);}
+    const float getFootprintCorrectiondR03(const pat::Tau& tau, size_t tau_index) {     return tau.tauID("footprintCorrectiondR03");}
+
+
+    const float getNeutralIsoPtSum(const reco::PFTau& tau, size_t tau_index) {  return neutralIsoPtSumCollection.value(tau_index);}
+    const float getNeutralIsoPtSum(const pat::Tau& tau, size_t tau_index) {  return tau.tauID("neutralIsoPtSum");}
+
+    const float getNeutralIsoPtSumdR03(const reco::PFTau& tau, size_t tau_index) {  return neutralIsoPtSumdR03Collection.value(tau_index);}
+    const float getNeutralIsoPtSumdR03(const pat::Tau& tau, size_t tau_index)   {return tau.tauID("neutralIsoPtSumdR03");}
+
+
+    const float getNeutralIsoPtSumWeight(const reco::PFTau& tau, size_t tau_index) { return neutralIsoPtSumWeightCollection.value(tau_index);}
+    const float getNeutralIsoPtSumWeight(const pat::Tau& tau, size_t tau_index) {return tau.tauID("neutralIsoPtSumWeight");}
+
+
+    const float getNeutralIsoPtSumdR03Weight(const reco::PFTau& tau, size_t tau_index) { return neutralIsoPtSumWeightdR03Collection.value(tau_index);}
+    const float getNeutralIsoPtSumdR03Weight(const pat::Tau& tau, size_t tau_index) {return tau.tauID("neutralIsoPtSumWeightdR03");}
+
+
+    const float getPhotonPtSumOutsideSignalCone(const reco::PFTau& tau, size_t tau_index) { return photonPtSumOutsideSignalConeCollection.value(tau_index);}
+    const float getPhotonPtSumOutsideSignalCone(const pat::Tau& tau, size_t tau_index) {return tau.tauID("photonPtSumOutsideSignalCone");}
+
+
+    const float getPhotonPtSumOutsideSignalConedR03(const reco::PFTau& tau, size_t tau_index) {  return photonPtSumOutsideSignalConedR03Collection.value(tau_index);}
+    const float getPhotonPtSumOutsideSignalConedR03(const pat::Tau& tau, size_t tau_index) {return tau.tauID("photonPtSumOutsideSignalConedR03");}
+
+
+    const float getPuCorrPtSum(const reco::PFTau& tau, size_t tau_index) { return puCorrPtSumCollection.value(tau_index);}
+    const float getPuCorrPtSum(const pat::Tau& tau, size_t tau_index) { return tau.tauID("puCorrPtSum");}
+
+    auto getdxyPCA(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy_PCA();}
+    auto getdxyPCA(const pat::Tau& tau, size_t tau_index) {return tau.dxy_PCA();}
+    auto getdxy(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy();}
+    auto getdxy(const pat::Tau& tau, size_t tau_index) {return tau.dxy();}
+    auto getdxyError(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy_error();}
+    auto getdxyError(const pat::Tau& tau, size_t tau_index) {return tau.dxy_error();}
+    auto getdxySig(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->dxy_Sig();}
+    auto getdxySig(const pat::Tau& tau, size_t tau_index) {return tau.dxy_Sig();}
+    auto getip3d(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->ip3d();}
+    auto getip3d(const pat::Tau& tau, size_t tau_index) {return tau.ip3d();}
+    auto getip3dError(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->ip3d_error();}
+    auto getip3dError(const pat::Tau& tau, size_t tau_index) {return tau.ip3d_error();}
+    auto getip3dSig(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->ip3d_Sig();}
+    auto getip3dSig(const pat::Tau& tau, size_t tau_index) {return tau.ip3d_Sig();}
+    auto getHasSecondaryVertex(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->hasSecondaryVertex();}
+    auto getHasSecondaryVertex(const pat::Tau& tau, size_t tau_index) {return tau.hasSecondaryVertex();}
+    auto getFlightLength(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->flightLength();}
+    auto getFlightLength(const pat::Tau& tau, size_t tau_index) {return tau.flightLength();}
+    auto getFlightLengthSig(const reco::PFTau& tau, size_t tau_index) {return PFTauTransverseImpactParameters->value(tau_index)->flightLengthSig();}
+    auto getFlightLengthSig(const pat::Tau& tau, size_t tau_index) {return tau.flightLengthSig();}
+
+    auto getLeadingTrackNormChi2(const reco::PFTau& tau) {return reco::tau::lead_track_chi2(tau);}
+    auto getLeadingTrackNormChi2(const pat::Tau& tau) {return tau.leadingTrackNormChi2();}
+
+    auto getEmFraction(const pat::Tau& tau) {return tau.emFraction_MVA();}
+    auto getEmFraction(const reco::PFTau& tau) {
+      auto leadChargedHadrCand = dynamic_cast<const reco::PFCandidate*>(tau.leadChargedHadrCand().get());
+      float emFraction = -1.;
+      float myHCALenergy = 0.;
+      float myECALenergy = 0.;
+      if(leadChargedHadrCand && leadChargedHadrCand->bestTrack() != nullptr){
+        for (const auto& isoPFCand : tau.isolationPFCands()) {
+            myHCALenergy += isoPFCand->hcalEnergy();
+            myECALenergy += isoPFCand->ecalEnergy();
+        }
+        for (const auto& signalPFCand : tau.signalPFCands()) {
+          myHCALenergy += signalPFCand->hcalEnergy();
+          myECALenergy += signalPFCand->ecalEnergy();
+        }
+        if (myHCALenergy + myECALenergy != 0.) {
+          emFraction = myECALenergy / (myHCALenergy + myECALenergy);
+        }
+      }
+      return emFraction;
+    }
+    auto getEtaAtEcalEntrance(const pat::Tau& tau) {return tau.etaAtEcalEntranceLeadChargedCand();}
+    auto getEtaAtEcalEntrance(const reco::PFTau& tau) {
+      const std::vector<reco::CandidatePtr>& signalCands = tau.signalCands();
+      float leadChargedCandPt = -99;
+      float leadChargedCandEtaAtEcalEntrance = -99;
+      for (const auto& it : signalCands) {
+        const reco::PFCandidate* icand = dynamic_cast<const reco::PFCandidate*>(it.get());
+        if (icand != nullptr) {
+          const reco::Track* track = nullptr;
+          if (icand->trackRef().isNonnull())
+            track = icand->trackRef().get();
+          else if (icand->muonRef().isNonnull() && icand->muonRef()->innerTrack().isNonnull())
+            track = icand->muonRef()->innerTrack().get();
+          else if (icand->muonRef().isNonnull() && icand->muonRef()->globalTrack().isNonnull())
+            track = icand->muonRef()->globalTrack().get();
+          else if (icand->muonRef().isNonnull() && icand->muonRef()->outerTrack().isNonnull())
+            track = icand->muonRef()->outerTrack().get();
+          else if (icand->gsfTrackRef().isNonnull())
+            track = icand->gsfTrackRef().get();
+          if (track) {
+            if (track->pt() > leadChargedCandPt) {
+              leadChargedCandEtaAtEcalEntrance = icand->positionAtECALEntrance().eta();
+              leadChargedCandPt = track->pt();
+            }
+          }
+        }
+      }
+      return leadChargedCandEtaAtEcalEntrance;
+    }
+    auto getEcalEnergyLeadingChargedHadr(const reco::PFTau& tau) {
+      auto leadChargedHadrCand = dynamic_cast<const reco::PFCandidate*>(tau.leadChargedHadrCand().get());
+      return leadChargedHadrCand->ecalEnergy();
+    }
+    auto getEcalEnergyLeadingChargedHadr(const pat::Tau& tau) {return tau.ecalEnergyLeadChargedHadrCand();} 
+    auto getHcalEnergyLeadingChargedHadr(const reco::PFTau& tau) {
+      auto leadChargedHadrCand = dynamic_cast<const reco::PFCandidate*>(tau.leadChargedHadrCand().get());
+      return leadChargedHadrCand->hcalEnergy();
+    }
+    auto getHcalEnergyLeadingChargedHadr(const pat::Tau& tau) {return tau.hcalEnergyLeadChargedHadrCand();} 
+  };
+
+  struct lightLepFunc{
+
+    const std::vector<pat::Electron>& electron_collection;
+    const std::vector<pat::Muon>& muon_collection;
+ 
+    const std::vector<pat::Electron> getElectrons(bool online){
+      if (!online) return electron_collection;
+      else{
+        const std::vector<pat::Electron> out_electrons;
+        return out_electrons;
+      }
+    }
+    const std::vector<pat::Muon> getMuons(bool online){
+      if (!online) return muon_collection;
+      else{
+        const std::vector<pat::Muon> out_muons;
+        return out_muons;
+      }
+    }
+  };
+
+
+  namespace candFunc{
+    auto getTauDz(const reco::PFCandidate* cand, float default_value) {return cand->bestTrack() != nullptr ? cand->bestTrack()->dz() : default_value;}
+    auto getTauDz(const pat::PackedCandidate* cand, float default_value) {return cand->dz();}    
+    auto getTauDzError(const reco::PFCandidate* cand, float default_value) {return cand->bestTrack() != nullptr ? cand->dzError() : default_value;}
+    auto getTauDzError(const pat::PackedCandidate* cand, float default_value) {return cand->hasTrackDetails() ? cand->dzError() : default_value;}  
+    auto getTauDz(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->dz() : default_value;}
+    auto getTauDz(const pat::PackedCandidate& cand, float default_value) {return cand.dz();}    
+    auto getTauDzError(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.dzError() : default_value;}
+    auto getTauDzError(const pat::PackedCandidate& cand, float default_value) {return cand.hasTrackDetails() ? cand.dzError() : default_value;}       
+    auto getTauDZSigValid(const reco::PFCandidate* cand) {
+      return cand->bestTrack() != nullptr && 
+      std::isnormal(cand->bestTrack()->dz())&& 
+      std::isnormal(cand->dzError()) && cand->dzError() > 0;
+      }
+    auto getTauDZSigValid(const pat::PackedCandidate* cand) {
+      return cand->hasTrackDetails() &&
+      std::isnormal(cand->dz()) &&
+      std::isnormal(cand->dzError()) && cand->dzError() > 0;
+    }    
+    auto getTauDxy(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->dxy() : default_value;}
+    auto getTauDxy(const pat::PackedCandidate& cand, float default_value) {return cand.dxy();}     
+    auto getPvAssocationQuality(const reco::PFCandidate& cand) {return 0.7013f;}
+    auto getPvAssocationQuality(const pat::PackedCandidate& cand) {return cand.pvAssociationQuality();}    
+    auto getPuppiWeight(const reco::PFCandidate& cand) {return 0.9907f;}
+    auto getPuppiWeight(const pat::PackedCandidate& cand) {return cand.puppiWeight();}    
+    auto getPuppiWeightNoLep(const reco::PFCandidate& cand) {return 0.8858f;}
+    auto getPuppiWeightNoLep(const pat::PackedCandidate& cand) {return cand.puppiWeightNoLep();}    
+    auto getLostInnerHits(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) : default_value;}
+    auto getLostInnerHits(const pat::PackedCandidate& cand, float default_value) {return cand.lostInnerHits();}    
+    auto getNumberOfPixelHits(const reco::PFCandidate& cand, float default_value) {return cand.bestTrack() != nullptr ? cand.bestTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) : default_value;}
+    auto getNumberOfPixelHits(const pat::PackedCandidate& cand, float default_value) {return cand.numberOfPixelHits();}    
+    auto getHasTrackDetails(const reco::PFCandidate& cand) {return cand.bestTrack() != nullptr;}
+    auto getHasTrackDetails(const pat::PackedCandidate& cand) {return cand.hasTrackDetails();}    
+    auto getPseudoTrack(const reco::PFCandidate& cand) {return *cand.bestTrack();}
+    auto getPseudoTrack(const pat::PackedCandidate& cand) {return cand.pseudoTrack();}    
+    auto getFromPV(const reco::PFCandidate& cand) {return 0.9994f;}
+    auto getFromPV(const pat::PackedCandidate& cand) {return cand.fromPV();}    
+    auto getHCalFraction(const reco::PFCandidate& cand) { return cand.rawHcalEnergy()/(cand.rawHcalEnergy()+cand.rawEcalEnergy());}
+    auto getHCalFraction(const pat::PackedCandidate& cand) { 
+      float hcal_fraction = 0.;
+      if (cand.pdgId() == 1 || cand.pdgId() == 130) {
+        hcal_fraction = cand.hcalFraction();
+      } else if (cand.isIsolatedChargedHadron()) {
+        hcal_fraction = cand.rawHcalFraction();
+      }
+      return hcal_fraction;
+    }
+    auto getRawCaloFraction(const reco::PFCandidate& cand) { return (cand.rawEcalEnergy()+cand.rawHcalEnergy())/cand.energy();}
+    auto getRawCaloFraction(const pat::PackedCandidate& cand) { return cand.rawCaloFraction();    }
+    
+  };
+
+
+
   template <typename LVector1, typename LVector2>
   float dEta(const LVector1& p4, const LVector2& tau_p4) {
     return static_cast<float>(p4.eta() - tau_p4.eta());
@@ -441,7 +653,7 @@ namespace {
       n_hits[MuonSubdetId::RPC].assign(n_muon_stations, 0);
     }
 
-    void addMatchedMuon(const pat::Muon& muon, const pat::Tau& tau) {
+    void addMatchedMuon(const pat::Muon& muon, const edm::View<reco::BaseTau>::const_reference& tau) {
       static constexpr int n_stations = 4;
 
       ++n_muons;
@@ -484,8 +696,9 @@ namespace {
       }
     }
 
-    static std::vector<const pat::Muon*> findMatchedMuons(const pat::Tau& tau,
-                                                          const pat::MuonCollection& muons,
+    template <typename TauCastType>
+    static std::vector<const pat::Muon*> findMatchedMuons(const TauCastType& tau,
+                                                          const std::vector<pat::Muon>& muons,
                                                           double deltaR,
                                                           double minPt) {
       const reco::Muon* hadr_cand_muon = nullptr;
@@ -506,8 +719,8 @@ namespace {
       return matched_muons;
     }
 
-    template <typename dnn, typename TensorElemGet>
-    void fillTensor(const TensorElemGet& get, const pat::Tau& tau, float default_value) const {
+    template <typename dnn, typename TensorElemGet, typename TauCastType>
+    void fillTensor(const TensorElemGet& get, const TauCastType& tau, float default_value) const {
       get(dnn::n_matched_muons) = n_muons;
       get(dnn::muon_pt) = best_matched_muon != nullptr ? best_matched_muon->p4().pt() : default_value;
       get(dnn::muon_dEta) = best_matched_muon != nullptr ? dEta(best_matched_muon->p4(), tau.p4()) : default_value;
@@ -723,7 +936,7 @@ namespace {
   }
 
   template <>
-  CellObjectType GetCellObjectType(const pat::PackedCandidate& cand) {
+  CellObjectType GetCellObjectType(const edm::View<reco::Candidate>::const_reference& cand) {
     static const std::map<int, CellObjectType> obj_types = {{11, CellObjectType::PfCand_electron},
                                                             {13, CellObjectType::PfCand_muon},
                                                             {22, CellObjectType::PfCand_gamma},
@@ -833,19 +1046,45 @@ public:
     desc.add<unsigned>("version", 2);
     desc.add<int>("debug_level", 0);
     desc.add<bool>("disable_dxy_pca", false);
+    desc.add<bool>("is_online", false);
 
     desc.add<std::vector<std::string>>("VSeWP");
     desc.add<std::vector<std::string>>("VSmuWP");
     desc.add<std::vector<std::string>>("VSjetWP");
+
+    desc.add<edm::InputTag>("chargedIsoPtSum", edm::InputTag("chargedIsoPtSum"));
+    desc.add<edm::InputTag>("chargedIsoPtSumdR03", edm::InputTag("chargedIsoPtSumdR03"));
+    desc.add<edm::InputTag>("neutralIsoPtSum", edm::InputTag("neutralIsoPtSum"));
+    desc.add<edm::InputTag>("neutralIsoPtSumdR03", edm::InputTag("neutralIsoPtSumdR03"));
+    desc.add<edm::InputTag>("puCorrPtSum", edm::InputTag("puCorrPtSum"));
+    desc.add<edm::InputTag>("footprintCorrection", edm::InputTag("footprintCorrection"));
+    desc.add<edm::InputTag>("neutralIsoPtSumWeight", edm::InputTag("neutralIsoPtSumWeight"));
+    desc.add<edm::InputTag>("neutralIsoPtSumWeightdR03", edm::InputTag("neutralIsoPtSumWeightdR03"));
+    desc.add<edm::InputTag>("photonPtSumOutsideSignalCone", edm::InputTag("photonPtSumOutsideSignalCone"));
+    desc.add<edm::InputTag>("photonPtSumOutsideSignalConedR03", edm::InputTag("photonPtSumOutsideSignalConedr03"));
+    desc.add<edm::InputTag>("pfTauTransverseImpactParameters", edm::InputTag("hpsPFTauTransverseImpactParameters"));
+
     descriptions.add("DeepTau", desc);
   }
 
 public:
   explicit DeepTauId(const edm::ParameterSet& cfg, const deep_tau::DeepTauCache* cache)
       : DeepTauBase(cfg, GetOutputs(), cache),
-        electrons_token_(consumes<ElectronCollection>(cfg.getParameter<edm::InputTag>("electrons"))),
-        muons_token_(consumes<MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))),
+        electrons_token_(consumes<std::vector<pat::Electron>>(cfg.getParameter<edm::InputTag>("electrons"))),
+        muons_token_(consumes<std::vector<pat::Muon>>(cfg.getParameter<edm::InputTag>("muons"))),
         rho_token_(consumes<double>(cfg.getParameter<edm::InputTag>("rho"))),
+        chargedIsoPtSum_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("chargedIsoPtSum"))),
+        chargedIsoPtSumdR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("chargedIsoPtSumdR03"))),
+        neutralIsoPtSum_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSum"))),
+        neutralIsoPtSumdR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSumdR03"))),
+        puCorrPtSum_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("puCorrPtSum"))),
+        footprintCorrection_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("footprintCorrection"))),
+        neutralIsoPtSumWeight_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSumWeight"))),
+        neutralIsoPtSumWeightdR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("neutralIsoPtSumWeightdR03"))),
+        photonPtSumOutsideSignalCone_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("photonPtSumOutsideSignalCone"))),
+        photonPtSumOutsideSignalConedR03_inputToken(consumes<reco::PFTauDiscriminator>(cfg.getParameter<edm::InputTag>("photonPtSumOutsideSignalConedR03"))),
+        PFTauTransverseImpactParameters_token(consumes<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>(cfg.getParameter<edm::InputTag>("pfTauTransverseImpactParameters"))),
+
         version(cfg.getParameter<unsigned>("version")),
         debug_level(cfg.getParameter<int>("debug_level")),
         disable_dxy_pca_(cfg.getParameter<bool>("disable_dxy_pca")) {
@@ -966,13 +1205,62 @@ private:
 
 private:
   tensorflow::Tensor getPredictions(edm::Event& event, edm::Handle<TauCollection> taus) override {
-    edm::Handle<pat::ElectronCollection> electrons;
-    event.getByToken(electrons_token_, electrons);
 
-    edm::Handle<pat::MuonCollection> muons;
-    event.getByToken(muons_token_, muons);
+    edm::Handle<std::vector<pat::Electron>> tmp_electrons;
+    edm::Handle<std::vector<pat::Muon>> tmp_muons;
+    edm::Handle<reco::PFTauDiscriminator> chargedIsoPtSumCollection;
+    edm::Handle<reco::PFTauDiscriminator> chargedIsoPtSumdR03Collection;
+    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumCollection;
+    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumdR03Collection;
+    edm::Handle<reco::PFTauDiscriminator> puCorrPtSumCollection;
+    edm::Handle<reco::PFTauDiscriminator> footprintCorrectionCollection;
+    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumWeightCollection;
+    edm::Handle<reco::PFTauDiscriminator> neutralIsoPtSumWeightdR03Collection;
+    edm::Handle<reco::PFTauDiscriminator> photonPtSumOutsideSignalConeCollection;
+    edm::Handle<reco::PFTauDiscriminator> photonPtSumOutsideSignalConedR03Collection;
+    edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>> PFTauTransverseImpactParameters;
 
-    edm::Handle<pat::PackedCandidateCollection> pfCands;
+
+    if (!is_online){
+      event.getByToken(electrons_token_, tmp_electrons);
+      event.getByToken(muons_token_, tmp_muons);
+    } else {
+      event.getByToken(chargedIsoPtSum_inputToken, chargedIsoPtSumCollection);
+      event.getByToken(chargedIsoPtSumdR03_inputToken, chargedIsoPtSumdR03Collection);
+      event.getByToken(neutralIsoPtSum_inputToken, neutralIsoPtSumCollection);
+      event.getByToken(neutralIsoPtSumdR03_inputToken, neutralIsoPtSumdR03Collection);
+      event.getByToken(puCorrPtSum_inputToken, puCorrPtSumCollection);
+      event.getByToken(footprintCorrection_inputToken, footprintCorrectionCollection);
+      event.getByToken(neutralIsoPtSumWeight_inputToken, neutralIsoPtSumWeightCollection);
+      event.getByToken(neutralIsoPtSumWeightdR03_inputToken, neutralIsoPtSumWeightdR03Collection);
+      event.getByToken(photonPtSumOutsideSignalCone_inputToken, photonPtSumOutsideSignalConeCollection);
+      event.getByToken(photonPtSumOutsideSignalConedR03_inputToken, photonPtSumOutsideSignalConedR03Collection);
+      event.getByToken(PFTauTransverseImpactParameters_token, PFTauTransverseImpactParameters);
+    }
+
+    tauFunc tauIDs = {
+      *chargedIsoPtSumCollection,
+      *chargedIsoPtSumdR03Collection,
+      *neutralIsoPtSumCollection,
+      *neutralIsoPtSumdR03Collection,
+      *puCorrPtSumCollection,
+      *footprintCorrectionCollection,
+      *neutralIsoPtSumWeightCollection,
+      *neutralIsoPtSumWeightdR03Collection,
+      *photonPtSumOutsideSignalConeCollection,
+      *photonPtSumOutsideSignalConedR03Collection,
+      PFTauTransverseImpactParameters
+    };
+
+    lightLepFunc lightlep = {
+      *tmp_electrons,
+      *tmp_muons
+    };
+
+    std::vector<pat::Electron> electrons = lightlep.getElectrons(is_online);
+    std::vector<pat::Muon> muons = lightlep.getMuons(is_online);
+
+    edm::Handle<edm::View<reco::Candidate>> pfCands;
     event.getByToken(pfcandToken_, pfCands);
 
     edm::Handle<reco::VertexCollection> vertices;
@@ -982,14 +1270,28 @@ private:
     event.getByToken(rho_token_, rho);
 
     tensorflow::Tensor predictions(tensorflow::DT_FLOAT, {static_cast<int>(taus->size()), deep_tau::NumberOfOutputs});
+
+
     for (size_t tau_index = 0; tau_index < taus->size(); ++tau_index) {
+
       std::vector<tensorflow::Tensor> pred_vector;
-      if (version == 1)
-        getPredictionsV1(taus->at(tau_index), *electrons, *muons, pred_vector);
-      else if (version == 2)
-        getPredictionsV2(taus->at(tau_index), *electrons, *muons, *pfCands, vertices->at(0), *rho, pred_vector);
-      else
-        throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+      if (is_online){
+        if (version == 1)
+          getPredictionsV1<reco::PFCandidate, reco::PFTau>(taus->at(tau_index), tau_index, electrons, muons, pred_vector, tauIDs);
+        else if (version == 2){
+          getPredictionsV2<reco::PFCandidate, reco::PFTau>(taus->at(tau_index), tau_index, electrons, muons, *pfCands, vertices->at(0), *rho, pred_vector, tauIDs);
+        }
+        else
+          throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+      } else {
+        if (version == 1)
+          getPredictionsV1<pat::PackedCandidate, pat::Tau>(taus->at(tau_index), tau_index, electrons, muons, pred_vector, tauIDs);
+        else if (version == 2)
+          getPredictionsV2<pat::PackedCandidate, pat::Tau>(taus->at(tau_index), tau_index, electrons, muons, *pfCands, vertices->at(0), *rho, pred_vector, tauIDs);
+        else
+          throw cms::Exception("DeepTauId") << "version " << version << " is not supported.";
+      }
+
       for (int k = 0; k < deep_tau::NumberOfOutputs; ++k) {
         const float pred = pred_vector[0].flat<float>()(k);
         if (!(pred >= 0 && pred <= 1))
@@ -1001,30 +1303,37 @@ private:
     return predictions;
   }
 
-  void getPredictionsV1(const TauType& tau,
-                        const pat::ElectronCollection& electrons,
-                        const pat::MuonCollection& muons,
-                        std::vector<tensorflow::Tensor>& pred_vector) {
-    const tensorflow::Tensor& inputs = createInputsV1<dnn_inputs_2017v1>(tau, electrons, muons);
+  template <typename CandidateCastType, typename TauCastType>
+  void getPredictionsV1(const TauType::const_reference& tau,
+                        size_t tau_index,
+                        const std::vector<pat::Electron>& electrons,
+                        const std::vector<pat::Muon>& muons,
+                        std::vector<tensorflow::Tensor>& pred_vector,
+                        tauFunc tau_funcs) {
+    const tensorflow::Tensor& inputs = createInputsV1<dnn_inputs_2017v1, const CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, electrons, muons, tau_funcs);
     tensorflow::run(&(cache_->getSession()), {{input_layer_, inputs}}, {output_layer_}, &pred_vector);
   }
 
-  void getPredictionsV2(const TauType& tau,
-                        const pat::ElectronCollection& electrons,
-                        const pat::MuonCollection& muons,
-                        const pat::PackedCandidateCollection& pfCands,
+  template <typename CandidateCastType, typename TauCastType>
+  void getPredictionsV2(const TauType::const_reference& tau,
+                        size_t tau_index,
+                        const std::vector<pat::Electron>& electrons,
+                        const std::vector<pat::Muon>& muons,
+                        const edm::View<reco::Candidate>& pfCands,
                         const reco::Vertex& pv,
                         double rho,
-                        std::vector<tensorflow::Tensor>& pred_vector) {
+                        std::vector<tensorflow::Tensor>& pred_vector,
+                        tauFunc tau_funcs) {
+
     CellGrid inner_grid(dnn_inputs_2017_v2::number_of_inner_cell, dnn_inputs_2017_v2::number_of_inner_cell, 0.02, 0.02);
     CellGrid outer_grid(dnn_inputs_2017_v2::number_of_outer_cell, dnn_inputs_2017_v2::number_of_outer_cell, 0.05, 0.05);
-    fillGrids(tau, electrons, inner_grid, outer_grid);
-    fillGrids(tau, muons, inner_grid, outer_grid);
-    fillGrids(tau, pfCands, inner_grid, outer_grid);
+    fillGrids(dynamic_cast<const TauCastType&>(tau), electrons, inner_grid, outer_grid);
+    fillGrids(dynamic_cast<const TauCastType&>(tau), muons, inner_grid, outer_grid);
+    fillGrids(dynamic_cast<const TauCastType&>(tau), pfCands, inner_grid, outer_grid);
 
-    createTauBlockInputs(tau, pv, rho);
-    createConvFeatures(tau, pv, rho, electrons, muons, pfCands, inner_grid, true);
-    createConvFeatures(tau, pv, rho, electrons, muons, pfCands, outer_grid, false);
+    createTauBlockInputs<CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, pv, rho, tau_funcs);
+    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, pv, rho, electrons, muons, pfCands, inner_grid, tau_funcs, true);
+    createConvFeatures<CandidateCastType>(dynamic_cast<const TauCastType&>(tau), tau_index, pv, rho, electrons, muons, pfCands, outer_grid, tau_funcs, false);
 
     tensorflow::run(&(cache_->getSession("core")),
                     {{"input_tau", *tauBlockTensor_},
@@ -1034,8 +1343,8 @@ private:
                     &pred_vector);
   }
 
-  template <typename Collection>
-  void fillGrids(const TauType& tau, const Collection& objects, CellGrid& inner_grid, CellGrid& outer_grid) {
+  template <typename Collection, typename TauCastType>
+  void fillGrids(const TauCastType& tau, const Collection& objects, CellGrid& inner_grid, CellGrid& outer_grid) {
     static constexpr double outer_dR2 = 0.25;  //0.5^2
     const double inner_radius = getInnerSignalConeRadius(tau.polarP4().pt());
     const double inner_dR2 = std::pow(inner_radius, 2);
@@ -1069,6 +1378,7 @@ private:
       if (dR2 < outer_dR2)
         addObject(n, deta, dphi, outer_grid);
     }
+
   }
 
   tensorflow::Tensor getPartialPredictions(bool is_inner) {
@@ -1092,19 +1402,22 @@ private:
                       {"outer_all_dropout_4/Identity"},
                       &pred_vector);
     }
+
     return pred_vector.at(0);
   }
 
-  void createConvFeatures(const TauType& tau,
+  template <typename CandidateCastType, typename TauCastType>
+  void createConvFeatures(const TauCastType& tau,
+                          size_t tau_index,
                           const reco::Vertex& pv,
                           double rho,
-                          const pat::ElectronCollection& electrons,
-                          const pat::MuonCollection& muons,
-                          const pat::PackedCandidateCollection& pfCands,
+                          const std::vector<pat::Electron>& electrons,
+                          const std::vector<pat::Muon>& muons,
+                          const edm::View<reco::Candidate>& pfCands,
                           const CellGrid& grid,
+                          tauFunc tau_funcs,
                           bool is_inner) {
     tensorflow::Tensor& convTensor = *convTensor_.at(is_inner);
-
     eGammaTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
         tensorflow::DT_FLOAT,
         tensorflow::TensorShape{
@@ -1129,16 +1442,15 @@ private:
         const auto cell_iter = grid.find(cell_index);
         if (cell_iter != grid.end()) {
           const Cell& cell = cell_iter->second;
-          createEgammaBlockInputs(idx, tau, pv, rho, electrons, pfCands, cell, is_inner);
-          createMuonBlockInputs(idx, tau, pv, rho, muons, pfCands, cell, is_inner);
-          createHadronsBlockInputs(idx, tau, pv, rho, pfCands, cell, is_inner);
+          createEgammaBlockInputs<CandidateCastType>(idx, tau, tau_index, pv, rho, electrons, pfCands, cell, tau_funcs, is_inner);
+          createMuonBlockInputs<CandidateCastType>(idx, tau, tau_index, pv, rho, muons, pfCands, cell, tau_funcs, is_inner);
+          createHadronsBlockInputs<CandidateCastType>(idx, tau, tau_index, pv, rho, pfCands, cell, tau_funcs, is_inner);
           idx += 1;
         }
       }
     }
 
     const auto predTensor = getPartialPredictions(is_inner);
-
     idx = 0;
     for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
       for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
@@ -1166,7 +1478,8 @@ private:
       convTensor.tensor<float, 4>()(0, eta_index, phi_index, n) = features.tensor<float, 4>()(batch_idx, 0, 0, n);
   }
 
-  void createTauBlockInputs(const TauType& tau, const reco::Vertex& pv, double rho) {
+  template <typename CandidateCastType, typename TauCastType>
+  void createTauBlockInputs(const TauCastType& tau, size_t& tau_index, const reco::Vertex& pv, double rho, tauFunc tau_funcs) {
     namespace dnn = dnn_inputs_2017_v2::TauBlockInputs;
 
     tensorflow::Tensor& inputs = *tauBlockTensor_;
@@ -1174,7 +1487,7 @@ private:
 
     const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
 
-    auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
+    auto leadChargedHadrCand = dynamic_cast<const CandidateCastType*>(tau.leadChargedHadrCand().get());
 
     get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
     get(dnn::tau_pt) = getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
@@ -1185,59 +1498,54 @@ private:
     get(dnn::tau_charge) = getValue(tau.charge());
     get(dnn::tau_n_charged_prongs) = getValueLinear(tau.decayMode() / 5 + 1, 1, 3, true);
     get(dnn::tau_n_neutral_prongs) = getValueLinear(tau.decayMode() % 5, 0, 2, true);
-    get(dnn::chargedIsoPtSum) = getValueNorm(tau.tauID("chargedIsoPtSum"), 47.78f, 123.5f);
-    get(dnn::chargedIsoPtSumdR03_over_dR05) = getValue(tau.tauID("chargedIsoPtSumdR03") / tau.tauID("chargedIsoPtSum"));
-    get(dnn::footprintCorrection) = getValueNorm(tau.tauID("footprintCorrectiondR03"), 9.029f, 26.42f);
-    get(dnn::neutralIsoPtSum) = getValueNorm(tau.tauID("neutralIsoPtSum"), 57.59f, 155.3f);
+    get(dnn::chargedIsoPtSum) = getValueNorm(tau_funcs.getChargedIsoPtSum(tau, tau_index), 47.78f, 123.5f);
+    get(dnn::chargedIsoPtSumdR03_over_dR05) = getValue(tau_funcs.getChargedIsoPtSumdR03(tau, tau_index) / tau_funcs.getChargedIsoPtSum(tau, tau_index));
+    get(dnn::footprintCorrection) = getValueNorm(tau_funcs.getFootprintCorrectiondR03(tau, tau_index), 9.029f, 26.42f);
+    get(dnn::neutralIsoPtSum) = getValueNorm(tau_funcs.getNeutralIsoPtSum(tau, tau_index), 57.59f, 155.3f);
     get(dnn::neutralIsoPtSumWeight_over_neutralIsoPtSum) =
-        getValue(tau.tauID("neutralIsoPtSumWeight") / tau.tauID("neutralIsoPtSum"));
+        getValue(tau_funcs.getNeutralIsoPtSumWeight(tau, tau_index) / tau_funcs.getNeutralIsoPtSum(tau, tau_index));
     get(dnn::neutralIsoPtSumWeightdR03_over_neutralIsoPtSum) =
-        getValue(tau.tauID("neutralIsoPtSumWeightdR03") / tau.tauID("neutralIsoPtSum"));
-    get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau.tauID("neutralIsoPtSumdR03") / tau.tauID("neutralIsoPtSum"));
+        getValue(tau_funcs.getNeutralIsoPtSumdR03Weight(tau, tau_index) / tau_funcs.getNeutralIsoPtSum(tau, tau_index));
+    get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau_funcs.getNeutralIsoPtSumdR03(tau, tau_index) / tau_funcs.getNeutralIsoPtSum(tau, tau_index));
     get(dnn::photonPtSumOutsideSignalCone) =
-        getValueNorm(tau.tauID("photonPtSumOutsideSignalConedR03"), 1.731f, 6.846f);
-    get(dnn::puCorrPtSum) = getValueNorm(tau.tauID("puCorrPtSum"), 22.38f, 16.34f);
+        getValueNorm(tau_funcs.getPhotonPtSumOutsideSignalCone(tau, tau_index), 1.731f, 6.846f);
+    get(dnn::puCorrPtSum) = getValueNorm(tau_funcs.getPuCorrPtSum(tau, tau_index), 22.38f, 16.34f);
     // The global PCA coordinates were used as inputs during the NN training, but it was decided to disable
     // them for the inference, because modeling of dxy_PCA in MC poorly describes the data, and x and y coordinates
     // in data results outside of the expected 5 std. dev. input validity range. On the other hand,
     // these coordinates are strongly era-dependent. Kept as comment to document what NN expects.
     if (!disable_dxy_pca_) {
-      get(dnn::tau_dxy_pca_x) = getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
-      get(dnn::tau_dxy_pca_y) = getValueNorm(tau.dxy_PCA().y(), 0.0675f, 0.0128f);
-      get(dnn::tau_dxy_pca_z) = getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
+      get(dnn::tau_dxy_pca_x) = getValueNorm(tau_funcs.getdxyPCA(tau, tau_index).x(), -0.0241f, 0.0074f);
+      get(dnn::tau_dxy_pca_y) = getValueNorm(tau_funcs.getdxyPCA(tau, tau_index).y(), 0.0675f, 0.0128f);
+      get(dnn::tau_dxy_pca_z) = getValueNorm(tau_funcs.getdxyPCA(tau, tau_index).z(), 0.7973f, 3.456f);
     } else {
       get(dnn::tau_dxy_pca_x) = 0;
       get(dnn::tau_dxy_pca_y) = 0;
       get(dnn::tau_dxy_pca_z) = 0;
     }
-
     const bool tau_dxy_valid =
-        std::isnormal(tau.dxy()) && tau.dxy() > -10 && std::isnormal(tau.dxy_error()) && tau.dxy_error() > 0;
+        std::isnormal(tau_funcs.getdxy(tau, tau_index)) && tau_funcs.getdxy(tau, tau_index) > -10 && std::isnormal(tau_funcs.getdxyError(tau, tau_index)) && tau_funcs.getdxyError(tau, tau_index) > 0;
     if (tau_dxy_valid) {
       get(dnn::tau_dxy_valid) = tau_dxy_valid;
-      get(dnn::tau_dxy) = getValueNorm(tau.dxy(), 0.0018f, 0.0085f);
-      get(dnn::tau_dxy_sig) = getValueNorm(std::abs(tau.dxy()) / tau.dxy_error(), 2.26f, 4.191f);
+      get(dnn::tau_dxy) = getValueNorm(tau_funcs.getdxy(tau, tau_index), 0.0018f, 0.0085f);
+      get(dnn::tau_dxy_sig) = getValueNorm(std::abs(tau_funcs.getdxy(tau, tau_index)) / tau_funcs.getdxyError(tau, tau_index), 2.26f, 4.191f);
     }
     const bool tau_ip3d_valid =
-        std::isnormal(tau.ip3d()) && tau.ip3d() > -10 && std::isnormal(tau.ip3d_error()) && tau.ip3d_error() > 0;
+        std::isnormal(tau_funcs.getip3d(tau, tau_index)) && tau_funcs.getip3d(tau, tau_index) > -10 && std::isnormal(tau_funcs.getip3dError(tau, tau_index)) && tau_funcs.getip3dError(tau, tau_index) > 0;
     if (tau_ip3d_valid) {
       get(dnn::tau_ip3d_valid) = tau_ip3d_valid;
-      get(dnn::tau_ip3d) = getValueNorm(tau.ip3d(), 0.0026f, 0.0114f);
-      get(dnn::tau_ip3d_sig) = getValueNorm(std::abs(tau.ip3d()) / tau.ip3d_error(), 2.928f, 4.466f);
+      get(dnn::tau_ip3d) = getValueNorm(tau_funcs.getip3d(tau, tau_index), 0.0026f, 0.0114f);
+      get(dnn::tau_ip3d_sig) = getValueNorm(std::abs(tau_funcs.getip3d(tau, tau_index)) / tau_funcs.getip3dError(tau, tau_index), 2.928f, 4.466f);
     }
     if (leadChargedHadrCand) {
-      get(dnn::tau_dz) = getValueNorm(leadChargedHadrCand->dz(), 0.f, 0.0190f);
-      const bool tau_dz_sig_valid = leadChargedHadrCand->hasTrackDetails() &&
-                                    std::isnormal(leadChargedHadrCand->dz()) &&
-                                    std::isnormal(leadChargedHadrCand->dzError()) && leadChargedHadrCand->dzError() > 0;
-      get(dnn::tau_dz_sig_valid) = tau_dz_sig_valid;
-      const double dzError = leadChargedHadrCand->hasTrackDetails() ? leadChargedHadrCand->dzError() : default_value;
-      get(dnn::tau_dz_sig) = getValueNorm(std::abs(leadChargedHadrCand->dz()) / dzError, 4.717f, 11.78f);
+      get(dnn::tau_dz) = getValueNorm(candFunc::getTauDz(leadChargedHadrCand, default_value), 0.f, 0.0190f);
+      get(dnn::tau_dz_sig_valid) = candFunc::getTauDZSigValid(leadChargedHadrCand);
+      const double dzError = candFunc::getTauDzError(leadChargedHadrCand, default_value);
+      get(dnn::tau_dz_sig) = getValueNorm(std::abs(candFunc::getTauDz(leadChargedHadrCand, default_value)) / dzError, 4.717f, 11.78f);
     }
-    get(dnn::tau_flightLength_x) = getValueNorm(tau.flightLength().x(), -0.0003f, 0.7362f);
-    get(dnn::tau_flightLength_y) = getValueNorm(tau.flightLength().y(), -0.0009f, 0.7354f);
-    get(dnn::tau_flightLength_z) = getValueNorm(tau.flightLength().z(), -0.0022f, 1.993f);
-    // get(dnn::tau_flightLength_sig) = getValueNorm(tau.flightLengthSig(), -4.78f, 9.573f);
+    get(dnn::tau_flightLength_x) = getValueNorm(tau_funcs.getFlightLength(tau, tau_index).x(), -0.0003f, 0.7362f);
+    get(dnn::tau_flightLength_y) = getValueNorm(tau_funcs.getFlightLength(tau, tau_index).y(), -0.0009f, 0.7354f);
+    get(dnn::tau_flightLength_z) = getValueNorm(tau_funcs.getFlightLength(tau, tau_index).z(), -0.0022f, 1.993f);
     get(dnn::tau_flightLength_sig) = 0.55756444;  //This value is set due to a bug in the training
     get(dnn::tau_pt_weighted_deta_strip) =
         getValueLinear(reco::tau::pt_weighted_deta_strip(tau, tau.decayMode()), 0, 1, true);
@@ -1247,31 +1555,34 @@ private:
     get(dnn::tau_pt_weighted_dr_signal) =
         getValueNorm(reco::tau::pt_weighted_dr_signal(tau, tau.decayMode()), 0.0052f, 0.01433f);
     get(dnn::tau_pt_weighted_dr_iso) = getValueLinear(reco::tau::pt_weighted_dr_iso(tau, tau.decayMode()), 0, 1, true);
-    get(dnn::tau_leadingTrackNormChi2) = getValueNorm(tau.leadingTrackNormChi2(), 1.538f, 4.401f);
+    get(dnn::tau_leadingTrackNormChi2) = getValueNorm(tau_funcs.getLeadingTrackNormChi2(tau), 1.538f, 4.401f);
     const auto eratio = reco::tau::eratio(tau);
     const bool tau_e_ratio_valid = std::isnormal(eratio) && eratio > 0.f;
     get(dnn::tau_e_ratio_valid) = tau_e_ratio_valid;
     get(dnn::tau_e_ratio) = tau_e_ratio_valid ? getValueLinear(eratio, 0, 1, true) : 0.f;
-    const double gj_angle_diff = calculateGottfriedJacksonAngleDifference(tau);
+    const double gj_angle_diff = calculateGottfriedJacksonAngleDifference(tau, tau_index, tau_funcs);
     const bool tau_gj_angle_diff_valid = (std::isnormal(gj_angle_diff) || gj_angle_diff == 0) && gj_angle_diff >= 0;
     get(dnn::tau_gj_angle_diff_valid) = tau_gj_angle_diff_valid;
     get(dnn::tau_gj_angle_diff) = tau_gj_angle_diff_valid ? getValueLinear(gj_angle_diff, 0, pi, true) : 0;
     get(dnn::tau_n_photons) = getValueNorm(reco::tau::n_photons_total(tau), 2.95f, 3.927f);
-    get(dnn::tau_emFraction) = getValueLinear(tau.emFraction_MVA(), -1, 1, false);
+    get(dnn::tau_emFraction) = getValueLinear(tau_funcs.getEmFraction(tau), -1, 1, false);
+
     get(dnn::tau_inside_ecal_crack) = getValue(isInEcalCrack(tau.p4().eta()));
     get(dnn::leadChargedCand_etaAtEcalEntrance_minus_tau_eta) =
-        getValueNorm(tau.etaAtEcalEntranceLeadChargedCand() - tau.p4().eta(), 0.0042f, 0.0323f);
-
+        getValueNorm(tau_funcs.getEtaAtEcalEntrance(tau) - tau.p4().eta(), 0.0042f, 0.0323f);
     checkInputs(inputs, "tau_block", dnn::NumberOfInputs);
   }
 
+  template <typename CandidateCastType, typename TauCastType>
   void createEgammaBlockInputs(unsigned idx,
-                               const TauType& tau,
+                               const TauCastType& tau,
+                               size_t tau_index,
                                const reco::Vertex& pv,
                                double rho,
-                               const pat::ElectronCollection& electrons,
-                               const pat::PackedCandidateCollection& pfCands,
+                               const std::vector<pat::Electron>& electrons,
+                               const edm::View<reco::Candidate>& pfCands,
                                const Cell& cell_map,
+                               tauFunc tau_funcs,
                                bool is_inner) {
     namespace dnn = dnn_inputs_2017_v2::EgammaBlockInputs;
 
@@ -1283,6 +1594,7 @@ private:
     const bool valid_index_pf_gamma = cell_map.count(CellObjectType::PfCand_gamma);
     const bool valid_index_ele = cell_map.count(CellObjectType::Electron);
 
+
     if (!cell_map.empty()) {
       get(dnn::rho) = getValueNorm(rho, 21.49f, 9.713f);
       get(dnn::tau_pt) = getValueLinear(tau.polarP4().pt(), 20.f, 1000.f, true);
@@ -1291,6 +1603,7 @@ private:
     }
     if (valid_index_pf_ele) {
       size_t index_pf_ele = cell_map.at(CellObjectType::PfCand_electron);
+      const auto& ele_cand = dynamic_cast<const CandidateCastType&>(pfCands.at(index_pf_ele));
 
       get(dnn::pfCand_ele_valid) = valid_index_pf_ele;
       get(dnn::pfCand_ele_rel_pt) = getValueNorm(pfCands.at(index_pf_ele).polarP4().pt() / tau.polarP4().pt(),
@@ -1305,12 +1618,12 @@ private:
                                                  is_inner ? 0.1f : 0.5f,
                                                  false);
       get(dnn::pfCand_ele_pvAssociationQuality) =
-          getValueLinear<int>(pfCands.at(index_pf_ele).pvAssociationQuality(), 0, 7, true);
-      get(dnn::pfCand_ele_puppiWeight) = getValue(pfCands.at(index_pf_ele).puppiWeight());
-      get(dnn::pfCand_ele_charge) = getValue(pfCands.at(index_pf_ele).charge());
-      get(dnn::pfCand_ele_lostInnerHits) = getValue<int>(pfCands.at(index_pf_ele).lostInnerHits());
+          getValueLinear<int>(candFunc::getPvAssocationQuality(ele_cand), 0, 7, true);
+      get(dnn::pfCand_ele_puppiWeight) = getValue(candFunc::getPuppiWeight(ele_cand));
+      get(dnn::pfCand_ele_charge) = getValue(ele_cand.charge());
+      get(dnn::pfCand_ele_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(ele_cand, default_value));
       get(dnn::pfCand_ele_numberOfPixelHits) =
-          getValueLinear(pfCands.at(index_pf_ele).numberOfPixelHits(), 0, 10, true);
+          getValueLinear(candFunc::getNumberOfPixelHits(ele_cand, default_value), 0, 10, true);
       get(dnn::pfCand_ele_vertex_dx) =
           getValueNorm(pfCands.at(index_pf_ele).vertex().x() - pv.position().x(), 0.f, 0.1221f);
       get(dnn::pfCand_ele_vertex_dy) =
@@ -1318,30 +1631,32 @@ private:
       get(dnn::pfCand_ele_vertex_dz) =
           getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z(), 0.001f, 1.024f);
       get(dnn::pfCand_ele_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_pf_ele).vertex().x() - pv.position().x() - tau.flightLength().x(), 0.f, 0.3411f);
+          pfCands.at(index_pf_ele).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), 0.f, 0.3411f);
       get(dnn::pfCand_ele_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_pf_ele).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0003f, 0.3385f);
+          pfCands.at(index_pf_ele).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0003f, 0.3385f);
       get(dnn::pfCand_ele_vertex_dz_tauFL) =
-          getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z() - tau.flightLength().z(), 0.f, 1.307f);
+          getValueNorm(pfCands.at(index_pf_ele).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), 0.f, 1.307f);
 
-      const bool hasTrackDetails = pfCands.at(index_pf_ele).hasTrackDetails();
+      const bool hasTrackDetails = candFunc::getHasTrackDetails(ele_cand);
       if (hasTrackDetails) {
         get(dnn::pfCand_ele_hasTrackDetails) = hasTrackDetails;
-        get(dnn::pfCand_ele_dxy) = getValueNorm(pfCands.at(index_pf_ele).dxy(), 0.f, 0.171f);
+        get(dnn::pfCand_ele_dxy) = getValueNorm(candFunc::getTauDxy(ele_cand, default_value), 0.f, 0.171f);
         get(dnn::pfCand_ele_dxy_sig) =
-            getValueNorm(std::abs(pfCands.at(index_pf_ele).dxy()) / pfCands.at(index_pf_ele).dxyError(), 1.634f, 6.45f);
-        get(dnn::pfCand_ele_dz) = getValueNorm(pfCands.at(index_pf_ele).dz(), 0.001f, 1.02f);
+            getValueNorm(std::abs(candFunc::getTauDxy(ele_cand, default_value)) / pfCands.at(index_pf_ele).dxyError(), 1.634f, 6.45f);
+        get(dnn::pfCand_ele_dz) = getValueNorm(candFunc::getTauDz(ele_cand, default_value), 0.001f, 1.02f);
         get(dnn::pfCand_ele_dz_sig) =
-            getValueNorm(std::abs(pfCands.at(index_pf_ele).dz()) / pfCands.at(index_pf_ele).dzError(), 24.56f, 210.4f);
+            getValueNorm(std::abs(candFunc::getTauDz(ele_cand, default_value)) / candFunc::getTauDzError(ele_cand, default_value), 24.56f, 210.4f);
         get(dnn::pfCand_ele_track_chi2_ndof) =
-            getValueNorm(pfCands.at(index_pf_ele).pseudoTrack().chi2() / pfCands.at(index_pf_ele).pseudoTrack().ndof(),
+            getValueNorm(candFunc::getPseudoTrack(ele_cand).chi2() / candFunc::getPseudoTrack(ele_cand).ndof(),
                          2.272f,
                          8.439f);
-        get(dnn::pfCand_ele_track_ndof) = getValueNorm(pfCands.at(index_pf_ele).pseudoTrack().ndof(), 15.18f, 3.203f);
+        get(dnn::pfCand_ele_track_ndof) = getValueNorm(candFunc::getPseudoTrack(ele_cand).ndof(), 15.18f, 3.203f);
       }
     }
     if (valid_index_pf_gamma) {
       size_t index_pf_gamma = cell_map.at(CellObjectType::PfCand_gamma);
+      const auto& gamma_cand = dynamic_cast<const CandidateCastType&>(pfCands.at(index_pf_gamma));
+
       get(dnn::pfCand_gamma_valid) = valid_index_pf_gamma;
       get(dnn::pfCand_gamma_rel_pt) = getValueNorm(pfCands.at(index_pf_gamma).polarP4().pt() / tau.polarP4().pt(),
                                                    is_inner ? 0.6048f : 0.02576f,
@@ -1355,13 +1670,13 @@ private:
                                                    is_inner ? 0.1f : 0.5f,
                                                    false);
       get(dnn::pfCand_gamma_pvAssociationQuality) =
-          getValueLinear<int>(pfCands.at(index_pf_gamma).pvAssociationQuality(), 0, 7, true);
-      get(dnn::pfCand_gamma_fromPV) = getValueLinear<int>(pfCands.at(index_pf_gamma).fromPV(), 0, 3, true);
-      get(dnn::pfCand_gamma_puppiWeight) = getValue(pfCands.at(index_pf_gamma).puppiWeight());
-      get(dnn::pfCand_gamma_puppiWeightNoLep) = getValue(pfCands.at(index_pf_gamma).puppiWeightNoLep());
-      get(dnn::pfCand_gamma_lostInnerHits) = getValue<int>(pfCands.at(index_pf_gamma).lostInnerHits());
+          getValueLinear<int>(candFunc::getPvAssocationQuality(gamma_cand), 0, 7, true);
+      get(dnn::pfCand_gamma_fromPV) = getValueLinear<int>(candFunc::getFromPV(gamma_cand), 0, 3, true);
+      get(dnn::pfCand_gamma_puppiWeight) = getValue(candFunc::getPuppiWeight(gamma_cand));
+      get(dnn::pfCand_gamma_puppiWeightNoLep) = getValue(candFunc::getPuppiWeightNoLep(gamma_cand));
+      get(dnn::pfCand_gamma_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(gamma_cand, default_value));
       get(dnn::pfCand_gamma_numberOfPixelHits) =
-          getValueLinear(pfCands.at(index_pf_gamma).numberOfPixelHits(), 0, 7, true);
+          getValueLinear(candFunc::getNumberOfPixelHits(gamma_cand, default_value), 0, 7, true);
       get(dnn::pfCand_gamma_vertex_dx) =
           getValueNorm(pfCands.at(index_pf_gamma).vertex().x() - pv.position().x(), 0.f, 0.0067f);
       get(dnn::pfCand_gamma_vertex_dy) =
@@ -1369,30 +1684,29 @@ private:
       get(dnn::pfCand_gamma_vertex_dz) =
           getValueNorm(pfCands.at(index_pf_gamma).vertex().z() - pv.position().z(), 0.f, 0.0578f);
       get(dnn::pfCand_gamma_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_pf_gamma).vertex().x() - pv.position().x() - tau.flightLength().x(), 0.001f, 0.9565f);
+          pfCands.at(index_pf_gamma).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), 0.001f, 0.9565f);
       get(dnn::pfCand_gamma_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_pf_gamma).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0008f, 0.9592f);
+          pfCands.at(index_pf_gamma).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0008f, 0.9592f);
       get(dnn::pfCand_gamma_vertex_dz_tauFL) = getValueNorm(
-          pfCands.at(index_pf_gamma).vertex().z() - pv.position().z() - tau.flightLength().z(), 0.0038f, 2.154f);
-
-      const bool hasTrackDetails = pfCands.at(index_pf_gamma).hasTrackDetails();
+          pfCands.at(index_pf_gamma).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), 0.0038f, 2.154f);
+      const bool hasTrackDetails = candFunc::getHasTrackDetails(gamma_cand);
       if (hasTrackDetails) {
         get(dnn::pfCand_gamma_hasTrackDetails) = hasTrackDetails;
-        get(dnn::pfCand_gamma_dxy) = getValueNorm(pfCands.at(index_pf_gamma).dxy(), 0.0004f, 0.882f);
+        get(dnn::pfCand_gamma_dxy) = getValueNorm(candFunc::getTauDxy(gamma_cand, default_value), 0.0004f, 0.882f);
         get(dnn::pfCand_gamma_dxy_sig) = getValueNorm(
-            std::abs(pfCands.at(index_pf_gamma).dxy()) / pfCands.at(index_pf_gamma).dxyError(), 4.271f, 63.78f);
-        get(dnn::pfCand_gamma_dz) = getValueNorm(pfCands.at(index_pf_gamma).dz(), 0.0071f, 5.285f);
+            std::abs(candFunc::getTauDxy(gamma_cand, default_value)) / gamma_cand.dxyError(), 4.271f, 63.78f);
+        get(dnn::pfCand_gamma_dz) = getValueNorm(candFunc::getTauDz(gamma_cand, default_value), 0.0071f, 5.285f);
         get(dnn::pfCand_gamma_dz_sig) = getValueNorm(
-            std::abs(pfCands.at(index_pf_gamma).dz()) / pfCands.at(index_pf_gamma).dzError(), 162.1f, 622.4f);
-        get(dnn::pfCand_gamma_track_chi2_ndof) = pfCands.at(index_pf_gamma).pseudoTrack().ndof() > 0
-                                                     ? getValueNorm(pfCands.at(index_pf_gamma).pseudoTrack().chi2() /
-                                                                        pfCands.at(index_pf_gamma).pseudoTrack().ndof(),
+            std::abs(candFunc::getTauDz(gamma_cand, default_value)) / candFunc::getTauDzError(gamma_cand, default_value), 162.1f, 622.4f);
+        get(dnn::pfCand_gamma_track_chi2_ndof) = candFunc::getPseudoTrack(gamma_cand).ndof() > 0
+                                                     ? getValueNorm(candFunc::getPseudoTrack(gamma_cand).chi2() /
+                                                                        candFunc::getPseudoTrack(gamma_cand).ndof(),
                                                                     4.268f,
                                                                     15.47f)
                                                      : 0;
         get(dnn::pfCand_gamma_track_ndof) =
-            pfCands.at(index_pf_gamma).pseudoTrack().ndof() > 0
-                ? getValueNorm(pfCands.at(index_pf_gamma).pseudoTrack().ndof(), 12.25f, 4.774f)
+            candFunc::getPseudoTrack(gamma_cand).ndof() > 0
+                ? getValueNorm(candFunc::getPseudoTrack(gamma_cand).ndof(), 12.25f, 4.774f)
                 : 0;
       }
     }
@@ -1463,7 +1777,6 @@ private:
           getValueNorm(electrons.at(index_ele).mvaInput().sigmaEtaEta, 0.0008f, 0.0052f);
       get(dnn::ele_mvaInput_hadEnergy) = getValueNorm(electrons.at(index_ele).mvaInput().hadEnergy, 14.04f, 69.48f);
       get(dnn::ele_mvaInput_deltaEta) = getValueNorm(electrons.at(index_ele).mvaInput().deltaEta, 0.0099f, 0.0851f);
-
       const auto& gsfTrack = electrons.at(index_ele).gsfTrack();
       if (gsfTrack.isNonnull()) {
         get(dnn::ele_gsfTrack_normalizedChi2) = getValueNorm(gsfTrack->normalizedChi2(), 3.049f, 10.39f);
@@ -1481,16 +1794,20 @@ private:
             getValueNorm(closestCtfTrack->numberOfValidHits(), 15.16f, 5.26f);
       }
     }
-    checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
+    if (valid_index_ele or valid_index_pf_ele or valid_index_pf_gamma) checkInputs(inputs, is_inner ? "egamma_inner_block" : "egamma_outer_block", dnn::NumberOfInputs);
+
   }
 
+  template <typename CandidateCastType, typename TauCastType>
   void createMuonBlockInputs(unsigned idx,
-                             const TauType& tau,
+                             const TauCastType& tau,
+                             size_t tau_index, 
                              const reco::Vertex& pv,
                              double rho,
-                             const pat::MuonCollection& muons,
-                             const pat::PackedCandidateCollection& pfCands,
+                             const std::vector<pat::Muon>& muons,
+                             const edm::View<reco::Candidate>& pfCands,
                              const Cell& cell_map,
+                             tauFunc tau_funcs,
                              bool is_inner) {
     namespace dnn = dnn_inputs_2017_v2::MuonBlockInputs;
 
@@ -1509,6 +1826,7 @@ private:
     }
     if (valid_index_pf_muon) {
       size_t index_pf_muon = cell_map.at(CellObjectType::PfCand_muon);
+      const auto& muon_cand = dynamic_cast<const CandidateCastType&>(pfCands.at(index_pf_muon));
 
       get(dnn::pfCand_muon_valid) = valid_index_pf_muon;
       get(dnn::pfCand_muon_rel_pt) = getValueNorm(pfCands.at(index_pf_muon).polarP4().pt() / tau.polarP4().pt(),
@@ -1523,13 +1841,13 @@ private:
                                                   is_inner ? 0.1f : 0.5f,
                                                   false);
       get(dnn::pfCand_muon_pvAssociationQuality) =
-          getValueLinear<int>(pfCands.at(index_pf_muon).pvAssociationQuality(), 0, 7, true);
-      get(dnn::pfCand_muon_fromPV) = getValueLinear<int>(pfCands.at(index_pf_muon).fromPV(), 0, 3, true);
-      get(dnn::pfCand_muon_puppiWeight) = getValue(pfCands.at(index_pf_muon).puppiWeight());
-      get(dnn::pfCand_muon_charge) = getValue(pfCands.at(index_pf_muon).charge());
-      get(dnn::pfCand_muon_lostInnerHits) = getValue<int>(pfCands.at(index_pf_muon).lostInnerHits());
+          getValueLinear<int>(candFunc::getPvAssocationQuality(muon_cand), 0, 7, true);
+      get(dnn::pfCand_muon_fromPV) = getValueLinear<int>(candFunc::getFromPV(muon_cand), 0, 3, true);
+      get(dnn::pfCand_muon_puppiWeight) = getValue(candFunc::getPuppiWeight(muon_cand));
+      get(dnn::pfCand_muon_charge) = getValue(muon_cand.charge());
+      get(dnn::pfCand_muon_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(muon_cand, default_value));
       get(dnn::pfCand_muon_numberOfPixelHits) =
-          getValueLinear(pfCands.at(index_pf_muon).numberOfPixelHits(), 0, 11, true);
+          getValueLinear(candFunc::getNumberOfPixelHits(muon_cand, default_value), 0, 11, true);
       get(dnn::pfCand_muon_vertex_dx) =
           getValueNorm(pfCands.at(index_pf_muon).vertex().x() - pv.position().x(), -0.0007f, 0.6869f);
       get(dnn::pfCand_muon_vertex_dy) =
@@ -1537,26 +1855,26 @@ private:
       get(dnn::pfCand_muon_vertex_dz) =
           getValueNorm(pfCands.at(index_pf_muon).vertex().z() - pv.position().z(), -0.0117f, 4.097f);
       get(dnn::pfCand_muon_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_pf_muon).vertex().x() - pv.position().x() - tau.flightLength().x(), -0.0001f, 0.8642f);
+          pfCands.at(index_pf_muon).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), -0.0001f, 0.8642f);
       get(dnn::pfCand_muon_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_pf_muon).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0004f, 0.8561f);
+          pfCands.at(index_pf_muon).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0004f, 0.8561f);
       get(dnn::pfCand_muon_vertex_dz_tauFL) = getValueNorm(
-          pfCands.at(index_pf_muon).vertex().z() - pv.position().z() - tau.flightLength().z(), -0.0118f, 4.405f);
+          pfCands.at(index_pf_muon).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), -0.0118f, 4.405f);
 
-      const bool hasTrackDetails = pfCands.at(index_pf_muon).hasTrackDetails();
+      const bool hasTrackDetails = candFunc::getHasTrackDetails(muon_cand);
       if (hasTrackDetails) {
         get(dnn::pfCand_muon_hasTrackDetails) = hasTrackDetails;
-        get(dnn::pfCand_muon_dxy) = getValueNorm(pfCands.at(index_pf_muon).dxy(), -0.0045f, 0.9655f);
+        get(dnn::pfCand_muon_dxy) = getValueNorm(candFunc::getTauDxy(muon_cand, default_value), -0.0045f, 0.9655f);
         get(dnn::pfCand_muon_dxy_sig) = getValueNorm(
-            std::abs(pfCands.at(index_pf_muon).dxy()) / pfCands.at(index_pf_muon).dxyError(), 4.575f, 42.36f);
-        get(dnn::pfCand_muon_dz) = getValueNorm(pfCands.at(index_pf_muon).dz(), -0.0117f, 4.097f);
+            std::abs(candFunc::getTauDxy(muon_cand, default_value)) / muon_cand.dxyError(), 4.575f, 42.36f);
+        get(dnn::pfCand_muon_dz) = getValueNorm(candFunc::getTauDz(muon_cand, default_value), -0.0117f, 4.097f);
         get(dnn::pfCand_muon_dz_sig) = getValueNorm(
-            std::abs(pfCands.at(index_pf_muon).dz()) / pfCands.at(index_pf_muon).dzError(), 80.37f, 343.3f);
+            std::abs(candFunc::getTauDz(muon_cand, default_value)) / candFunc::getTauDz(muon_cand, default_value), 80.37f, 343.3f);
         get(dnn::pfCand_muon_track_chi2_ndof) = getValueNorm(
-            pfCands.at(index_pf_muon).pseudoTrack().chi2() / pfCands.at(index_pf_muon).pseudoTrack().ndof(),
+            candFunc::getPseudoTrack(muon_cand).chi2() / candFunc::getPseudoTrack(muon_cand).ndof(),
             0.69f,
             1.711f);
-        get(dnn::pfCand_muon_track_ndof) = getValueNorm(pfCands.at(index_pf_muon).pseudoTrack().ndof(), 17.5f, 5.11f);
+        get(dnn::pfCand_muon_track_ndof) = getValueNorm(candFunc::getPseudoTrack(muon_cand).ndof(), 17.5f, 5.11f);
       }
     }
     if (valid_index_muon) {
@@ -1624,12 +1942,15 @@ private:
     checkInputs(inputs, is_inner ? "muon_inner_block" : "muon_outer_block", dnn::NumberOfInputs);
   }
 
+  template <typename CandidateCastType, typename TauCastType>
   void createHadronsBlockInputs(unsigned idx,
-                                const TauType& tau,
+                                const TauCastType& tau,
+                                size_t tau_index,
                                 const reco::Vertex& pv,
                                 double rho,
-                                const pat::PackedCandidateCollection& pfCands,
+                                const edm::View<reco::Candidate>& pfCands,
                                 const Cell& cell_map,
+                                tauFunc tau_funcs,
                                 bool is_inner) {
     namespace dnn = dnn_inputs_2017_v2::HadronBlockInputs;
 
@@ -1648,6 +1969,7 @@ private:
     }
     if (valid_chH) {
       size_t index_chH = cell_map.at(CellObjectType::PfCand_chargedHadron);
+      const auto& chH_cand = dynamic_cast<const CandidateCastType&>(pfCands.at(index_chH));
 
       get(dnn::pfCand_chHad_valid) = valid_chH;
       get(dnn::pfCand_chHad_rel_pt) = getValueNorm(pfCands.at(index_chH).polarP4().pt() / tau.polarP4().pt(),
@@ -1662,15 +1984,15 @@ private:
                                                    is_inner ? 0.1f : 0.5f,
                                                    false);
       get(dnn::pfCand_chHad_leadChargedHadrCand) = getValue(
-          &pfCands.at(index_chH) == dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get()));
+          &chH_cand == dynamic_cast<const CandidateCastType*>(tau.leadChargedHadrCand().get()));
       get(dnn::pfCand_chHad_pvAssociationQuality) =
-          getValueLinear<int>(pfCands.at(index_chH).pvAssociationQuality(), 0, 7, true);
-      get(dnn::pfCand_chHad_fromPV) = getValueLinear<int>(pfCands.at(index_chH).fromPV(), 0, 3, true);
-      get(dnn::pfCand_chHad_puppiWeight) = getValue(pfCands.at(index_chH).puppiWeight());
-      get(dnn::pfCand_chHad_puppiWeightNoLep) = getValue(pfCands.at(index_chH).puppiWeightNoLep());
-      get(dnn::pfCand_chHad_charge) = getValue(pfCands.at(index_chH).charge());
-      get(dnn::pfCand_chHad_lostInnerHits) = getValue<int>(pfCands.at(index_chH).lostInnerHits());
-      get(dnn::pfCand_chHad_numberOfPixelHits) = getValueLinear(pfCands.at(index_chH).numberOfPixelHits(), 0, 12, true);
+          getValueLinear<int>(candFunc::getPvAssocationQuality(chH_cand), 0, 7, true);
+      get(dnn::pfCand_chHad_fromPV) = getValueLinear<int>(candFunc::getFromPV(chH_cand), 0, 3, true);
+      get(dnn::pfCand_chHad_puppiWeight) = getValue(candFunc::getPuppiWeight(chH_cand));
+      get(dnn::pfCand_chHad_puppiWeightNoLep) = getValue(candFunc::getPuppiWeightNoLep(chH_cand));
+      get(dnn::pfCand_chHad_charge) = getValue(chH_cand.charge());
+      get(dnn::pfCand_chHad_lostInnerHits) = getValue<int>(candFunc::getLostInnerHits(chH_cand, default_value));
+      get(dnn::pfCand_chHad_numberOfPixelHits) = getValueLinear(candFunc::getNumberOfPixelHits(chH_cand, default_value), 0, 12, true);
       get(dnn::pfCand_chHad_vertex_dx) =
           getValueNorm(pfCands.at(index_chH).vertex().x() - pv.position().x(), 0.0005f, 1.735f);
       get(dnn::pfCand_chHad_vertex_dy) =
@@ -1678,43 +2000,39 @@ private:
       get(dnn::pfCand_chHad_vertex_dz) =
           getValueNorm(pfCands.at(index_chH).vertex().z() - pv.position().z(), -0.0201f, 8.333f);
       get(dnn::pfCand_chHad_vertex_dx_tauFL) = getValueNorm(
-          pfCands.at(index_chH).vertex().x() - pv.position().x() - tau.flightLength().x(), -0.0014f, 1.93f);
+          pfCands.at(index_chH).vertex().x() - pv.position().x() - tau_funcs.getFlightLength(tau, tau_index).x(), -0.0014f, 1.93f);
       get(dnn::pfCand_chHad_vertex_dy_tauFL) = getValueNorm(
-          pfCands.at(index_chH).vertex().y() - pv.position().y() - tau.flightLength().y(), 0.0022f, 1.948f);
+          pfCands.at(index_chH).vertex().y() - pv.position().y() - tau_funcs.getFlightLength(tau, tau_index).y(), 0.0022f, 1.948f);
       get(dnn::pfCand_chHad_vertex_dz_tauFL) = getValueNorm(
-          pfCands.at(index_chH).vertex().z() - pv.position().z() - tau.flightLength().z(), -0.0138f, 8.622f);
+          pfCands.at(index_chH).vertex().z() - pv.position().z() - tau_funcs.getFlightLength(tau, tau_index).z(), -0.0138f, 8.622f);
 
-      const bool hasTrackDetails = pfCands.at(index_chH).hasTrackDetails();
+      const bool hasTrackDetails = candFunc::getHasTrackDetails(chH_cand);
       if (hasTrackDetails) {
         get(dnn::pfCand_chHad_hasTrackDetails) = hasTrackDetails;
-        get(dnn::pfCand_chHad_dxy) = getValueNorm(pfCands.at(index_chH).dxy(), -0.012f, 2.386f);
+        get(dnn::pfCand_chHad_dxy) = getValueNorm(candFunc::getTauDxy(chH_cand, default_value), -0.012f, 2.386f);
         get(dnn::pfCand_chHad_dxy_sig) =
-            getValueNorm(std::abs(pfCands.at(index_chH).dxy()) / pfCands.at(index_chH).dxyError(), 6.417f, 36.28f);
-        get(dnn::pfCand_chHad_dz) = getValueNorm(pfCands.at(index_chH).dz(), -0.0246f, 7.618f);
+            getValueNorm(std::abs(candFunc::getTauDxy(chH_cand, default_value)) / chH_cand.dxyError(), 6.417f, 36.28f);
+        get(dnn::pfCand_chHad_dz) = getValueNorm(candFunc::getTauDz(chH_cand, default_value), -0.0246f, 7.618f);
         get(dnn::pfCand_chHad_dz_sig) =
-            getValueNorm(std::abs(pfCands.at(index_chH).dz()) / pfCands.at(index_chH).dzError(), 301.3f, 491.1f);
+            getValueNorm(std::abs(candFunc::getTauDz(chH_cand, default_value)) / candFunc::getTauDzError(chH_cand, default_value), 301.3f, 491.1f);
         get(dnn::pfCand_chHad_track_chi2_ndof) =
-            pfCands.at(index_chH).pseudoTrack().ndof() > 0
-                ? getValueNorm(pfCands.at(index_chH).pseudoTrack().chi2() / pfCands.at(index_chH).pseudoTrack().ndof(),
+            candFunc::getPseudoTrack(chH_cand).ndof() > 0
+                ? getValueNorm(candFunc::getPseudoTrack(chH_cand).chi2() / candFunc::getPseudoTrack(chH_cand).ndof(),
                                0.7876f,
                                3.694f)
                 : 0;
         get(dnn::pfCand_chHad_track_ndof) =
-            pfCands.at(index_chH).pseudoTrack().ndof() > 0
-                ? getValueNorm(pfCands.at(index_chH).pseudoTrack().ndof(), 13.92f, 6.581f)
+            candFunc::getPseudoTrack(chH_cand).ndof() > 0
+                ? getValueNorm(candFunc::getPseudoTrack(chH_cand).ndof(), 13.92f, 6.581f)
                 : 0;
       }
-      float hcal_fraction = 0.;
-      if (pfCands.at(index_chH).pdgId() == 1 || pfCands.at(index_chH).pdgId() == 130) {
-        hcal_fraction = pfCands.at(index_chH).hcalFraction();
-      } else if (pfCands.at(index_chH).isIsolatedChargedHadron()) {
-        hcal_fraction = pfCands.at(index_chH).rawHcalFraction();
-      }
+      float hcal_fraction = candFunc::getHCalFraction(chH_cand) ;
       get(dnn::pfCand_chHad_hcalFraction) = getValue(hcal_fraction);
-      get(dnn::pfCand_chHad_rawCaloFraction) = getValueLinear(pfCands.at(index_chH).rawCaloFraction(), 0.f, 2.6f, true);
+      get(dnn::pfCand_chHad_rawCaloFraction) = getValueLinear(candFunc::getRawCaloFraction(chH_cand), 0.f, 2.6f, true);
     }
     if (valid_nH) {
       size_t index_nH = cell_map.at(CellObjectType::PfCand_neutralHadron);
+      const auto& nH_cand = dynamic_cast<const CandidateCastType&>(pfCands.at(index_nH));
 
       get(dnn::pfCand_nHad_valid) = valid_nH;
       get(dnn::pfCand_nHad_rel_pt) = getValueNorm(pfCands.at(index_nH).polarP4().pt() / tau.polarP4().pt(),
@@ -1726,29 +2044,27 @@ private:
                                                   false);
       get(dnn::pfCand_nHad_dphi) = getValueLinear(
           dPhi(tau.polarP4(), pfCands.at(index_nH).polarP4()), is_inner ? -0.1f : -0.5f, is_inner ? 0.1f : 0.5f, false);
-      get(dnn::pfCand_nHad_puppiWeight) = getValue(pfCands.at(index_nH).puppiWeight());
-      get(dnn::pfCand_nHad_puppiWeightNoLep) = getValue(pfCands.at(index_nH).puppiWeightNoLep());
-      float hcal_fraction = 0.;
-      if (pfCands.at(index_nH).pdgId() == 1 || pfCands.at(index_nH).pdgId() == 130) {
-        hcal_fraction = pfCands.at(index_nH).hcalFraction();
-      } else if (pfCands.at(index_nH).isIsolatedChargedHadron()) {
-        hcal_fraction = pfCands.at(index_nH).rawHcalFraction();
-      }
+      get(dnn::pfCand_nHad_puppiWeight) = getValue(candFunc::getPuppiWeight(nH_cand));
+      get(dnn::pfCand_nHad_puppiWeightNoLep) = getValue(candFunc::getPuppiWeightNoLep(nH_cand));
+      float hcal_fraction = candFunc::getHCalFraction(nH_cand);
       get(dnn::pfCand_nHad_hcalFraction) = getValue(hcal_fraction);
     }
     checkInputs(inputs, is_inner ? "hadron_inner_block" : "hadron_outer_block", dnn::NumberOfInputs);
   }
 
-  template <typename dnn>
-  tensorflow::Tensor createInputsV1(const TauType& tau,
-                                    const ElectronCollection& electrons,
-                                    const MuonCollection& muons) const {
+  template <typename dnn, typename CandidateCastType, typename TauCastType>
+  tensorflow::Tensor createInputsV1(const TauCastType& tau,
+                                    size_t tau_index,
+                                    const std::vector<pat::Electron>& electrons,
+                                    const std::vector<pat::Muon>& muons,
+                                    tauFunc tau_funcs) const {
     static constexpr bool check_all_set = false;
     static constexpr float default_value_for_set_check = -42;
 
     tensorflow::Tensor inputs(tensorflow::DT_FLOAT, {1, dnn_inputs_2017v1::NumberOfInputs});
     const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
-    auto leadChargedHadrCand = dynamic_cast<const pat::PackedCandidate*>(tau.leadChargedHadrCand().get());
+    auto leadChargedHadrCand = dynamic_cast<const CandidateCastType*>(tau.leadChargedHadrCand().get());
+    // const reco::PFTauTransverseImpactParameter impact_param = tau_funcs.getImpactObject(tau, tau_index);
 
     if (check_all_set) {
       for (int var_index = 0; var_index < dnn::NumberOfInputs; ++var_index) {
@@ -1760,21 +2076,21 @@ private:
     get(dnn::eta) = tau.p4().eta();
     get(dnn::mass) = tau.p4().mass();
     get(dnn::decayMode) = tau.decayMode();
-    get(dnn::chargedIsoPtSum) = tau.tauID("chargedIsoPtSum");
-    get(dnn::neutralIsoPtSum) = tau.tauID("neutralIsoPtSum");
-    get(dnn::neutralIsoPtSumWeight) = tau.tauID("neutralIsoPtSumWeight");
-    get(dnn::photonPtSumOutsideSignalCone) = tau.tauID("photonPtSumOutsideSignalCone");
-    get(dnn::puCorrPtSum) = tau.tauID("puCorrPtSum");
-    get(dnn::dxy) = tau.dxy();
-    get(dnn::dxy_sig) = tau.dxy_Sig();
-    get(dnn::dz) = leadChargedHadrCand ? leadChargedHadrCand->dz() : default_value;
-    get(dnn::ip3d) = tau.ip3d();
-    get(dnn::ip3d_sig) = tau.ip3d_Sig();
-    get(dnn::hasSecondaryVertex) = tau.hasSecondaryVertex();
-    get(dnn::flightLength_r) = tau.flightLength().R();
-    get(dnn::flightLength_dEta) = dEta(tau.flightLength(), tau.p4());
-    get(dnn::flightLength_dPhi) = dPhi(tau.flightLength(), tau.p4());
-    get(dnn::flightLength_sig) = tau.flightLengthSig();
+    get(dnn::chargedIsoPtSum) = tau_funcs.getChargedIsoPtSum(tau, tau_index);
+    get(dnn::neutralIsoPtSum) = tau_funcs.getNeutralIsoPtSum(tau, tau_index);
+    get(dnn::neutralIsoPtSumWeight) = tau_funcs.getNeutralIsoPtSumWeight(tau, tau_index);
+    get(dnn::photonPtSumOutsideSignalCone) = tau_funcs.getPhotonPtSumOutsideSignalCone(tau, tau_index);
+    get(dnn::puCorrPtSum) = tau_funcs.getPuCorrPtSum(tau, tau_index);
+    get(dnn::dxy) = tau_funcs.getdxy(tau, tau_index);
+    get(dnn::dxy_sig) = tau_funcs.getdxySig(tau, tau_index);
+    get(dnn::dz) = leadChargedHadrCand ? candFunc::getTauDz(leadChargedHadrCand, default_value) : default_value;
+    get(dnn::ip3d) = tau_funcs.getip3d(tau, tau_index);
+    get(dnn::ip3d_sig) = tau_funcs.getip3dSig(tau, tau_index);
+    get(dnn::hasSecondaryVertex) = tau_funcs.getHasSecondaryVertex(tau, tau_index);
+    get(dnn::flightLength_r) = tau_funcs.getFlightLength(tau, tau_index).R();
+    get(dnn::flightLength_dEta) = dEta(tau_funcs.getFlightLength(tau, tau_index), tau.p4());
+    get(dnn::flightLength_dPhi) = dPhi(tau_funcs.getFlightLength(tau, tau_index), tau.p4());
+    get(dnn::flightLength_sig) = tau_funcs.getFlightLengthSig(tau, tau_index);
     get(dnn::leadChargedHadrCand_pt) = leadChargedHadrCand ? leadChargedHadrCand->p4().Pt() : default_value;
     get(dnn::leadChargedHadrCand_dEta) =
         leadChargedHadrCand ? dEta(leadChargedHadrCand->p4(), tau.p4()) : default_value;
@@ -1785,11 +2101,11 @@ private:
     get(dnn::pt_weighted_dphi_strip) = reco::tau::pt_weighted_dphi_strip(tau, tau.decayMode());
     get(dnn::pt_weighted_dr_signal) = reco::tau::pt_weighted_dr_signal(tau, tau.decayMode());
     get(dnn::pt_weighted_dr_iso) = reco::tau::pt_weighted_dr_iso(tau, tau.decayMode());
-    get(dnn::leadingTrackNormChi2) = tau.leadingTrackNormChi2();
+    get(dnn::leadingTrackNormChi2) = tau_funcs.getLeadingTrackNormChi2(tau);
     get(dnn::e_ratio) = reco::tau::eratio(tau);
-    get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau);
+    get(dnn::gj_angle_diff) = calculateGottfriedJacksonAngleDifference(tau, tau_index, tau_funcs);
     get(dnn::n_photons) = reco::tau::n_photons_total(tau);
-    get(dnn::emFraction) = tau.emFraction_MVA();
+    get(dnn::emFraction) = tau_funcs.getEmFraction(tau);
     get(dnn::has_gsf_track) = leadChargedHadrCand && std::abs(leadChargedHadrCand->pdgId()) == 11;
     get(dnn::inside_ecal_crack) = isInEcalCrack(tau.p4().Eta());
     auto gsf_ele = findMatchedElectron(tau, electrons, 0.3);
@@ -1832,14 +2148,14 @@ private:
       get(dnn::gsf_ele_Chi2NormKF) = gsf_ele->closestCtfTrackRef()->normalizedChi2();
       get(dnn::gsf_ele_KFNumHits) = gsf_ele->closestCtfTrackRef()->numberOfValidHits();
     }
-    get(dnn::leadChargedCand_etaAtEcalEntrance) = tau.etaAtEcalEntranceLeadChargedCand();
-    get(dnn::leadChargedCand_pt) = tau.ptLeadChargedCand();
+    get(dnn::leadChargedCand_etaAtEcalEntrance) = tau_funcs.getEtaAtEcalEntrance(tau);
+    get(dnn::leadChargedCand_pt) = tau.leadChargedHadrCand()->pt();
 
     get(dnn::leadChargedHadrCand_HoP) = default_value;
     get(dnn::leadChargedHadrCand_EoP) = default_value;
     if (tau.leadChargedHadrCand()->pt() > 0) {
-      get(dnn::leadChargedHadrCand_HoP) = tau.hcalEnergyLeadChargedHadrCand() / tau.leadChargedHadrCand()->pt();
-      get(dnn::leadChargedHadrCand_EoP) = tau.ecalEnergyLeadChargedHadrCand() / tau.leadChargedHadrCand()->pt();
+      get(dnn::leadChargedHadrCand_HoP) = tau_funcs.getEcalEnergyLeadingChargedHadr(tau) / tau.leadChargedHadrCand()->pt();
+      get(dnn::leadChargedHadrCand_EoP) = tau_funcs.getHcalEnergyLeadingChargedHadr(tau) / tau.leadChargedHadrCand()->pt();
     }
 
     MuonHitMatchV1 muon_hit_match;
@@ -1960,8 +2276,8 @@ private:
     }
   }
 
-  template <typename CandidateCollection>
-  static void processSignalPFComponents(const pat::Tau& tau,
+  template <typename CandidateCollection, typename TauCastType>
+  static void processSignalPFComponents(const TauCastType& tau,
                                         const CandidateCollection& candidates,
                                         LorentzVectorXYZ& p4_inner,
                                         LorentzVectorXYZ& p4_outer,
@@ -2004,8 +2320,8 @@ private:
     m_outer = n_outer != 0 ? p4_outer.mass() : default_value;
   }
 
-  template <typename CandidateCollection>
-  static void processIsolationPFComponents(const pat::Tau& tau,
+  template <typename CandidateCollection, typename TauCastType>
+  static void processIsolationPFComponents(const TauCastType& tau,
                                            const CandidateCollection& candidates,
                                            LorentzVectorXYZ& p4,
                                            float& pt,
@@ -2034,14 +2350,15 @@ private:
   }
 
   // Copied from https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc#L218
-  static bool calculateGottfriedJacksonAngleDifference(const pat::Tau& tau, double& gj_diff) {
-    if (tau.hasSecondaryVertex()) {
+  template <typename TauCastType>
+  static bool calculateGottfriedJacksonAngleDifference(const TauCastType& tau, size_t tau_index, double& gj_diff, tauFunc tau_funcs) {
+    if (tau_funcs.getHasSecondaryVertex(tau, tau_index)) {
       static constexpr double mTau = 1.77682;
       const double mAOne = tau.p4().M();
       const double pAOneMag = tau.p();
       const double argumentThetaGJmax = (std::pow(mTau, 2) - std::pow(mAOne, 2)) / (2 * mTau * pAOneMag);
       const double argumentThetaGJmeasured =
-          tau.p4().Vect().Dot(tau.flightLength()) / (pAOneMag * tau.flightLength().R());
+          tau.p4().Vect().Dot(tau_funcs.getFlightLength(tau, tau_index)) / (pAOneMag * tau_funcs.getFlightLength(tau, tau_index).R());
       if (std::abs(argumentThetaGJmax) <= 1. && std::abs(argumentThetaGJmeasured) <= 1.) {
         double thetaGJmax = std::asin(argumentThetaGJmax);
         double thetaGJmeasured = std::acos(argumentThetaGJmeasured);
@@ -2052,9 +2369,10 @@ private:
     return false;
   }
 
-  static float calculateGottfriedJacksonAngleDifference(const pat::Tau& tau) {
+  template <typename TauCastType>
+  static float calculateGottfriedJacksonAngleDifference(const TauCastType& tau, size_t tau_index, tauFunc tau_funcs) {
     double gj_diff;
-    if (calculateGottfriedJacksonAngleDifference(tau, gj_diff))
+    if (calculateGottfriedJacksonAngleDifference(tau, tau_index, gj_diff, tau_funcs))
       return static_cast<float>(gj_diff);
     return default_value;
   }
@@ -2064,8 +2382,9 @@ private:
     return abs_eta > 1.46 && abs_eta < 1.558;
   }
 
-  static const pat::Electron* findMatchedElectron(const pat::Tau& tau,
-                                                  const pat::ElectronCollection& electrons,
+  template <typename TauCastType>
+  static const pat::Electron* findMatchedElectron(const TauCastType& tau,
+                                                  const std::vector<pat::Electron>& electrons,
                                                   double deltaR) {
     const double dR2 = deltaR * deltaR;
     const pat::Electron* matched_ele = nullptr;
@@ -2078,11 +2397,25 @@ private:
   }
 
 private:
-  edm::EDGetTokenT<ElectronCollection> electrons_token_;
-  edm::EDGetTokenT<MuonCollection> muons_token_;
+  edm::EDGetTokenT<std::vector<pat::Electron>> electrons_token_;
+  edm::EDGetTokenT<std::vector<pat::Muon>> muons_token_;
   edm::EDGetTokenT<double> rho_token_;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSum_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> chargedIsoPtSumdR03_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSum_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumdR03_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> puCorrPtSum_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> footprintCorrection_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumWeight_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> neutralIsoPtSumWeightdR03_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> photonPtSumOutsideSignalCone_inputToken;
+  edm::EDGetTokenT<reco::PFTauDiscriminator> photonPtSumOutsideSignalConedR03_inputToken;
+  edm::EDGetTokenT<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>> PFTauTransverseImpactParameters_token;
+
+
   std::string input_layer_, output_layer_;
   const unsigned version;
+  // const bool is_online;
   const int debug_level;
   const bool disable_dxy_pca_;
   std::unique_ptr<tensorflow::Tensor> tauBlockTensor_;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1216,7 +1216,6 @@ public:
     //translate to a map of <BasicDiscriminator, index> and check if all discriminators are present
     std::map<BasicDiscriminator, size_t> discrIndexMap;
     for (size_t i = 0; i < requiredDiscr.size(); i++) {
-      std::cout << stringFromDiscriminator_.at(requiredDiscr[i]) << std::endl;
       if (discrIndexMapStr.find(stringFromDiscriminator_.at(requiredDiscr[i])) == discrIndexMapStr.end())
         throw cms::Exception("DeepTauId") << "Basic Discriminator " << stringFromDiscriminator_.at(requiredDiscr[i])
                                           << " was not provided in the config file.";

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -632,12 +632,12 @@ namespace {
   };
 
   struct lightLepFunc {
-    const std::vector<pat::Electron>& electron_collection;
-    const std::vector<pat::Muon>& muon_collection;
+    edm::Handle<std::vector<pat::Electron>> electron_collection;
+    edm::Handle<std::vector<pat::Muon>> muon_collection;
 
     const std::vector<pat::Electron> getElectrons(bool online) {
       if (!online)
-        return electron_collection;
+        return *electron_collection;
       else {
         const std::vector<pat::Electron> out_electrons;
         return out_electrons;
@@ -645,7 +645,7 @@ namespace {
     }
     const std::vector<pat::Muon> getMuons(bool online) {
       if (!online)
-        return muon_collection;
+        return *muon_collection;
       else {
         const std::vector<pat::Muon> out_muons;
         return out_muons;
@@ -1334,7 +1334,7 @@ private:
                       photonPtSumOutsideSignalCone_index,
                       puCorrPtSum_index};
 
-    lightLepFunc lightlep = {*tmp_electrons, *tmp_muons};
+    lightLepFunc lightlep = {tmp_electrons, tmp_muons};
 
     std::vector<pat::Electron> electrons = lightlep.getElectrons(is_online);
     std::vector<pat::Muon> muons = lightlep.getMuons(is_online);

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1168,12 +1168,12 @@ const std::map<bd, std::string> deep_tau::DeepTauBase::stringFromDiscriminator_{
     {bd::FootprintCorrection, "TauFootprintCorrection"},
     {bd::PhotonPtSumOutsideSignalCone, "PhotonPtSumOutsideSignalCone"},
     {bd::PUcorrPtSum, "PUcorrPtSum"}};
-const std::vector<bd> deep_tau::DeepTauBase::requiredBasicDiscriminators = {bd::ChargedIsoPtSum,
+const std::vector<bd> deep_tau::DeepTauBase::requiredBasicDiscriminators_ = {bd::ChargedIsoPtSum,
                                                                             bd::NeutralIsoPtSum,
                                                                             bd::NeutralIsoPtSumWeight,
                                                                             bd::PhotonPtSumOutsideSignalCone,
                                                                             bd::PUcorrPtSum};
-const std::vector<bd> deep_tau::DeepTauBase::requiredBasicDiscriminatorsdR03 = {bd::ChargedIsoPtSum,
+const std::vector<bd> deep_tau::DeepTauBase::requiredBasicDiscriminatorsdR03_ = {bd::ChargedIsoPtSum,
                                                                                 bd::NeutralIsoPtSum,
                                                                                 bd::NeutralIsoPtSumWeight,
                                                                                 bd::PhotonPtSumOutsideSignalCone,
@@ -1404,7 +1404,7 @@ private:
     edm::Handle<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
         PFTauTransverseImpactParameters;
 
-    if (!is_online) {
+    if (!is_online_) {
       event.getByToken(electrons_token_, tmp_electrons);
       event.getByToken(muons_token_, tmp_muons);
     } else {
@@ -1415,9 +1415,9 @@ private:
       // Get indices for discriminators
       if (!discrIndicesMapped_) {
         basicDiscrIndexMap_ =
-            matchDiscriminatorIndices(event, basicTauDiscriminators_inputToken, requiredBasicDiscriminators);
+            matchDiscriminatorIndices(event, basicTauDiscriminators_inputToken, requiredBasicDiscriminators_);
         basicDiscrdR03IndexMap_ =
-            matchDiscriminatorIndices(event, basicTauDiscriminatorsdR03_inputToken, requiredBasicDiscriminatorsdR03);
+            matchDiscriminatorIndices(event, basicTauDiscriminatorsdR03_inputToken, requiredBasicDiscriminatorsdR03_);
         discrIndicesMapped_ = true;
       }
     }
@@ -1430,8 +1430,8 @@ private:
 
     lightLepFunc lightlep = {tmp_electrons, tmp_muons};
 
-    std::vector<pat::Electron> electrons = lightlep.getElectrons(is_online);
-    std::vector<pat::Muon> muons = lightlep.getMuons(is_online);
+    std::vector<pat::Electron> electrons = lightlep.getElectrons(is_online_);
+    std::vector<pat::Muon> muons = lightlep.getMuons(is_online_);
 
     edm::Handle<edm::View<reco::Candidate>> pfCands;
     event.getByToken(pfcandToken_, pfCands);
@@ -1450,7 +1450,7 @@ private:
       std::vector<tensorflow::Tensor> pred_vector;
 
       bool passesPrediscriminants;
-      if (is_online) {
+      if (is_online_) {
         passesPrediscriminants = tauIDs.passPrediscriminants<std::vector<TauDiscInfo<reco::PFTauDiscriminator>>>(
             recoPrediscriminants_, andPrediscriminants_, tauRef);
       } else {
@@ -1460,14 +1460,14 @@ private:
 
       if (passesPrediscriminants) {
         if (version == 1) {
-          if (is_online)
+          if (is_online_)
             getPredictionsV1<reco::PFCandidate, reco::PFTau>(
                 taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
           else
             getPredictionsV1<pat::PackedCandidate, pat::Tau>(
                 taus->at(tau_index), tau_index, tauRef, electrons, muons, pred_vector, tauIDs);
         } else if (version == 2) {
-          if (is_online) {
+          if (is_online_) {
             getPredictionsV2<reco::PFCandidate, reco::PFTau>(taus->at(tau_index),
                                                              tau_index,
                                                              tauRef,

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -2064,7 +2064,6 @@ private:
     tensorflow::Tensor inputs(tensorflow::DT_FLOAT, {1, dnn_inputs_2017v1::NumberOfInputs});
     const auto& get = [&](int var_index) -> float& { return inputs.matrix<float>()(0, var_index); };
     auto leadChargedHadrCand = dynamic_cast<const CandidateCastType*>(tau.leadChargedHadrCand().get());
-    // const reco::PFTauTransverseImpactParameter impact_param = tau_funcs.getImpactObject(tau, tau_index);
 
     if (check_all_set) {
       for (int var_index = 0; var_index < dnn::NumberOfInputs; ++var_index) {
@@ -2415,7 +2414,6 @@ private:
 
   std::string input_layer_, output_layer_;
   const unsigned version;
-  // const bool is_online;
   const int debug_level;
   const bool disable_dxy_pca_;
   std::unique_ptr<tensorflow::Tensor> tauBlockTensor_;

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -702,7 +702,8 @@ class TauIDEmbedder(object):
                 mem_mapped               = cms.bool(False),
                 version                  = cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
                 debug_level              = cms.int32(0),
-                disable_dxy_pca          = cms.bool(True)
+                disable_dxy_pca          = cms.bool(True),
+                is_online                = cms.bool(False)
             )
 
             self.processDeepProducer('deepTau2017v2p1', tauIDSources, workingPoints_)

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -7,6 +7,9 @@
  * \author Maria Rosaria Di Domenico, University of Siena & INFN Pisa
  */
 
+ //TODO: port to offline RECO/AOD inputs to allow usage with offline AOD
+ //TODO: Take into account that PFTaus can also be build with pat::PackedCandidates
+
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 
 namespace deep_tau {

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -94,11 +94,78 @@ namespace deep_tau {
         workingPoints_[output_desc.first].push_back(std::make_unique<Cutter>(cut_str));
       }
     }
+
+    // prediscriminant operator
+    // require the tau to pass the following prediscriminants
+    const edm::ParameterSet& prediscriminantConfig = cfg.getParameter<edm::ParameterSet>("Prediscriminants");
+
+    // determine boolean operator used on the prediscriminants
+    std::string pdBoolOperator = prediscriminantConfig.getParameter<std::string>("BooleanOperator");
+    // convert string to lowercase
+    transform(pdBoolOperator.begin(), pdBoolOperator.end(), pdBoolOperator.begin(), ::tolower);
+
+    if (pdBoolOperator == "and") {
+      andPrediscriminants_ = 0x1;  //use chars instead of bools so we can do a bitwise trick later
+    } else if (pdBoolOperator == "or") {
+      andPrediscriminants_ = 0x0;
+    } else {
+      throw cms::Exception("TauDiscriminationProducerBase")
+          << "PrediscriminantBooleanOperator defined incorrectly, options are: AND,OR";
+    }
+
+    // get the list of prediscriminants
+    std::vector<std::string> prediscriminantsNames =
+        prediscriminantConfig.getParameterNamesForType<edm::ParameterSet>();
+
+    for (std::vector<std::string>::const_iterator iDisc = prediscriminantsNames.begin();
+         iDisc != prediscriminantsNames.end();
+         ++iDisc) {
+      const edm::ParameterSet& iPredisc = prediscriminantConfig.getParameter<edm::ParameterSet>(*iDisc);
+      const edm::InputTag& label = iPredisc.getParameter<edm::InputTag>("Producer");
+      double cut = iPredisc.getParameter<double>("cut");
+
+      if (is_online) {
+        TauDiscInfo<reco::PFTauDiscriminator> thisDiscriminator;
+        thisDiscriminator.label = label;
+        thisDiscriminator.cut = cut;
+        thisDiscriminator.disc_token = consumes<reco::PFTauDiscriminator>(label);
+        recoPrediscriminants_.push_back(thisDiscriminator);
+      } else {
+        TauDiscInfo<pat::PATTauDiscriminator> thisDiscriminator;
+        thisDiscriminator.label = label;
+        thisDiscriminator.cut = cut;
+        thisDiscriminator.disc_token = consumes<pat::PATTauDiscriminator>(label);
+        patPrediscriminants_.push_back(thisDiscriminator);
+      }
+    }
   }
 
   void DeepTauBase::produce(edm::Event& event, const edm::EventSetup& es) {
     edm::Handle<TauCollection> taus;
     event.getByToken(tausToken_, taus);
+    edm::ProductID tauProductID = taus.id();
+
+    // load prediscriminators
+    size_t nPrediscriminants =
+        patPrediscriminants_.empty() ? recoPrediscriminants_.size() : patPrediscriminants_.size();
+    for (size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc) {
+      edm::ProductID discKeyId;
+      if (is_online) {
+        recoPrediscriminants_[iDisc].fill(event);
+        discKeyId = recoPrediscriminants_[iDisc].handle->keyProduct().id();
+      } else {
+        patPrediscriminants_[iDisc].fill(event);
+        discKeyId = patPrediscriminants_[iDisc].handle->keyProduct().id();
+      }
+
+      // Check to make sure the product is correct for the discriminator.
+      // If not, throw a more informative exception.
+      if (tauProductID != discKeyId) {
+        throw cms::Exception("MisconfiguredPrediscriminant")
+            << "The tau collection has product ID: " << tauProductID
+            << " but the pre-discriminator is keyed with product ID: " << discKeyId << std::endl;
+      }
+    }
 
     const tensorflow::Tensor& pred = getPredictions(event, taus);
     createOutputs(event, pred, taus);

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -87,8 +87,6 @@ namespace deep_tau {
         is_online(cfg.getParameter<bool>("is_online")),
         outputs_(outputCollection),
         cache_(cache) {
-
-
     for (const auto& output_desc : outputs_) {
       produces<TauDiscriminator>(output_desc.first);
       const auto& cut_list = cfg.getParameter<std::vector<std::string>>(output_desc.first + "WP");

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -87,7 +87,7 @@ namespace deep_tau {
       : tausToken_(consumes<TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
         pfcandToken_(consumes<CandidateType>(cfg.getParameter<edm::InputTag>("pfcands"))),
         vtxToken_(consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertices"))),
-        is_online(cfg.getParameter<bool>("is_online")),
+        is_online_(cfg.getParameter<bool>("is_online")),
         outputs_(outputCollection),
         cache_(cache) {
     for (const auto& output_desc : outputs_) {
@@ -127,7 +127,7 @@ namespace deep_tau {
       const edm::InputTag& label = iPredisc.getParameter<edm::InputTag>("Producer");
       double cut = iPredisc.getParameter<double>("cut");
 
-      if (is_online) {
+      if (is_online_) {
         TauDiscInfo<reco::PFTauDiscriminator> thisDiscriminator;
         thisDiscriminator.label = label;
         thisDiscriminator.cut = cut;
@@ -153,7 +153,7 @@ namespace deep_tau {
         patPrediscriminants_.empty() ? recoPrediscriminants_.size() : patPrediscriminants_.size();
     for (size_t iDisc = 0; iDisc < nPrediscriminants; ++iDisc) {
       edm::ProductID discKeyId;
-      if (is_online) {
+      if (is_online_) {
         recoPrediscriminants_[iDisc].fill(event);
         discKeyId = recoPrediscriminants_[iDisc].handle->keyProduct().id();
       } else {
@@ -176,7 +176,7 @@ namespace deep_tau {
 
   void DeepTauBase::createOutputs(edm::Event& event, const tensorflow::Tensor& pred, edm::Handle<TauCollection> taus) {
     for (const auto& output_desc : outputs_) {
-      auto result = output_desc.second.get_value(taus, pred, workingPoints_.at(output_desc.first), is_online);
+      auto result = output_desc.second.get_value(taus, pred, workingPoints_.at(output_desc.first), is_online_);
       event.put(std::move(result), output_desc.first);
     }
   }

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -7,8 +7,8 @@
  * \author Maria Rosaria Di Domenico, University of Siena & INFN Pisa
  */
 
- //TODO: port to offline RECO/AOD inputs to allow usage with offline AOD
- //TODO: Take into account that PFTaus can also be build with pat::PackedCandidates
+//TODO: port to offline RECO/AOD inputs to allow usage with offline AOD
+//TODO: Take into account that PFTaus can also be build with pat::PackedCandidates
 
 #include "RecoTauTag/RecoTau/interface/DeepTauBase.h"
 


### PR DESCRIPTION
#### The DeepTau modules have been adapted to not only handle AOD input but to also be able to process RECO input.\

The following changes have been made:\
- Input tokens for Candidate and Tau collections now use base classes
- taus and candidates are accessed by dynamic_cast and edm::View on the base class objects
- A boolean "is_online" is added to specify whether the input is AOD or RECO
- Electron and muon collections are initialized as empty arrays if is_online is True
- A structure "tauFunc" containing a range of functions was added to calculate both tau ID quantities as well as other quantities that needed recalculation for RECO input. 
- A namespace "candFunc" was introduced containing functions to calculate quantities that need recalculation for RECO input. 
- A structure lightLepFunc was added to initialize the electron and muon collections depending on the value of the boolean "is_online"
- Functions that use taus or candidates have been turned into template functions where the CandidateType and/or TauType are specified

A few small integration tests have been performed to check if the adapted code works for both RECO and miniAOD inputs:\
- RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py was run with a setup without any changes and the version of the setup in this PR over the same 1000 events of the same dataset. The output of both runs was identical.
- A simple setup was made with hltGetConfiguration for the latest HLT menu where the isolation modules were replaced by the adapted DeepTauId module. This setup ran smoothly and the output looked as expected.

