### PR TITLE
Fix of issues in L2NNTag modules

### DIFF
--- a/RecoTauTag/HLTProducers/python/applyL2TauTag.py
+++ b/RecoTauTag/HLTProducers/python/applyL2TauTag.py
@@ -52,7 +52,8 @@ def update(process):
         nExpected = 2,
         L1TauSrc = 'hltL1sDoubleTauBigOR',
         L2Outcomes = 'hltL2TauTagNNProducer:DoubleTau',
-        DiscrWP = thWp[working_point]
+        DiscrWP = thWp[working_point],
+        l1TauPtThreshold = 250,
     )
     # L2 updated Sequence
     process.hltL2TauTagNNSequence = cms.Sequence(process.HLTDoCaloSequence + process.hltL1sDoubleTauBigOR + process.hltL2TauTagNNProducer)

--- a/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
@@ -55,7 +55,7 @@ public:
       throw cms::Exception("Inconsistent Data", "L2TauTagFilter::hltFilter") << "CNN output size != L1 taus size \n";
     }
     for (size_t l1_idx = 0; l1_idx < l1Taus.size(); l1_idx++) {
-      if (L2Outcomes[l1_idx] >= discrWP_) {
+      if (L2Outcomes[l1_idx] >= discrWP_ || l1Taus[l1_idx]->polarP4().pt()>250) {
         filterproduct.addObject(nTauPassed, l1Taus[l1_idx]);
         nTauPassed++;
       }

--- a/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagFilter.cc
@@ -26,7 +26,8 @@ public:
         l1TauSrc_(cfg.getParameter<edm::InputTag>("L1TauSrc")),
         l1TauSrcToken_(consumes<trigger::TriggerFilterObjectWithRefs>(l1TauSrc_)),
         l2OutcomesToken_(consumes<std::vector<float>>(cfg.getParameter<edm::InputTag>("L2Outcomes"))),
-        discrWP_(cfg.getParameter<double>("DiscrWP")) {}
+        discrWP_(cfg.getParameter<double>("DiscrWP")),
+        l1PtTh_(cfg.getParameter<double>("l1TauPtThreshold")) {}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     makeHLTFilterDescription(desc);
@@ -35,6 +36,7 @@ public:
         ->setComment("Which trigger should the L1 Taus collection pass");
     desc.add<edm::InputTag>("L2Outcomes", edm::InputTag(""))->setComment("L2 CNN outcomes");
     desc.add<double>("DiscrWP", 0.1227)->setComment("value of discriminator threshold");
+    desc.add<double>("l1TauPtThreshold", 250)->setComment("value of discriminator threshold");
     descriptions.addWithDefaultLabel(desc);
   }
 
@@ -55,12 +57,12 @@ public:
       throw cms::Exception("Inconsistent Data", "L2TauTagFilter::hltFilter") << "CNN output size != L1 taus size \n";
     }
     for (size_t l1_idx = 0; l1_idx < l1Taus.size(); l1_idx++) {
-      if (L2Outcomes[l1_idx] >= discrWP_ || l1Taus[l1_idx]->polarP4().pt()>250) {
+      if (L2Outcomes[l1_idx] >= discrWP_ || l1Taus[l1_idx]->polarP4().pt()>l1PtTh_) {
         filterproduct.addObject(nTauPassed, l1Taus[l1_idx]);
         nTauPassed++;
       }
     }
-
+    
     return nTauPassed >= nExpected_;
   }
 
@@ -70,6 +72,7 @@ private:
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> l1TauSrcToken_;
   const edm::EDGetTokenT<std::vector<float>> l2OutcomesToken_;
   const double discrWP_;
+  const double l1PtTh_;
 };
 
 //define this as a plug-in

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -257,8 +257,11 @@ void L2TauNNProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   edm::ParameterSetDescription l1TausPset;
   l1TausPset.add<std::string>("L1CollectionName", "")->setComment("Name of collections");
   l1TausPset.add<edm::InputTag>("L1TauTrigger", edm::InputTag(""))
-      ->setComment("Which trigger should the L1 Taus collection pass");
-  desc.addVPSet("L1Taus", l1TausPset);
+            ->setComment("Which trigger should the L1 Taus collection pass");
+  edm::ParameterSet l1TausPSetDefault;
+  l1TausPSetDefault.addParameter<std::string>("L1CollectionName", "DoubleTau");
+  l1TausPSetDefault.addParameter<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"));
+  desc.addVPSet("L1Taus", l1TausPset, {l1TausPSetDefault});
   desc.add<edm::InputTag>("hbheInput", edm::InputTag(""))->setComment("HBHE recHit collection");
   desc.add<edm::InputTag>("hoInput", edm::InputTag(""))->setComment("HO recHit Collection");
   desc.add<edm::InputTag>("ebInput", edm::InputTag(""))->setComment("EB recHit Collection");

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -255,21 +255,21 @@ void L2TauNNProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   edm::ParameterSetDescription desc;
   desc.add<int>("debugLevel", 0)->setComment("set debug level for printing out info");
   edm::ParameterSetDescription l1TausPset;
-  l1TausPset.add<std::string>("L1CollectionName", "")->setComment("Name of collections");
-  l1TausPset.add<edm::InputTag>("L1TauTrigger", edm::InputTag(""))
+  l1TausPset.add<std::string>("L1CollectionName", "DoubleTau")->setComment("Name of collections");
+  l1TausPset.add<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"))
             ->setComment("Which trigger should the L1 Taus collection pass");
   edm::ParameterSet l1TausPSetDefault;
   l1TausPSetDefault.addParameter<std::string>("L1CollectionName", "DoubleTau");
   l1TausPSetDefault.addParameter<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"));
   desc.addVPSet("L1Taus", l1TausPset, {l1TausPSetDefault});
-  desc.add<edm::InputTag>("hbheInput", edm::InputTag(""))->setComment("HBHE recHit collection");
-  desc.add<edm::InputTag>("hoInput", edm::InputTag(""))->setComment("HO recHit Collection");
-  desc.add<edm::InputTag>("ebInput", edm::InputTag(""))->setComment("EB recHit Collection");
-  desc.add<edm::InputTag>("eeInput", edm::InputTag(""))->setComment("EE recHit Collection");
+  desc.add<edm::InputTag>("hbheInput", edm::InputTag("hltHbhereco"))->setComment("HBHE recHit collection");
+  desc.add<edm::InputTag>("hoInput", edm::InputTag("hltHoreco"))->setComment("HO recHit Collection");
+  desc.add<edm::InputTag>("ebInput", edm::InputTag("hltEcalRecHit:EcalRecHitsEB"))->setComment("EB recHit Collection");
+  desc.add<edm::InputTag>("eeInput", edm::InputTag("hltEcalRecHit:EcalRecHitsEE"))->setComment("EE recHit Collection");
   desc.add<edm::InputTag>("pataVertices", edm::InputTag("hltPixelVerticesSoA"))
       ->setComment("patatrack vertices collection");
   desc.add<edm::InputTag>("pataTracks", edm::InputTag("hltPixelTracksSoA"))->setComment("patatrack collection");
-  desc.add<edm::InputTag>("BeamSpot", edm::InputTag(""))->setComment("BeamSpot Collection");
+  desc.add<edm::InputTag>("BeamSpot", edm::InputTag("hltOnlineBeamSpot"))->setComment("BeamSpot Collection");
   desc.add<uint>("maxVtx", 100)->setComment("max output collection size (number of accepted vertices)");
   desc.add<double>("fractionSumPt2", 0.3)->setComment("threshold on sumPt2 fraction of the leading vertex");
   desc.add<double>("minSumPt2", 0.)->setComment("min sumPt2");


### PR DESCRIPTION
This PR has been created to fix two critical issues we found in L2NNTag modules: 
1. impossible to modify and L2TauTag modules in ConfDB, because some default values were not set: all default values are now set.  
2. We saw a drop in efficiency for taus with gen_vis_pt > 500 GeV in L2NNTauTag (while for taus with true pt < 500 GeV the algo efficiency is above 90%): to avoid this we added a passthrough at L2 for all L1 taus with pt > 250 GeV. We saw that the rate with this  passthrough does not significantly change: for the 3 kHz Working Point (WP) it goes from 2999.7 Hz to 3026.4 Hz and changes are similar also for the other WPs. 

