### PR TITLE
Add switch in L1 matcher to produce full PFtaus

### DIFF
--- a/RecoTauTag/HLTProducers/interface/L1THLTTauMatching.h
+++ b/RecoTauTag/HLTProducers/interface/L1THLTTauMatching.h
@@ -28,6 +28,7 @@ private:
   const edm::EDGetTokenT<reco::PFTauCollection> jetSrc;
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauTrigger;
   const double mEt_Min;
-  const bool simplifiedTau;
+  const bool reduceTauContent;
+  const bool keepOriginalVertex;
 };
 #endif

--- a/RecoTauTag/HLTProducers/interface/L1THLTTauMatching.h
+++ b/RecoTauTag/HLTProducers/interface/L1THLTTauMatching.h
@@ -28,5 +28,6 @@ private:
   const edm::EDGetTokenT<reco::PFTauCollection> jetSrc;
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauTrigger;
   const double mEt_Min;
+  const bool simplifiedTau;
 };
 #endif

--- a/RecoTauTag/HLTProducers/python/deepTauAtHLT.py
+++ b/RecoTauTag/HLTProducers/python/deepTauAtHLT.py
@@ -146,7 +146,8 @@ def update(process):
 
     process.hltHpsL1JetsHLTForDeepTauInput = process.hltHpsL1JetsHLTDoublePFTauTrackPt1MediumChargedIsolationMatchReg.clone(
         JetSrc = cms.InputTag('hltHpsPFTauProducerReg'),
-        SimplifiedTau = cms.bool(False)
+        ReduceTauContent = cms.bool(False),
+        KeepOriginalVertex = cms.bool(True),
     )
 
     file_names = [

--- a/RecoTauTag/HLTProducers/src/L1THLTTauMatching.cc
+++ b/RecoTauTag/HLTProducers/src/L1THLTTauMatching.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/Common/interface/RefVector.h"
 
 //
 // class decleration
@@ -16,12 +17,12 @@ L1THLTTauMatching::L1THLTTauMatching(const edm::ParameterSet& iConfig)
     : jetSrc(consumes<PFTauCollection>(iConfig.getParameter<InputTag>("JetSrc"))),
       tauTrigger(consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("L1TauTrigger"))),
       mEt_Min(iConfig.getParameter<double>("EtMin")) {
-  produces<PFTauCollection>();
+  produces<RefVector<PFTauCollection>>();
 }
 L1THLTTauMatching::~L1THLTTauMatching() {}
 
 void L1THLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const {
-  unique_ptr<PFTauCollection> tauL2jets(new PFTauCollection);
+  unique_ptr<RefVector<PFTauCollection>> tauL2jets(new RefVector<PFTauCollection>);
 
   double deltaR = 1.0;
   double matchingR = 0.5;
@@ -47,9 +48,10 @@ void L1THLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const ed
         if (myJet.leadChargedHadrCand().isNonnull()) {
           a = myJet.leadChargedHadrCand()->vertex();
         }
-        PFTau myPFTau(std::numeric_limits<int>::quiet_NaN(), myJet.p4(), a);
+        // PFTau myPFTau(std::numeric_limits<int>::quiet_NaN(), myJet.p4(), a);
         if (myJet.pt() > mEt_Min) {
-          tauL2jets->push_back(myPFTau);
+          edm::Ref<PFTauCollection> jetRef(tauJets, iJet);
+          tauL2jets->push_back(jetRef);
         }
         break;
       }
@@ -71,3 +73,4 @@ void L1THLTTauMatching::fillDescriptions(edm::ConfigurationDescriptions& descrip
       "returned PFTaus are set).");
   descriptions.add("L1THLTTauMatching", desc);
 }
+


### PR DESCRIPTION
This PR is a result of the discussion in [PR#151](https://github.com/cms-tau-pog/cmssw/pull/151) where it was concluded to change the L1 matcher to be able to produce a collection of the original taus to use as input for the DeepTauProducer.
Two switches were added, one to add "full" taus to the collection and one to change the vertex of the tau in the way it was originally done.
**Testing**
The regular tests as mentioned on [this page](http://cms-sw.github.io/PRWorkflow.html) were performed and succeeded