### PR TITLE
Issue in nVertices in L2NNTagTauProducer

### DIFF
--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -572,6 +572,7 @@ std::vector<int> L2TauNNProducer::selectGoodVertices(const ZVertexSoA& patavtx_s
   auto maxTracks = patatracks_tsoa.stride();
   const int nv = patavtx_soa.nvFinal;
   std::vector<int> VtxGood;
+  if(nv==0) return VtxGood;
   VtxGood.reserve(nv);
 
   std::vector<double> maxChi2_;


### PR DESCRIPTION
This pull request fixes a segmentation violation issue in L2NNTagTauProducer, which was occurring when nVertices is 0.